### PR TITLE
Responsive Modal Styles

### DIFF
--- a/lib/components/Alert.js
+++ b/lib/components/Alert.js
@@ -5,8 +5,8 @@ import classnames from "classnames";
 const ALERT_STYLE_BACKGROUND = {
   danger: "bg-red-50",
   info: "bg-blue-50",
-  warning: "bg-yellow-50"
-}
+  warning: "bg-yellow-50",
+};
 
 export default function Alert({
   style = "danger",
@@ -41,7 +41,7 @@ export default function Alert({
       }}
       {...otherProps}
     >
-      <div className="flex">
+      <div className="flex flex-col items-center space-y-4 md:flex-row md:items-start md:space-y-0 md:space-x-4">
         <div
           className={classnames(
             "flex items-center justify-center flex-shrink-0 w-10 h-10 rounded-full",
@@ -51,23 +51,23 @@ export default function Alert({
           <i className={classnames([icon, "ri-lg"])}></i>
         </div>
 
-        <div className="ml-4">
+        <div className="w-full md:w-auto">
           <h3
             data-cy="alert-title"
-            className="mb-2 text-lg font-medium text-gray-800"
+            className="mb-2 text-lg font-medium text-center text-gray-800 md:text-left"
           >
             {title}
           </h3>
           <div
             data-cy="alert-message"
-            className="mb-2 text-sm leading-5 text-gray-600"
+            className="mb-2 text-sm leading-5 text-center text-gray-600 md:text-left"
           >
             {message}
           </div>
           {!hideConfirmation && (
             <div
               data-cy="alert-confirmation-text"
-              className="text-sm leading-5 text-gray-600"
+              className="text-sm leading-5 text-center text-gray-600 md:text-left"
             >
               {confirmationText || "Are you sure you want to continue?"}
             </div>

--- a/lib/styles/abstracts/variables.scss
+++ b/lib/styles/abstracts/variables.scss
@@ -6,5 +6,11 @@ $pane-header-height: 78px;
 $pane-footer-height: 64px;
 $modal-footer-padding: 96px;
 
+// Breakpoints
+$mob-479: 479px;
+$tab-768: 768px;
+$tab-1024: 1024px;
+$desk-1200: 1200px;
+
 //Colors
 $primary-gradient: linear-gradient(223.53deg, #6671e5 3.65%, #4852d9 102.22%);

--- a/lib/styles/abstracts/variables.scss
+++ b/lib/styles/abstracts/variables.scss
@@ -5,6 +5,7 @@ $sidebar-width: 72px;
 $pane-header-height: 78px;
 $pane-footer-height: 64px;
 $modal-footer-padding: 96px;
+$modal-footer-padding-mobile: 180px;;
 
 // Breakpoints
 $mob-479: 479px;

--- a/lib/styles/components/modal.scss
+++ b/lib/styles/components/modal.scss
@@ -43,11 +43,8 @@
     border-radius: 0;
 
     @include viewport(mob) {
-      width: 100%;
-    }
-
-    @include viewport(mob) {
       height: 100vh;
+      width: 100%;
     }
   }
 
@@ -63,7 +60,7 @@
     padding-bottom: $modal-footer-padding;
 
     @include viewport(mob) {
-      padding-bottom: 180px;
+      padding-bottom: $modal-footer-padding-mobile;
 
       button{
         width: 100%;

--- a/lib/styles/components/modal.scss
+++ b/lib/styles/components/modal.scss
@@ -13,15 +13,19 @@
     width: 40%;
     max-width: 544px;
     min-height: 40vh;
+
+    @include viewport(tab-min) {
+      margin: 0 8px;
+      width: 100%;
+    }
   }
 
   &.nui-modal__wrapper--md {
     width: 65%;
     min-height: 65vh;
 
-    @include viewport(mob){
-        width: 100%;
-        min-height: 65vh;
+    @include viewport(tab-min) {
+      width: 100%;
     }
   }
 
@@ -30,6 +34,14 @@
     min-height: 100vh;
     margin: 0;
     border-radius: 0;
+
+    @include viewport(tab-min) {
+      width: 100%;
+    }
+
+    @include viewport(mob) {
+      height: 100vh;
+    }
   }
 
   &.nui-modal__wrapper--auto-height {
@@ -61,6 +73,7 @@
     position: absolute;
     right: 24px;
     top: 24px;
+
     .nui-btn {
       width: 30px;
       height: 30px;

--- a/lib/styles/components/modal.scss
+++ b/lib/styles/components/modal.scss
@@ -7,7 +7,6 @@
   background-color: theme("colors.white");
   border-radius: theme("borderRadius.lg");
   box-shadow: theme("boxShadow.xl");
-  overflow: hidden;
 
   &.nui-modal__wrapper--sm {
     width: 40%;
@@ -15,6 +14,10 @@
     min-height: 40vh;
 
     @include viewport(tab-min) {
+      width: 75%;
+    }
+
+    @include viewport(mob) {
       margin: 0 8px;
       width: 100%;
     }
@@ -25,6 +28,10 @@
     min-height: 65vh;
 
     @include viewport(tab-min) {
+      width: 75%;
+    }
+
+    @include viewport(mob) {
       width: 100%;
     }
   }
@@ -35,7 +42,7 @@
     margin: 0;
     border-radius: 0;
 
-    @include viewport(tab-min) {
+    @include viewport(mob) {
       width: 100%;
     }
 
@@ -54,6 +61,18 @@
 
   &.nui-modal__wrapper--footer {
     padding-bottom: $modal-footer-padding;
+
+    @include viewport(mob) {
+      padding-bottom: 180px;
+
+      button{
+        width: 100%;
+        justify-content: center;
+        padding-top: 12px;
+        padding-bottom: 12px;
+        margin: 8px 0;
+      }
+    }
   }
 
   .nui-modal__footer {
@@ -67,6 +86,10 @@
     width: 100%;
     padding: 14px 24px;
     background-color: theme("colors.gray.50");
+
+    @include viewport(mob){
+      flex-direction: column-reverse;
+    }
   }
 
   .nui-modal__close {

--- a/lib/styles/components/modal.scss
+++ b/lib/styles/components/modal.scss
@@ -18,6 +18,11 @@
   &.nui-modal__wrapper--md {
     width: 65%;
     min-height: 65vh;
+
+    @include viewport(mob){
+        width: 100%;
+        min-height: 65vh;
+    }
   }
 
   &.nui-modal__wrapper--lg {

--- a/lib/styles/index.scss
+++ b/lib/styles/index.scss
@@ -8,6 +8,10 @@
 //Abstracts
 @import "./abstracts/variables";
 
+//Utilities
+@import "./utilities/animations";
+@import "./utilities/media-query";
+
 //Components
 @import "./components/badge";
 @import "./components/button";
@@ -33,6 +37,3 @@
 @import "./layout/filterbar";
 @import "./layout/header";
 @import "./layout/menubar";
-
-//Utilities
-@import "./utilities/animations";

--- a/lib/styles/utilities/media-query.scss
+++ b/lib/styles/utilities/media-query.scss
@@ -1,0 +1,49 @@
+@mixin viewport($media) {
+  @if $media==desk {
+    @media screen and (min-width: $desk-1200) {
+      @content;
+    }
+  }
+
+  @else if $media==tab-min {
+    @media screen and (max-width: $tab-1024) {
+      @content;
+    }
+  }
+
+  @else if $media==tab-only {
+    @media screen and (min-width: $tab-768) and (max-width: $tab-1024 - 1) {
+      @content;
+    }
+  }
+
+  @else if $media==mob {
+    @media screen and (max-width: $tab-768 - 1) {
+      @content;
+    }
+  }
+
+  @else if $media==xs-mob {
+    @media screen and (max-width: $mob-479) {
+      @content;
+    }
+  }
+}
+
+@mixin min-max($resMin, $resMax) {
+  @media (min-width: $resMin+px) and (max-width: $resMax+px) {
+    @content;
+  }
+}
+
+@mixin max($res) {
+  @media (max-width: $res+px) {
+    @content;
+  }
+}
+
+@mixin min($res) {
+  @media (min-width: $res+px) {
+    @content;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet">
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>neetoUI</title>
   </head>
   <body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,6 +64,10 @@ module.exports = {
       zIndex: {
         1: 1,
       },
+      screens: {
+        sm: "768px",
+        md: "991px",
+      },
     },
   },
   variants: {
@@ -72,7 +76,7 @@ module.exports = {
     backgroundColor: ["hover", "active"],
     color: ["hover", "active"],
     margin: ["last"],
-    outline: ["focus"] 
+    outline: ["focus"],
   },
   plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
Fixes #317 

@goutham-subramanyam _a Please review.

Screenshots- 

1.  Mobile (Portrait)

<img width="385" alt="Screenshot 2021-06-16 at 1 41 49 AM" src="https://user-images.githubusercontent.com/41678651/122117537-9d794300-ce44-11eb-925c-ceee99c82ca3.png">

2. Mobile (Landscape)

<img width="846" alt="Screenshot 2021-06-16 at 1 41 54 AM" src="https://user-images.githubusercontent.com/41678651/122117561-a36f2400-ce44-11eb-8d7e-38bec3f8f517.png">


3. Tablet (Landscape)

<img width="1001" alt="Screenshot 2021-06-16 at 1 42 34 AM" src="https://user-images.githubusercontent.com/41678651/122117591-ac5ff580-ce44-11eb-8706-a6b389658357.png">

4. For Modal `type=large`, I have added height as `100vh`. Please let me know if I need to revert this change.

<img width="444" alt="Screenshot 2021-06-16 at 1 43 57 AM" src="https://user-images.githubusercontent.com/41678651/122117705-cbf71e00-ce44-11eb-99d4-56e2633c4b8f.png">
