### PR TITLE
Updated toastr styles

### DIFF
--- a/example/v2/Pages/Toastr.js
+++ b/example/v2/Pages/Toastr.js
@@ -1,39 +1,46 @@
 import React from "react";
-import { Button, Toastr } from "../../../lib/components";
+
 import Header from "../Header";
+import { Button, Toastr } from "../../../lib/components";
 
 const Toastrs = () => {
   return (
     <div className="w-full">
       <Header title="Toastr" />
       <div className="p-6 space-y-6">
-        <div className="space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
-            <Button
-              label="Show toastr info"
-              onClick={() => Toastr.info("This is an info toastr.")}
-            />
-            <Button
-              label="Show toastr warning"
-              onClick={() => Toastr.warning("This is a warning toastr.")}
-            />
-            <Button
-              label="Show toastr success"
-              onClick={() =>
-                Toastr.success("Form has been successfully saved.")
-              }
-            />
-            <Button
-              label="Show toastr error"
-              onClick={() =>
-                Toastr.error(
-                  Error(
-                    "Some error occured! Please visit https://github.com/bigbinary/neeto-ui."
-                  )
+        <div className="flex flex-row items-center justify-start space-x-6">
+          <Button
+            label="Info Toastr"
+            onClick={() => Toastr.info("This is an info toastr.")}
+          />
+          <Button
+            label="Warning Toastr"
+            onClick={() => Toastr.warning("This is a warning toastr.")}
+          />
+          <Button
+            label="Success Toastr"
+            onClick={() => Toastr.success("Form has been successfully saved.")}
+          />
+          <Button
+            label="Toastr with CTA"
+            onClick={() =>
+              Toastr.error(
+                Error("Ticket marked as spam."),
+                "Block Customer",
+                () => alert("Customer blocked successfully!")
+              )
+            }
+          />
+          <Button
+            label="Error Toastr"
+            onClick={() =>
+              Toastr.error(
+                Error(
+                  "Some error occured! Please visit https://github.com/bigbinary/neeto-ui."
                 )
-              }
-            />
-          </div>
+              )
+            }
+          />
         </div>
       </div>
     </div>

--- a/example/v2/Pages/Toastr.js
+++ b/example/v2/Pages/Toastr.js
@@ -7,25 +7,31 @@ const Toastrs = () => {
     <div className="w-full">
       <Header title="Toastr" />
       <div className="p-6 space-y-6">
-        <div className="w-1/2 space-y-8">
+        <div className="space-y-8">
           <div className="flex flex-row items-center justify-start space-x-6">
             <Button
+              label="Show toastr info"
+              onClick={() => Toastr.info("This is an info toastr.")}
+            />
+            <Button
+              label="Show toastr warning"
+              onClick={() => Toastr.warning("This is a warning toastr.")}
+            />
+            <Button
               label="Show toastr success"
-              onClick={() => Toastr.success("Form has been successfully saved")}
+              onClick={() =>
+                Toastr.success("Form has been successfully saved.")
+              }
             />
             <Button
               label="Show toastr error"
               onClick={() =>
                 Toastr.error(
                   Error(
-                    "Some error occured! Please visit https://github.com/bigbinary/neeto-ui. Some error occured!Some error occured!Some error occured!Some error occured!Some error occured!"
+                    "Some error occured! Please visit https://github.com/bigbinary/neeto-ui."
                   )
                 )
               }
-            />
-            <Button
-              label="Show toastr info"
-              onClick={() => Toastr.info("Toaster info")}
             />
           </div>
         </div>

--- a/lib/components/Toastr.js
+++ b/lib/components/Toastr.js
@@ -1,10 +1,36 @@
 import React from "react";
-import * as R from "ramda";
-import { toast, Slide } from "react-toastify";
-import Button from "./Button";
+import { join } from "ramda";
 import Linkify from "react-linkify";
+import { toast, Slide } from "react-toastify";
+import {
+  CheckCircle,
+  Warning,
+  CloseCircle,
+  Info,
+  Close,
+} from "@bigbinary/neeto-icons";
+
+import Button from "./Button";
 
 const noop = () => {};
+
+const TOAST_CONFIG = {
+  autoClose: false,
+  position: toast.POSITION.BOTTOM_CENTER,
+  transition: Slide,
+  hideProgressBar: true,
+  closeButton: (
+    <Close size={16} color="#68737D" className="nui-toastr__close-button" />
+  ),
+  className: "nui-toast",
+};
+
+const TOAST_ICON = {
+  success: <CheckCircle color="#00BA88" />,
+  warning: <Warning color="#F3CD82" />,
+  error: <CloseCircle color="#F56A58" />,
+  info: <Info color="#276EF1" />,
+};
 
 const ToastrComponent = ({
   type,
@@ -16,56 +42,47 @@ const ToastrComponent = ({
     <div
       data-cy="toastr-message-container"
       data-test={`toastr-${type}-container`}
-      className="flex flex-row items-start justify-start"
     >
       <Linkify
         componentDecorator={(decoratedHref, decoratedText, key) => (
           <a target="_blank" href={decoratedHref} key={key} rel="noreferrer">
-            {" "}
-            {decoratedText}{" "}
+            &nbsp;{decoratedText}&nbsp;
           </a>
         )}
       >
-        <p className="mx-4 font-medium leading-5 text-white">{message}</p>
+        {TOAST_ICON[type]}
+        <p>{message}</p>
       </Linkify>
-      {buttonLabel && (
-        <Button style="link" label={buttonLabel} onClick={onClick} data-cy={`toastr-${type}-button`} />
-      )}
+      {/* {buttonLabel && (
+        <Button
+          style="link"
+          label={buttonLabel}
+          onClick={onClick}
+          data-cy={`toastr-${type}-button`}
+        />
+      )} */}
     </div>
   );
 };
 
 const showToastr = (message, buttonLabel, onClick) => {
-  toast.dark(
-    <ToastrComponent
-      type="success"
-      message={"🎉 " + message}
-      buttonLabel={buttonLabel}
-      onClick={onClick}
-    />,
-    {
-      position: toast.POSITION.BOTTOM_CENTER,
-      transition: Slide,
-      hideProgressBar: true,
-      className: "nui-toast",
-    }
+  toast.success(
+    <ToastrComponent type="success" message={message} onClick={onClick} />,
+    { ...TOAST_CONFIG }
   );
 };
 
 const showInfoToastr = (message, buttonLabel, onClick) => {
-  toast.dark(
-    <ToastrComponent
-      type="info"
-      message={"🦄 " + message}
-      buttonLabel={buttonLabel}
-      onClick={onClick}
-    />,
-    {
-      position: toast.POSITION.BOTTOM_CENTER,
-      transition: Slide,
-      hideProgressBar: true,
-      className: "nui-toast",
-    }
+  toast.info(
+    <ToastrComponent type="info" message={message} onClick={onClick} />,
+    { ...TOAST_CONFIG, autoClose: 10000 }
+  );
+};
+
+const ShowToastrWarning = (message, buttonLabel, onClick) => {
+  toast.warning(
+    <ToastrComponent type="warning" message={message} onClick={onClick} />,
+    { ...TOAST_CONFIG }
   );
 };
 
@@ -75,21 +92,11 @@ const showErrorToastr = (errorObject, buttonLabel, onClick) => {
   let errorMessage;
   if (isError(errorObject)) errorMessage = errorObject.message;
   else if (errorObject.error) errorMessage = errorObject.error;
-  else if (errorObject.errors) errorMessage = R.join("\n", errorObject.errors);
+  else if (errorObject.errors) errorMessage = join("\n", errorObject.errors);
   else errorMessage = "Something went wrong.";
-  toast.dark(
-    <ToastrComponent
-      type="error"
-      message={"❌ " + errorMessage}
-      buttonLabel={buttonLabel}
-      onClick={onClick}
-    />,
-    {
-      position: toast.POSITION.BOTTOM_CENTER,
-      hideProgressBar: true,
-      transition: Slide,
-      className: "nui-toast",
-    }
+  toast.error(
+    <ToastrComponent type="error" message={errorMessage} onClick={onClick} />,
+    { ...TOAST_CONFIG }
   );
 };
 
@@ -97,6 +104,7 @@ export const Toastr = {
   success: showToastr,
   show: showToastr,
   error: showErrorToastr,
+  warning: ShowToastrWarning,
   info: showInfoToastr,
 };
 

--- a/lib/components/Toastr.js
+++ b/lib/components/Toastr.js
@@ -14,8 +14,8 @@ const noop = () => {};
 
 const TOAST_CONFIG = {
   autoClose: 3500,
-  position: toast.POSITION.BOTTOM_CENTER,
   transition: Slide,
+  position: toast.POSITION.BOTTOM_CENTER,
   hideProgressBar: true,
   closeButton: (
     <Close size={16} color="#68737D" className="nui-toastr__close-button" />
@@ -66,7 +66,7 @@ const ToastrComponent = ({
   );
 };
 
-const showToastr = (message, buttonLabel, onClick) => {
+const showSuccessToastr = (message, buttonLabel, onClick) => {
   toast.success(
     <ToastrComponent
       type="success"
@@ -89,7 +89,7 @@ const showInfoToastr = (message, buttonLabel, onClick) => {
       buttonLabel={buttonLabel}
       onClick={onClick}
     />,
-    { ...TOAST_CONFIG, icon: TOAST_ICON["info"], closeOnClick: !buttonLabel }
+    { ...TOAST_CONFIG, icon: TOAST_ICON["info"] }
   );
 };
 
@@ -127,7 +127,7 @@ const showErrorToastr = (errorObject, buttonLabel, onClick) => {
       ...TOAST_CONFIG,
       icon: TOAST_ICON["error"],
       role: "alert",
-      autoClose: false,
+      autoClose: 7000,
     }
   );
 };
@@ -135,7 +135,7 @@ const showErrorToastr = (errorObject, buttonLabel, onClick) => {
 export const Toastr = {
   info: showInfoToastr,
   show: showInfoToastr,
-  success: showToastr,
+  success: showSuccessToastr,
   error: showErrorToastr,
   warning: showWarningToastr,
 };

--- a/lib/components/Toastr.js
+++ b/lib/components/Toastr.js
@@ -10,19 +10,18 @@ import {
   Close,
 } from "@bigbinary/neeto-icons";
 
-import Button from "./Button";
-
 const noop = () => {};
 
 const TOAST_CONFIG = {
-  autoClose: false,
+  autoClose: 3500,
   position: toast.POSITION.BOTTOM_CENTER,
   transition: Slide,
   hideProgressBar: true,
   closeButton: (
     <Close size={16} color="#68737D" className="nui-toastr__close-button" />
   ),
-  className: "nui-toast",
+  role: "log",
+  className: "nui-toastr",
 };
 
 const TOAST_ICON = {
@@ -50,39 +49,62 @@ const ToastrComponent = ({
           </a>
         )}
       >
-        {TOAST_ICON[type]}
         <p>{message}</p>
       </Linkify>
-      {/* {buttonLabel && (
-        <Button
-          style="link"
-          label={buttonLabel}
-          onClick={onClick}
+      {buttonLabel && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+          }}
           data-cy={`toastr-${type}-button`}
-        />
-      )} */}
+        >
+          {buttonLabel}
+        </button>
+      )}
     </div>
   );
 };
 
 const showToastr = (message, buttonLabel, onClick) => {
   toast.success(
-    <ToastrComponent type="success" message={message} onClick={onClick} />,
-    { ...TOAST_CONFIG }
+    <ToastrComponent
+      type="success"
+      message={message}
+      buttonLabel={buttonLabel}
+      onClick={onClick}
+    />,
+    {
+      ...TOAST_CONFIG,
+      icon: TOAST_ICON["success"],
+    }
   );
 };
 
 const showInfoToastr = (message, buttonLabel, onClick) => {
   toast.info(
-    <ToastrComponent type="info" message={message} onClick={onClick} />,
-    { ...TOAST_CONFIG, autoClose: 10000 }
+    <ToastrComponent
+      type="info"
+      message={message}
+      buttonLabel={buttonLabel}
+      onClick={onClick}
+    />,
+    { ...TOAST_CONFIG, icon: TOAST_ICON["info"], closeOnClick: !buttonLabel }
   );
 };
 
-const ShowToastrWarning = (message, buttonLabel, onClick) => {
+const showWarningToastr = (message, buttonLabel, onClick) => {
   toast.warning(
-    <ToastrComponent type="warning" message={message} onClick={onClick} />,
-    { ...TOAST_CONFIG }
+    <ToastrComponent
+      type="warning"
+      message={message}
+      buttonLabel={buttonLabel}
+      onClick={onClick}
+    />,
+    {
+      ...TOAST_CONFIG,
+      icon: TOAST_ICON["warning"],
+    }
   );
 };
 
@@ -95,17 +117,27 @@ const showErrorToastr = (errorObject, buttonLabel, onClick) => {
   else if (errorObject.errors) errorMessage = join("\n", errorObject.errors);
   else errorMessage = "Something went wrong.";
   toast.error(
-    <ToastrComponent type="error" message={errorMessage} onClick={onClick} />,
-    { ...TOAST_CONFIG }
+    <ToastrComponent
+      type="error"
+      message={errorMessage}
+      buttonLabel={buttonLabel}
+      onClick={onClick}
+    />,
+    {
+      ...TOAST_CONFIG,
+      icon: TOAST_ICON["error"],
+      role: "alert",
+      autoClose: false,
+    }
   );
 };
 
 export const Toastr = {
-  success: showToastr,
-  show: showToastr,
-  error: showErrorToastr,
-  warning: ShowToastrWarning,
   info: showInfoToastr,
+  show: showInfoToastr,
+  success: showToastr,
+  error: showErrorToastr,
+  warning: showWarningToastr,
 };
 
 export default Toastr;

--- a/lib/styles/abstracts/_variables.scss
+++ b/lib/styles/abstracts/_variables.scss
@@ -54,7 +54,7 @@ $transition: all 0.3s ease-in-out;
 
 //Shadows
 
-$shadow: 0px 0px 0px 3px $gray-100;
+$shadow: 0px 0px 0px 3px $gray-200;
 $shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 

--- a/lib/styles/components/_toast.scss
+++ b/lib/styles/components/_toast.scss
@@ -2,7 +2,7 @@
   padding: 0;
 
   width: auto;
-  max-width: 680px;
+  max-width: 640px;
   min-width: 320px;
 
   .Toastify__toast,

--- a/lib/styles/components/_toast.scss
+++ b/lib/styles/components/_toast.scss
@@ -1,63 +1,71 @@
-.nui-toast {
-  min-height: unset;
-}
-
 .Toastify__toast-container {
   padding: 0 !important;
   width: auto !important;
-  max-width: 520px;
-  min-width: 300px;
+  max-width: 620px;
+  min-width: 320px;
 
-  .Toastify__toast {
-    border-radius: theme("borderRadius.sm");
+  .Toastify__toast,
+  .nui-toast {
     min-height: 40px;
-    padding: 12px;
+    padding: 0.5rem;
     margin: 0 0 1rem;
-    box-shadow: theme("boxShadow.sm");
+
+    box-shadow: none;
+
+    border-radius: $rounded-sm;
 
     .Toastify__toast-body {
       margin: 0;
+
+      color: $gray-800;
+
+      div {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        p {
+          font-size: $text-sm;
+          margin: 0 0.75rem;
+        }
+      }
     }
 
-    // &.Toastify__toast--success {
-    //   background: theme("colors.green.600");
-    // }
+    &.Toastify__toast--success {
+      background: $pastel-green;
+      border: 1px solid $green;
+    }
 
     &.Toastify__toast--error {
-      background: theme("colors.red.500");
+      background: $pastel-red;
+      border: 1px solid $red;
     }
 
     &.Toastify__toast--info {
-      background: theme("colors.blue.500");
+      background: $pastel-blue;
+      border: 1px solid $blue;
+    }
+
+    &.Toastify__toast--warning {
+      background: $pastel-yellow;
+      border: 1px solid $yellow;
     }
 
     &.Toastify__toast--default {
-      background: theme("colors.blue.500");
+      background: $pastel-blue;
+      border: 1px solid $blue;
     }
 
-    .Toastify__progress-bar {
-      background-color: theme("colors.white");
-      height: 6px;
-    }
+    .nui-toastr__close-button {
+      opacity: 0.5;
+      margin: auto 0;
 
-    .Toastify__close-button {
-      opacity: 0.8;
+      transition: $transition;
 
       &:hover,
       &:focus,
       &:active {
         opacity: 1;
-      }
-    }
-
-    .nui-btn--link {
-      color: theme("colors.gray.100");
-      margin-left: auto;
-      padding: 0 16px;
-      line-height: 20px;
-      font-weight: theme("fontWeight.medium");
-      &:hover {
-        color: theme("colors.white");
       }
     }
   }

--- a/lib/styles/components/_toast.scss
+++ b/lib/styles/components/_toast.scss
@@ -1,11 +1,12 @@
 .Toastify__toast-container {
-  padding: 0 !important;
-  width: auto !important;
-  max-width: 620px;
+  padding: 0;
+
+  width: auto;
+  max-width: 680px;
   min-width: 320px;
 
   .Toastify__toast,
-  .nui-toast {
+  .nui-toastr {
     min-height: 40px;
     padding: 0.5rem;
     margin: 0 0 1rem;
@@ -14,20 +15,54 @@
 
     border-radius: $rounded-sm;
 
+    .Toastify__toast-icon {
+      margin: 0;
+    }
+
     .Toastify__toast-body {
       margin: 0;
+      padding: 0;
 
       color: $gray-800;
 
       div {
         display: flex;
         flex-direction: row;
+        justify-content: space-between;
         align-items: center;
 
         p {
           font-size: $text-sm;
           margin: 0 0.75rem;
         }
+
+        button {
+          padding: 0;
+          margin: 0 0.25rem 0;
+          cursor: pointer;
+
+          color: $gray-800;
+          opacity: 0.5;
+
+          transition: $transition;
+
+          &:hover {
+            opacity: 1;
+          }
+        }
+      }
+    }
+
+    .nui-toastr__close-button {
+      opacity: 0.5;
+      margin: auto 0;
+
+      transition: $transition;
+
+      &:hover,
+      &:focus,
+      &:active {
+        opacity: 1;
       }
     }
 
@@ -56,17 +91,5 @@
       border: 1px solid $blue;
     }
 
-    .nui-toastr__close-button {
-      opacity: 0.5;
-      margin: auto 0;
-
-      transition: $transition;
-
-      &:hover,
-      &:focus,
-      &:active {
-        opacity: 1;
-      }
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "react-spinners": "^0.9.0",
     "react-spring": "^8.0.27",
     "react-test-renderer": "^17.0.2",
-    "react-toastify": "^6.0.9",
     "sass": "^1.26.11",
     "sass-loader": "^10.0.2",
     "style-loader": "^1.2.1",
@@ -75,8 +74,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
-    "react-router-nav-prompt": "^0.4.1",
-    "react-toastify": "^6.0.9"
+    "react-router-nav-prompt": "^0.4.1"
   },
   "dependencies": {
     "@bigbinary/neeto-icons": "^1.6.2",
@@ -96,7 +94,8 @@
     "react-linkify": "^1.0.0-alpha",
     "react-outside-click-handler": "^1.3.0",
     "react-popper": "^2.2.5",
-    "react-router-nav-prompt": "^0.4.1"
+    "react-router-nav-prompt": "^0.4.1",
+    "react-toastify": "^8.0.2"
   },
   "description": "NeetoUI is the library that drives the experience in all Neeto products built at BigBinary",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-toastify": "^6.0.9"
   },
   "dependencies": {
-    "@bigbinary/neeto-icons": "^1.4.0",
+    "@bigbinary/neeto-icons": "^1.6.2",
     "@popperjs/core": "^2.9.2",
     "@reach/auto-id": "^0.15.0",
     "@tailwindcss/forms": "^0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4304,6 +4304,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -11900,14 +11905,12 @@ react-test-renderer@^17.0.2:
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
 
-react-toastify@^6.0.9:
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-6.0.9.tgz#2a65e5ad9e05f3ee47664cbc69441498b9d694ce"
-  integrity sha512-StHXv+4kezHUnPyoILlvygSptQ79bxVuvKcC05yXP0FlqQgPA1ue+80BqxZZiCw2jWDGiY2MHyqBfFKf5YzZbA==
+react-toastify@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-8.0.2.tgz#11f73b3a847fcffeb47b1823e8974e9895f98fae"
+  integrity sha512-0Nud2d0VD4LIevgkB4L8NYoQ5plTpfqgj2CRVxs58SGA/TTO+2Ojz4C1bLUdGUWsw0zuWqd4GJqxNuMIv0cXMw==
   dependencies:
-    classnames "^2.2.6"
-    prop-types "^15.7.2"
-    react-transition-group "^4.4.1"
+    clsx "^1.1.1"
 
 react-transition-group@^2.9.0:
   version "2.9.0"
@@ -11919,7 +11922,7 @@ react-transition-group@^2.9.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-transition-group@^4.3.0, react-transition-group@^4.4.1:
+react-transition-group@^4.3.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bigbinary/neeto-icons@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@bigbinary/neeto-icons/-/neeto-icons-1.4.0.tgz#82c911346421a8b6fd6f12d53ecbb9e5b1cde9d2"
-  integrity sha512-95llpdZV8eYaxwxR6Gfft/M4AINV1ytieZuhbYptFCG6Ks9jyzVC8CSVzAVs/3NcxDs18al3xspSRziFKWKC0g==
+"@bigbinary/neeto-icons@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@bigbinary/neeto-icons/-/neeto-icons-1.6.2.tgz#be266539875b374d1bc3c8310e7b79c9f7dcd394"
+  integrity sha512-ZUg7aY9PoTwZQNt0wL1hx55NUjoRRwx1+nsxLACvpIm+/qNEjZJHtCCk0jwdb2enscAvheFE7+ITxL6pS9PZ2Q==
   dependencies:
     prop-types "^15.7.2"
     react "^17.0.2"


### PR DESCRIPTION
Fixes #438 
Fixes #441 

- Updated Toastr styles to v2. 
- Upgraded `neeto-icons` and `react-toastify` packages.
- Added `roles` to Toastr. 
- Normal duration of toast - `3500`, for error toasts - `7000`.
- `buttonLabel` was previously added to `Toastr` based on https://github.com/bigbinary/neeto-ui/issues/296. I have used a custom-styled `button` for the same.
- Updated the `$shadow` variable to use `$gray-200` in place of `$gray-100`.


@edwinbbu _a @goutham-subramanyam Please review. 

Ref: [Loom Video](https://www.loom.com/share/93d20027eec64a3d88fc84f8da7c90a4)