### PR TITLE
Added support for `Light` and `Minimal` tooltips

### DIFF
--- a/lib/components/Tooltip.js
+++ b/lib/components/Tooltip.js
@@ -3,9 +3,11 @@ import classnames from "classnames";
 import { Tooltip as BlueprintTooltip } from "@blueprintjs/core";
 
 const Tooltip = ({
+  size,
+  theme = "dark",
+  minimal = false,
   children,
   className = "",
-  size,
   ...otherProps
 }) => {
   return (
@@ -15,10 +17,20 @@ const Tooltip = ({
         className
       ])}
       targetClassName="flex flex-row justify-center items-center"
-      popoverClassName={classnames({
-        [`bp3-tooltip--${size}`]: size
-      })}
+      popoverClassName={classnames(
+        [`bp3-tooltip bp3-tooltip--${theme}`],
+        {
+          [`bp3-tooltip--${size}`]: size
+        }
+      )}
       openOnTargetFocus={false}
+      minimal={minimal}
+      modifiers={{
+        offset: {
+          enabled: minimal,
+          offset: "0, 8"
+        }
+      }}
       {...otherProps}
     >
       {children}

--- a/lib/styles/components/table.scss
+++ b/lib/styles/components/table.scss
@@ -52,6 +52,8 @@
     tr {
       th,
       td {
+        text-align: left;
+
         label {
           display: flex;
           flex-direction: row;

--- a/lib/styles/components/tooltip.scss
+++ b/lib/styles/components/tooltip.scss
@@ -1,17 +1,61 @@
 .bp3-tooltip {
   border-radius: theme("borderRadius.DEFAULT");
   font-size: theme("fontSize.xs");
-  .bp3-popover-arrow-fill {
-    fill: theme("colors.gray.800");
-  }
+  box-shadow: theme("boxShadow.sm");
+
   .bp3-popover-arrow-border {
-    fill: theme("colors.gray.800");
-    fill-opacity: 0.3;
+    fill-opacity: 1;
   }
+
   .bp3-popover-content {
     border-radius: theme("borderRadius.DEFAULT");
-    background: theme("colors.gray.800");
     padding: 6px 10px;
+  }
+
+  &.bp3-tooltip--dark {
+    .bp3-popover-arrow-fill {
+      fill: theme("colors.gray.700");
+    }
+
+    .bp3-popover-arrow-border {
+      fill: transparent;
+    }
+
+    .bp3-popover-content {
+      background: theme("colors.gray.700");
+    }
+  }
+
+  &.bp3-tooltip--light {
+    box-shadow: 0 0 0 1px rgb(16 22 26 / 10%), 0 2px 4px rgb(16 22 26 / 10%),
+      0 8px 16px rgb(16 22 26 / 10%);
+
+    .bp3-popover-arrow-fill {
+      fill: theme("colors.white");
+    }
+
+    .bp3-popover-arrow-border {
+      fill: theme("colors.gray.300");
+    }
+
+    .bp3-popover-content {
+      background: theme("colors.white");
+      color: theme("colors.gray.700");
+    }
+  }
+
+  &.bp3-minimal {
+    .bp3-popover-arrow {
+      display: none !important;
+    }
+
+    .bp3-popover-content {
+      padding: 4px 8px;
+    }
+  }
+
+  &--sm {
+    width: 96px;
   }
 
   &--md {

--- a/src/Previews/Layouts.js
+++ b/src/Previews/Layouts.js
@@ -9,6 +9,11 @@ import {
   FilterBar,
 } from "../../lib/layouts";
 
+import {
+  Button,
+  Tooltip,
+} from "../../lib";
+
 const noop = () => {};
 const LABELS = ["Misc", "Random", "Urgent"];
 const COLUMNFILTERS = {
@@ -66,7 +71,38 @@ const Layouts = () => {
             />
             <div className="flex flex-row items-start justify-start w-full">
               <Scrollable className="w-full p-4">
-                <div className="flex-grow h-full bg-gray-100 rounded"></div>
+                <table className="nui-table nui-table--actions">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Email</th>
+                      <th>Company</th>
+                      <th>Phone No</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Goutham Subramanyam</td>
+                      <td>goutham.subramanyam@bigbinary.com</td>
+                      <td>BigBinary</td>
+                      <td>+91 9633123456</td>
+                      <td>
+                        <div className="flex flex-row items-center justify-end space-x-3">
+                          <Tooltip content="Edit" position="bottom">
+                            <Button icon="ri-pencil-line" style="icon"/>
+                          </Tooltip>
+                          <Tooltip content="Deactivate" position="bottom" theme="light">
+                            <Button icon="ri-lock-line" style="icon"/>
+                          </Tooltip>
+                          <Tooltip content="Delete" position="bottom" minimal>
+                            <Button icon="ri-delete-bin-line" style="icon"/>
+                          </Tooltip>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </Scrollable>
               <FilterBar showFilter={showFilter} />
             </div>


### PR DESCRIPTION
Fixes #276 

@edwinbbu _a Please review.

Dark:
<img width="502" alt="Screenshot 2021-05-22 at 11 45 12 PM" src="https://user-images.githubusercontent.com/24496302/119236964-f6143380-bb57-11eb-94e8-3b88f510d233.png">

Light:
<img width="432" alt="Screenshot 2021-05-22 at 11 45 16 PM" src="https://user-images.githubusercontent.com/24496302/119236966-f7ddf700-bb57-11eb-8385-68c743494333.png">

Light Minimal:
<img width="431" alt="Screenshot 2021-05-22 at 11 45 19 PM" src="https://user-images.githubusercontent.com/24496302/119236968-f90f2400-bb57-11eb-8bf2-0a86838ea2fa.png">

Dark Minimal:
<img width="453" alt="Screenshot 2021-05-22 at 11 45 23 PM" src="https://user-images.githubusercontent.com/24496302/119236969-f9a7ba80-bb57-11eb-9e54-34a2410e7b31.png">

We should start using `Dark Minimal` inside all tables.