### PR TITLE
Fix bug: Use custom Input Container for Select

### DIFF
--- a/lib/components/Select.js
+++ b/lib/components/Select.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import classnames from "classnames";
-import SelectInput from "react-select";
+import SelectInput, { components } from "react-select";
 import Label from "./Label";
 
 class Select extends Component {
@@ -23,6 +23,12 @@ class Select extends Component {
       ...otherProps
     } = this.props;
 
+    // Refer: https://github.com/bigbinary/neeto-ui/issues/123
+    const CustomInputContainer = props => (
+      <components.Input {...props} data-test-id={otherProps && otherProps["data-test-id"]}>
+      </components.Input>
+    );
+
     return (
       <div
         className={classnames([
@@ -44,6 +50,7 @@ class Select extends Component {
             "nui-react-select-container--error": !!error
           })}
           classNamePrefix="nui-react-select"
+          components={{ Input: CustomInputContainer }}
           {...otherProps}
         />
         {!!error && <p className="mt-1 text-xs text-red-600">{error}</p>}

--- a/lib/components/Select.js
+++ b/lib/components/Select.js
@@ -24,7 +24,7 @@ class Select extends Component {
     } = this.props;
 
     // Refer: https://github.com/bigbinary/neeto-ui/issues/123
-    const CustomInputContainer = props => (
+    const CustomInput = props => (
       <components.Input {...props} data-test-id={otherProps && otherProps["data-test-id"]}>
       </components.Input>
     );
@@ -50,7 +50,7 @@ class Select extends Component {
             "nui-react-select-container--error": !!error
           })}
           classNamePrefix="nui-react-select"
-          components={{ Input: CustomInputContainer }}
+          components={{ Input: CustomInput }}
           {...otherProps}
         />
         {!!error && <p className="mt-1 text-xs text-red-600">{error}</p>}

--- a/lib/components/formik/Select.js
+++ b/lib/components/formik/Select.js
@@ -6,7 +6,7 @@ import { useFormikContext } from "formik";
 
 import { either, isNil, isEmpty } from "ramda";
 
-const SelectField = ({ name, options, getOptionValue, isMulti, ...rest }) => {
+const SelectField = ({ name, options, getOptionValue = null, isMulti = false, ...rest }) => {
   const { values, setValues } = useFormikContext();
 
   const getRealOptionValue = option => {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   ActionBlock,
   Input as FormikInput,
   Radio as FormikRadio,
+  Select as FormikSelect,
 } from "../lib/components/formik";
 import {
   Avatar,
@@ -56,6 +57,17 @@ const App = () => {
       label: "Logged in users only",
       value: false,
       id: "Logged in users only"
+    }
+  ];
+
+  const formikSelectOptions = [
+    {
+      label: "Option 1",
+      value: "fselect-opt1",
+    },
+    {
+      label: "Option 2",
+      value: "fselect-opt2",
     }
   ];
 
@@ -123,6 +135,7 @@ const App = () => {
       <PageLoader />
 
       <Select
+        data-test-id="select-component-test-id"
         className="mt-4"
         label="Try out the select component"
         required
@@ -208,7 +221,7 @@ const App = () => {
       </Accordion>
 
       <Formik
-        initialValues={{ allow_anyone_to_submit_ticket: "" }}
+        initialValues={{ allow_anyone_to_submit_ticket: "", fselect: "" }}
         onSubmit={() => { }}
       >
         <Form className="w-full px-10 py-8 bg-white border rounded-lg shadow-sm">
@@ -228,6 +241,13 @@ const App = () => {
             label="Who can submit a ticket?"
             stacked
             options={formikRadioOptions}
+          />
+          <FormikSelect
+            name="fselect"
+            isMulti
+            data-test-id="formik-select-test-id"
+            label="Formik Select Component"
+            options={formikSelectOptions}
           />
         </Form>
       </Formik>


### PR DESCRIPTION
Fixes #123 

Currently I have fixed this by using a replaceable component from Select and by overriding the `Input` container to take in the `data-test-id` prop.


@edwinbbu _a
Please review. Now the `data-test-id` is definitely getting set to `input` of select. I had also tested the working of both Select components from UI. But for making sure that this change doesn't break anything in neeto-help, please do thoroughly verify both `Select` and `formik/Select` once again from your side too. 
This fix is required in the migration process too. Therefore once this is merged, please do update the bundle and version. 

Thanks