### PR TITLE
Removed unwanted box-shadow

### DIFF
--- a/lib/styles/components/_select.scss
+++ b/lib/styles/components/_select.scss
@@ -54,7 +54,6 @@
     border-radius: $rounded-sm;
     background-color: $white;
     min-height: 0;
-    box-shadow: $shadow;
     transition: border 0.3s;
   }
 


### PR DESCRIPTION
Fixes #448 

@goutham-subramanyam _a Please review. 

- Removed `box-shadow` styles from `react-select` container when not in focus. 


Ref - [loom video](https://www.loom.com/share/533c073ab4c548dd89db9eebea861216)
