### PR TITLE
Updated ColorPaletter to receive colorList as props

### DIFF
--- a/lib/components/ColorPalette.js
+++ b/lib/components/ColorPalette.js
@@ -1,20 +1,10 @@
 import React from "react";
 import classnames from "classnames";
 
-const COLORS = [
-  { from: "purple-1000", to: "purple-1050", hexCode: "#6671E5" },
-  { from: "ash-1000", to: "ash-1050", hexCode: "#606C88" },
-  { from: "kimoby-1000", to: "kimoby-1050", hexCode: "#396AFC" },
-  { from: "turquoise-1000", to: "turquoise-1050", hexCode: "#136A8A" },
-  { from: "shrimpy-1000", to: "shrimpy-1050", hexCode: "#E43A15" },
-  { from: "veryblue-1000", to: "veryblue-1050", hexCode: "#0575E6" },
-  { from: "fbmessenger-1000", to: "fbmessenger-1050", hexCode: "#00C6FF" }
-];
-
-const ColorPalette = ({ color, onChange }) => {
+const ColorPalette = ({ color, colorList, onChange }) => {
   return (
     <div className="flex flex-row flex-wrap items-start justify-start">
-      {COLORS.map((item, index) => (
+      {colorList.map((item, index) => (
         <div
           key={index}
           className={classnames("nui-color-palette__item", {

--- a/src/Previews/Components.js
+++ b/src/Previews/Components.js
@@ -14,6 +14,17 @@ import {
 import Header from "../Header";
 
 const cardItems = ["Card Item 1", "Card Item 2", "Card Item 3"];
+
+const COLOR_PALETTER_LIST = [
+  { from: "purple-500", to: "purple-600" },
+  { from: "pink-500", to: "pink-600" },
+  { from: "green-500", to: "green-600" },
+  { from: "red-500", to: "red-600" },
+  { from: "blue-500", to: "blue-600" },
+  { from: "indigo-500", to: "indigo-600" },
+  { from: "yellow-500", to: "yellow-600" }
+];
+
 const Components = () => {
   const [icon, setIcon] = useState(null);
   const [pageNo, setPageNo] = useState(1);
@@ -110,10 +121,11 @@ const Components = () => {
             Color Picker
           </h4>
           <ColorPicker
-            onChange={(value) => {}}
+            onChange={() => {}}
             color="#fefefe"
             colorPaletteProps={{
               color: "#fefefe",
+              colorList: COLOR_PALETTER_LIST,
               onChange: () => {},
             }}
           />


### PR DESCRIPTION
Fixes #255 

@edwinbbu _a Please review.

Note:

We need to pass the following colors as `colorList` prop in `neeto-chat-web` after upgrading to this version.

```
const COLORS = [
  { from: "purple-1000", to: "purple-1050", hexCode: "#6671E5" },
  { from: "ash-1000", to: "ash-1050", hexCode: "#606C88" },
  { from: "kimoby-1000", to: "kimoby-1050", hexCode: "#396AFC" },
  { from: "turquoise-1000", to: "turquoise-1050", hexCode: "#136A8A" },
  { from: "shrimpy-1000", to: "shrimpy-1050", hexCode: "#E43A15" },
  { from: "veryblue-1000", to: "veryblue-1050", hexCode: "#0575E6" },
  { from: "fbmessenger-1000", to: "fbmessenger-1050", hexCode: "#00C6FF" }
];
```