### PR TITLE
Updated button styles to match the new design

### DIFF
--- a/example/src/Pages/Button.js
+++ b/example/src/Pages/Button.js
@@ -13,588 +13,309 @@ const Buttons = () => {
       <Header title="Buttons" />
       <div className="p-6 space-y-6">
         <Button onClick={toggle} label="Toggle Loading State" />
-        <div className="grid grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 gap-6">
           <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Large/Primary</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
+            <h2 className="text-xl">Styles</h2>
+            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
               <Button
                 loading={loading}
                 onClick={toggle}
                 size="large"
-                label="Label"
+                label="Primary"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
                 size="large"
-                label="Label"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Label"
+                label="Primary"
                 disabled
               />
-              <Button onClick={toggle} size="large" label="Label" loading />
-            </div>
-            <div className="flex gap-6">
               <Button
                 loading={loading}
                 onClick={toggle}
                 size="large"
-                label="Label"
+                label="Primary"
                 icon={Keyboard}
               />
               <Button
                 loading={loading}
                 onClick={toggle}
                 size="large"
-                label="Label"
+                label="Primary"
                 icon={Keyboard}
+                iconPosition="left"
               />
               <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Label"
-                disabled
-                icon={Keyboard}
-              />
-              <Button
-                onClick={toggle}
-                size="large"
-                label="Label"
-                icon={Keyboard}
                 loading
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
                 onClick={toggle}
                 size="large"
-                label="Label"
+                label="Primary"
                 icon={Keyboard}
-                iconPosition="left"
               />
               <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Label"
-                disabled
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                onClick={toggle}
-                size="large"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
                 loading
-              />
-            </div>
-          </div>
-          <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Default/Primary</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button loading={loading} onClick={toggle} label="Label" />
-              <Button loading={loading} onClick={toggle} label="Label" />
-              <Button
-                loading={loading}
                 onClick={toggle}
-                label="Label"
-                disabled
-              />
-              <Button onClick={toggle} label="Label" loading />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Label"
+                size="large"
+                label="Primary"
                 icon={Keyboard}
+                iconPosition="left"
               />
               <Button
-                loading={loading}
-                onClick={toggle}
-                label="Label"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Label"
-                disabled
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Label"
-                icon={Keyboard}
                 loading
+                onClick={toggle}
+                size="large"
+                icon={Keyboard}
+              />
+            </div>
+            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Secondary"
+                style="secondary"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Secondary"
+                style="secondary"
+                disabled
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Secondary"
+                style="secondary"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Secondary"
+                style="secondary"
+                icon={Keyboard}
+                iconPosition="left"
+              />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
+                label="Secondary"
+                style="secondary"
+                icon={Keyboard}
+              />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
+                label="Secondary"
+                style="secondary"
+                icon={Keyboard}
+                iconPosition="left"
+              />
+            </div>
+            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Danger"
+                style="danger"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Danger"
+                style="danger"
+                disabled
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Danger"
+                style="danger"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Danger"
+                style="danger"
+                icon={Keyboard}
+                iconPosition="left"
+              />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
+                label="Danger"
+                style="danger"
+                icon={Keyboard}
+              />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
+                label="Danger"
+                style="danger"
+                icon={Keyboard}
+                iconPosition="left"
               />
             </div>
             <div className="flex flex-row flex-wrap items-center justify-start gap-8">
               <Button
                 loading={loading}
                 onClick={toggle}
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
+                size="large"
+                label="Text"
+                style="text"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Label"
+                size="large"
+                label="Text"
+                style="text"
                 disabled
-                icon={Keyboard}
-                iconPosition="left"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                label="Label"
+                size="large"
+                label="Text"
+                style="text"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Text"
+                style="text"
+                icon={Keyboard}
+                iconPosition="left"
+              />
+              <Button
                 loading
+                onClick={toggle}
+                size="large"
+                label="Text"
+                style="text"
+                icon={Keyboard}
+              />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
+                label="Text"
+                style="text"
                 icon={Keyboard}
                 iconPosition="left"
               />
             </div>
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-6">
-          <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Large/Secondary</h2>
             <div className="flex flex-row flex-wrap items-center justify-start gap-8">
               <Button
-                loading={loading}
-                onClick={toggle}
                 size="large"
-                style="secondary"
-                label="Label"
+                label="Link"
+                style="link"
               />
               <Button
-                loading={loading}
-                onClick={toggle}
                 size="large"
-                style="secondary"
-                label="Label"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
+                label="Link"
+                style="link"
                 disabled
               />
               <Button
-                onClick={toggle}
                 size="large"
-                style="secondary"
-                label="Label"
-                loading
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
+                label="Link"
+                style="link"
                 icon={Keyboard}
               />
               <Button
-                loading={loading}
-                onClick={toggle}
                 size="large"
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
-                disabled
-                icon={Keyboard}
-              />
-              <Button
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
-                loading
-                icon={Keyboard}
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
-                disabled
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                label="Label"
-                loading
+                label="Link"
+                style="link"
                 icon={Keyboard}
                 iconPosition="left"
               />
             </div>
           </div>
           <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Default/Secondary</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
+            <h2 className="text-xl">Sizes</h2>
+            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
               <Button
                 loading={loading}
                 onClick={toggle}
-                style="secondary"
-                label="Label"
+                size="large"
+                label="Large"
+                style="primary"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
+                size="large"
+                label="Large"
                 style="secondary"
-                label="Label"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                style="secondary"
-                label="Label"
-                disabled
+                size="large"
+                label="Large"
+                style="danger"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                style="secondary"
-                label="Label"
-                loading
+                size="large"
+                label="Large"
+                style="text"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                label="Large"
+                style="link"
               />
             </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
+            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
               <Button
                 loading={loading}
                 onClick={toggle}
+                label="Default"
+                style="primary"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                label="Default"
                 style="secondary"
-                label="Label"
-                icon={Keyboard}
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="secondary"
-                label="Label"
-                disabled
-                icon={Keyboard}
-              />
-              <Button
-                onClick={toggle}
-                style="secondary"
-                label="Label"
-                loading
-                icon={Keyboard}
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="secondary"
-                label="Label"
-                disabled
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                onClick={toggle}
-                style="secondary"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-                loading
-              />
-            </div>
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-6">
-          <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Large/Danger</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
+                label="Large"
                 style="danger"
-                label="Label"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
+                label="Default"
+                style="text"
               />
               <Button
                 loading={loading}
                 onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                disabled
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                loading
-              />
-            </div>
-            <div className="flex gap-6">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="right"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="right"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                disabled
-                icon={Keyboard}
-                iconPosition="right"
-              />
-              <Button
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                loading
-                icon={Keyboard}
-                iconPosition="right"
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                disabled
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                onClick={toggle}
-                size="large"
-                style="danger"
-                label="Label"
-                loading
-                icon={Keyboard}
-                iconPosition="left"
-              />
-            </div>
-          </div>
-          <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Default/Danger</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                disabled
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                disabled
-                icon={Keyboard}
-              />
-              <Button
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                loading
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                disabled
-                icon={Keyboard}
-                iconPosition="left"
-              />
-              <Button
-                onClick={toggle}
-                style="danger"
-                label="Label"
-                icon={Keyboard}
-                iconPosition="left"
-                loading
+                label="Default"
+                style="link"
               />
             </div>
           </div>

--- a/example/src/Pages/Button.js
+++ b/example/src/Pages/Button.js
@@ -13,10 +13,10 @@ const Buttons = () => {
       <Header title="Buttons" />
       <div className="p-6 space-y-6">
         <Button onClick={toggle} label="Toggle Loading State" />
-        <div className="grid grid-cols-1 gap-6">
-          <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Styles</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+        <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
+          <h2 className="text-xl">Styles</h2>
+          <div className="flex gap-10">
+            <div className="flex flex-col gap-6 items-start">
               <Button
                 loading={loading}
                 onClick={toggle}
@@ -62,7 +62,7 @@ const Buttons = () => {
               />
               <Button loading onClick={toggle} size="large" icon={Keyboard} />
             </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+            <div className="flex flex-col gap-6 items-start">
               <Button
                 loading={loading}
                 onClick={toggle}
@@ -121,7 +121,7 @@ const Buttons = () => {
                 iconPosition="left"
               />
             </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+            <div className="flex flex-col gap-6 items-start">
               <Button
                 loading={loading}
                 onClick={toggle}
@@ -180,7 +180,7 @@ const Buttons = () => {
                 iconPosition="left"
               />
             </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
+            <div className="flex flex-col gap-6 items-start">
               <Button
                 loading={loading}
                 onClick={toggle}
@@ -236,139 +236,141 @@ const Buttons = () => {
                 size="large"
                 style="text"
                 icon={Keyboard}
-                iconPosition="left"
               />
             </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
+            <div className="flex flex-col gap-6 items-start">
               <Button size="large" label="Link" style="link" />
               <Button size="large" label="Link" style="link" disabled />
               <Button size="large" label="Link" style="link" icon={Keyboard} />
-              <Button size="large" label="Link" style="link" icon={Keyboard} />
+              <Button size="large" label="Link" style="link" icon={Keyboard} iconPosition="left"/>
+              <Button loading size="large" label="Link" style="link" icon={Keyboard} iconPosition="left"/>
+              <Button loading size="large" label="Link" style="link" icon={Keyboard}/>
+              <Button loading size="large" style="link" icon={Keyboard}/>
             </div>
           </div>
-          <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
-            <h2 className="text-xl">Sizes</h2>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Large"
-                style="primary"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="primary"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Large"
-                style="secondary"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="secondary"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Large"
-                style="danger"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="danger"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Large"
-                style="text"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                style="text"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                size="large"
-                label="Large"
-                style="link"
-              />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-4">
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Default"
-                style="primary"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="primary"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Default"
-                style="secondary"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="secondary"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Large"
-                style="danger"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="danger"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Default"
-                style="text"
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                style="text"
-                icon={Keyboard}
-              />
-              <Button
-                loading={loading}
-                onClick={toggle}
-                label="Default"
-                style="link"
-              />
-            </div>
+        </div>
+        <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
+          <h2 className="text-xl">Sizes</h2>
+          <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              label="Large"
+              style="primary"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              style="primary"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              label="Large"
+              style="secondary"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              style="secondary"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              label="Large"
+              style="danger"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              style="danger"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              label="Large"
+              style="text"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              style="text"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              size="large"
+              label="Large"
+              style="link"
+            />
+          </div>
+          <div className="flex flex-row flex-wrap items-center justify-start gap-4">
+            <Button
+              loading={loading}
+              onClick={toggle}
+              label="Default"
+              style="primary"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              style="primary"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              label="Default"
+              style="secondary"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              style="secondary"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              label="Large"
+              style="danger"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              style="danger"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              label="Default"
+              style="text"
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              style="text"
+              icon={Keyboard}
+            />
+            <Button
+              loading={loading}
+              onClick={toggle}
+              label="Default"
+              style="link"
+            />
           </div>
         </div>
       </div>

--- a/example/src/Pages/Button.js
+++ b/example/src/Pages/Button.js
@@ -60,12 +60,7 @@ const Buttons = () => {
                 icon={Keyboard}
                 iconPosition="left"
               />
-              <Button
-                loading
-                onClick={toggle}
-                size="large"
-                icon={Keyboard}
-              />
+              <Button loading onClick={toggle} size="large" icon={Keyboard} />
             </div>
             <div className="flex flex-row flex-wrap items-center justify-start gap-4">
               <Button
@@ -117,6 +112,14 @@ const Buttons = () => {
                 icon={Keyboard}
                 iconPosition="left"
               />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
+                style="secondary"
+                icon={Keyboard}
+                iconPosition="left"
+              />
             </div>
             <div className="flex flex-row flex-wrap items-center justify-start gap-4">
               <Button
@@ -164,6 +167,14 @@ const Buttons = () => {
                 onClick={toggle}
                 size="large"
                 label="Danger"
+                style="danger"
+                icon={Keyboard}
+                iconPosition="left"
+              />
+              <Button
+                loading
+                onClick={toggle}
+                size="large"
                 style="danger"
                 icon={Keyboard}
                 iconPosition="left"
@@ -219,32 +230,20 @@ const Buttons = () => {
                 icon={Keyboard}
                 iconPosition="left"
               />
-            </div>
-            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
               <Button
+                loading
+                onClick={toggle}
                 size="large"
-                label="Link"
-                style="link"
-              />
-              <Button
-                size="large"
-                label="Link"
-                style="link"
-                disabled
-              />
-              <Button
-                size="large"
-                label="Link"
-                style="link"
-                icon={Keyboard}
-              />
-              <Button
-                size="large"
-                label="Link"
-                style="link"
+                style="text"
                 icon={Keyboard}
                 iconPosition="left"
               />
+            </div>
+            <div className="flex flex-row flex-wrap items-center justify-start gap-8">
+              <Button size="large" label="Link" style="link" />
+              <Button size="large" label="Link" style="link" disabled />
+              <Button size="large" label="Link" style="link" icon={Keyboard} />
+              <Button size="large" label="Link" style="link" icon={Keyboard} />
             </div>
           </div>
           <div className="p-4 space-y-8 border border-indigo-500 border-dashed">
@@ -261,8 +260,22 @@ const Buttons = () => {
                 loading={loading}
                 onClick={toggle}
                 size="large"
+                style="primary"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
                 label="Large"
                 style="secondary"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                style="secondary"
+                icon={Keyboard}
               />
               <Button
                 loading={loading}
@@ -275,8 +288,22 @@ const Buttons = () => {
                 loading={loading}
                 onClick={toggle}
                 size="large"
+                style="danger"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
                 label="Large"
                 style="text"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                size="large"
+                style="text"
+                icon={Keyboard}
               />
               <Button
                 loading={loading}
@@ -296,8 +323,20 @@ const Buttons = () => {
               <Button
                 loading={loading}
                 onClick={toggle}
+                style="primary"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
                 label="Default"
                 style="secondary"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                style="secondary"
+                icon={Keyboard}
               />
               <Button
                 loading={loading}
@@ -308,8 +347,20 @@ const Buttons = () => {
               <Button
                 loading={loading}
                 onClick={toggle}
+                style="danger"
+                icon={Keyboard}
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
                 label="Default"
                 style="text"
+              />
+              <Button
+                loading={loading}
+                onClick={toggle}
+                style="text"
+                icon={Keyboard}
               />
               <Button
                 loading={loading}

--- a/lib/components/Button.js
+++ b/lib/components/Button.js
@@ -2,11 +2,14 @@ import React from "react";
 import classnames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+
 import Spinner from "../atoms/Spinner";
 
 const noop = () => {};
-const sizes = { large: "large", default: "default" };
-const iconPositions = { left: "left", right: "right" };
+const BUTTON_STYLES = { primary: "primary", secondary: "secondary", danger: "danger", text: "text", link: "link" };
+const BUTTON_SIZES = { large: "large", default: "default" };
+const ICON_POSITIONS = { left: "left", right: "right" };
 
 const Button = React.forwardRef((props, ref) => {
   let {
@@ -61,10 +64,15 @@ const Button = React.forwardRef((props, ref) => {
     <Parent
       ref={ref}
       onClick={handleClick}
-      className={classnames("nui-btn", [`v2-nui-btn--${style}`, className], {
-        "nui-btn--large": size === sizes.large,
-        "nui-btn--full": fullWidth,
-        "nui-btn--iconLeft": iconPosition == iconPositions.left,
+      className={classnames("nui-btn", [className], {
+        "nui-btn--style-primary": style === BUTTON_STYLES.primary,
+        "nui-btn--style-secondary": style === BUTTON_STYLES.secondary,
+        "nui-btn--style-danger": style === BUTTON_STYLES.danger,
+        "nui-btn--style-text": style === BUTTON_STYLES.text,
+        "nui-btn--style-link": style === BUTTON_STYLES.link,
+        "nui-btn--size-large": size === BUTTON_SIZES.large,
+        "nui-btn--width-full": fullWidth,
+        "nui-btn--icon-left": iconPosition == ICON_POSITIONS.left,
         "disabled": disabled,
       })}
       disabled={disabled}
@@ -77,17 +85,18 @@ const Button = React.forwardRef((props, ref) => {
         {icon ? (
           /* When Icon is present, animate between the icon and the spinner*/
           loading ? (
-            <Spinner key="1" />
+            <Spinner key="1" size={14} className="nui-btn__spinner" />
           ) : (
-            <Icon key="2" size={14} />
+            <Icon key="2" size={14} className="nui-btn__icon" />
           )
         ) : (
           /* When Icon is not present, animate the margin from 0 to the needed value*/
           loading && (
             <motion.div
+              className="nui-btn__spinner-wrapper"
               initial={{ [spinnerMarginSide]: 0, width: 0, scale: 0 }}
               animate={{
-                [spinnerMarginSide]: iconPosition == "left" ? 12 : 24,
+                [spinnerMarginSide]: ".7142857143em",
                 width: "auto",
                 scale: 1,
               }}
@@ -102,5 +111,14 @@ const Button = React.forwardRef((props, ref) => {
     </Parent>
   );
 });
+
+Button.propTypes = {
+  style: PropTypes.oneOf(Object.values(BUTTON_STYLES)),
+  size: PropTypes.oneOf(Object.values(BUTTON_SIZES)),
+  iconPosition: PropTypes.oneOf(Object.values(ICON_POSITIONS)),
+  label: PropTypes.string,
+  loading: PropTypes.bool,
+  disabled: PropTypes.bool
+};
 
 export default Button;

--- a/lib/components/Button.js
+++ b/lib/components/Button.js
@@ -54,7 +54,7 @@ const Button = React.forwardRef((props, ref) => {
 
   let Icon =
     typeof icon == "string"
-      ? () => <i className={icon} />
+      ? () => <i className={classnames("nui-btn__icon", [icon])}/>
       : icon || React.Fragment;
 
   const spinnerMarginSide =

--- a/lib/styles/abstracts/_variables.scss
+++ b/lib/styles/abstracts/_variables.scss
@@ -1,16 +1,9 @@
-//Colors
-$nui-blue: #276ef1;
-$nui-green: #00ba88;
-$nui-light-green: #66d19e;
-$nui-yellow: #f3cd82;
-$nui-red: #f56a58;
-$nui-indigo: #5e5ce6;
-$nui-pastel-blue: #eaf3fc;
-$nui-pastel-green: #ebf5ec;
-$nui-pastel-yellow: #fff2d7;
-$nui-pastel-red: #ffefed;
+// Color palette
+
+// primary
 $nui-white: #ffffff;
 $nui-black: #1b1f23;
+// content
 $nui-gray-800: #2f3941;
 $nui-gray-700: #49545c;
 $nui-gray-600: #68737d;
@@ -19,8 +12,23 @@ $nui-gray-400: #c2c8cc;
 $nui-gray-300: #d8dcde;
 $nui-gray-200: #e9ebed;
 $nui-gray-100: #f8f9f9;
+// states
+$nui-success: #00ba88;
+$nui-info: #276ef1;
+$nui-warning: #f3cd82;
+$nui-error: #f56a58;
+// pastel
+$nui-pastel-blue: #eaf3fc;
+$nui-pastel-green: #ebf5ec;
+$nui-pastel-yellow: #fff2d7;
+$nui-pastel-red: #ffefed;
+$nui-pastel-teal: #98f3f4;
+// secondary
+$nui-secondary-indigo: #5e5ce6;
+$nui-secondary-green: #00ba88;
+$nui-secondary-teal: #64d2ff;
 
-//Weights
+// Font Weights
 $nui-font-thin: 100;
 $nui-font-extralight: 200;
 $nui-font-light: 300;
@@ -31,7 +39,7 @@ $nui-font-bold: 700;
 $nui-font-extrabold: 800;
 $nui-font-black: 900;
 
-//Sizes
+// Font Sizes
 $nui-text-xxs: 10px;
 $nui-text-xs: 12px;
 $nui-text-sm: 14px;
@@ -42,15 +50,15 @@ $nui-text-2xl: 24px;
 $nui-text-3xl: 32px;
 $nui-text-4xl: 48px;
 
-//Line height
-$nui-leading-none:1;
+// Line Heights
+$nui-leading-none: 1;
 $nui-leading-tight: 1.25;
 $nui-leading-snug: 1.375;
 $nui-leading-normal: 1.5;
 $nui-leading-relaxed: 1.625;
 $nui-leading-loose: 2;
 
-//Text-transform
+// Text-transform
 $nui-text-transform-none: none;
 $nui-text-transform-capitalize: capitalize;
 $nui-text-transform-uppercase: uppercase;
@@ -61,7 +69,7 @@ $nui-text-transform-initial: initial;
 $nui-text-transform-revert: revert;
 $nui-text-transform-unset: unset;
 
-//Border Radius
+// Border Radius
 $nui-rounded-sm: 2px;
 $nui-rounded: 4px;
 $nui-rounded-md: 6px;
@@ -69,14 +77,14 @@ $nui-rounded-lg: 8px;
 $nui-rounded-xl: 10px;
 $nui-rounded-full: 999px;
 
-//Transition
+// Transition
 $nui-transition: all 0.3s ease-in-out;
 
-//Shadows
+// Shadows
 
 $nui-shadow: 0px 0px 0px 3px $nui-gray-200;
 $nui-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
-0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  0 2px 4px -1px rgba(0, 0, 0, 0.06);
 
 // Breakpoints
 $mob-479: 479px;
@@ -84,7 +92,7 @@ $tab-768: 768px;
 $tab-1024: 1024px;
 $desk-1200: 1200px;
 
-//Constants
+// Constants
 $pane-header-height: 100px;
 $pane-footer-height: 104px;
 $main-header-height: 117px;

--- a/lib/styles/components/_avatar.scss
+++ b/lib/styles/components/_avatar.scss
@@ -61,11 +61,11 @@
     }
 
     &.online {
-      background-color: $nui-green;
+      background-color: $nui-success;
     }
 
     &.idle {
-      background-color: $nui-yellow;
+      background-color: $nui-warning;
     }
 
     &.offline {

--- a/lib/styles/components/_button.scss
+++ b/lib/styles/components/_button.scss
@@ -122,6 +122,10 @@
     &:focus {
       opacity: 0.8;
     }
+
+    &:focus-visible {
+      color: darken($nui-secondary-indigo, 25%);
+    }
   }
   
   &-danger {

--- a/lib/styles/components/_button.scss
+++ b/lib/styles/components/_button.scss
@@ -77,7 +77,7 @@
   
     &:hover:not(:disabled),
     &:active {
-      background-color: $nui-nui-gray-700;
+      background-color: $nui-gray-700;
     }
   
     &:focus-visible {
@@ -113,19 +113,19 @@
   }
 
   &-link {
-    color: $nui-gray-800;
+    color: $nui-secondary-indigo;
     min-height: initial;
     padding: 0;
   
     &:hover:not(:disabled),
     &:active,
     &:focus {
-      color: $nui-nui-gray-700;
+      opacity: 0.8;
     }
   }
   
   &-danger {
-    color: $nui-red;
+    color: $nui-error;
     background-color: $nui-pastel-red;
   
     &:hover:not(:disabled),

--- a/lib/styles/components/_button.scss
+++ b/lib/styles/components/_button.scss
@@ -1,199 +1,140 @@
+
 .nui-btn {
   display: inline-flex;
-  flex-direction: row;
-  justify-content: flex-start;
   align-items: center;
   font-size: $nui-text-sm;
   font-weight: $nui-font-medium;
   border-radius: $nui-rounded-sm;
-  line-height: 1.5;
+  line-height: 1.2;
   transition: $nui-transition;
   position: relative;
   border: none;
   cursor: pointer;
   padding: 0;
+  user-select: none;
+  padding: 0.4289em 0.7142857143em;
+  min-height: 28px;
+  letter-spacing: -0.15px;
+  outline: none;
 
   &:focus,
   &:focus-visible {
-    outline-color: transparent;
+    outline: none;
   }
 
   &:hover {
     text-decoration: none;
   }
 
-  &:not(.nui-btn--iconLeft) {
-    & > i,
-    svg,
-    div {
-      &:last-child:not(:first-child) {
-        margin-left: 24px;
-      }
-    }
+  &.disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
   }
 
-  &.nui-btn--iconLeft {
-    flex-direction: row-reverse;
-
-    & > i,
-    svg,
-    div {
-      &:last-child:not(:first-child) {
-        margin-right: 12px;
-      }
-      &:first-child:not(:last-child) {
-        margin-right: 12px;
-      }
-    }
+  .nui-btn__icon:last-child:not(:first-child),
+  .nui-btn__spinner:last-child:not(:first-child){
+    margin-left: .7142857143em;
   }
+}
 
-  &.nui-btn--primary {
-    padding: 8px 12px;
+.nui-btn--icon-left {
+  flex-direction: row-reverse;
+  .nui-btn__icon:last-child:not(:first-child),
+  .nui-btn__spinner:last-child:not(:first-child){
+    margin-right: .7142857143em;
+    margin-left: 0;
+  }
+}
+
+.nui-btn__icon,
+.nui-btn__spinner,
+.nui-btn__spinner-wrapper{
+  color: inherit;
+  svg{
+    color: inherit !important;
+  }
+}
+
+// width
+.nui-btn--width-full {
+  width: 100%;
+  justify-content: center;
+}
+
+// size
+.nui-btn--size-large {
+  font-size: $nui-text-base;
+  padding-top: 0.407em;
+  padding-bottom: 0.407em;
+  min-height: 32px;
+}
+
+// styles
+.nui-btn--style{
+  &-primary {
     color: $nui-white;
     background-color: $nui-gray-800;
-
+  
     &:hover:not(:disabled),
     &:active {
-      background-color: $nui-gray-700;
+      background-color: $nui-nui-gray-700;
     }
-
+  
     &:focus-visible {
-      box-shadow: 0 0 0 3px $nui-gray-200;
-    }
-
-    &:disabled {
-      background-color: $nui-gray-400;
-      color: $nui-gray-500;
+      box-shadow: 0 0 0 3px #E5E5E5;
     }
   }
 
-  &.nui-btn--danger {
-    padding: 8px 12px;
+  &-secondary {
+    color: $nui-gray-800;
+    background-color: $nui-gray-200;
+  
+    &:hover:not(:disabled),
+    &:active {
+      background-color: $nui-gray-400;
+    }
+  
+    &:focus-visible {
+      box-shadow: 0 0 0 3px #E5E5E5;
+    }
+  }
+
+  &-text {
+    color: $nui-gray-800;
+  
+    &:hover:not(:disabled),
+    &:active {
+      background-color: $nui-gray-200;
+    }
+  
+    &:focus-visible {
+      box-shadow: 0 0 0 3px #E5E5E5;
+    }
+  }
+
+  &-link {
+    color: $nui-gray-800;
+    min-height: initial;
+    padding: 0;
+  
+    &:hover:not(:disabled),
+    &:active,
+    &:focus {
+      color: $nui-nui-gray-700;
+    }
+  }
+  
+  &-danger {
     color: $nui-red;
     background-color: $nui-pastel-red;
-
+  
     &:hover:not(:disabled),
     &:active {
       background-color: darken($nui-pastel-red, 2.5%);
     }
-
+  
     &:focus-visible {
-      box-shadow: 0 0 0 3px $nui-pastel-red;
+      box-shadow: 0 0 0 3px darken($nui-pastel-red, 2.5%);
     }
-
-    &:disabled {
-      opacity: 0.5;
-    }
-  }
-
-  &.nui-btn--secondary {
-    padding: 8px 12px;
-    color: $nui-gray-800;
-    background-color: $nui-gray-200;
-
-    &:hover:not(:disabled),
-    &:active {
-      background-color: $nui-gray-300;
-    }
-
-    &:focus-visible {
-      box-shadow: 0 0 0 3px $nui-gray-300;
-    }
-
-    &:disabled {
-      background-color: $nui-gray-200;
-      color: $nui-gray-400;
-    }
-  }
-
-  &.nui-btn--text {
-    font-size: theme("fontSize.sm");
-    color: theme("colors.gray.600");
-    padding: 0;
-
-    &:hover:not(:disabled) {
-      color: theme("colors.gray.700");
-    }
-
-    &:active,
-    &:focus {
-      color: theme("colors.gray.800");
-    }
-
-    &:focus-visible {
-      box-shadow: 0 0 0 2px $nui-white, 0 0 0 4px theme("colors.gray.300");
-    }
-  }
-
-  &.nui-btn--link {
-    color: $nui-gray-800;
-
-    &:hover:not(:disabled),
-    &:active,
-    &:focus {
-      color: $nui-gray-700;
-    }
-
-    &:focus-visible {
-      box-shadow: 0 0 0 2px $nui-white, 0 0 0 4px $nui-gray-800;
-    }
-  }
-
-  &.nui-btn--icon {
-    opacity: 0.75;
-    color: $nui-gray-700;
-
-    svg {
-      width: 20px;
-      height: 20px;
-    }
-
-    &:hover:not(:disabled),
-    &:active,
-    &:focus {
-      opacity: 1;
-    }
-
-    &:focus-visible {
-      box-shadow: 0 0 0 2px $nui-white, 0 0 0 4px $nui-gray-300;
-    }
-  }
-
-  &.disabled {
-    cursor: not-allowed;
-  }
-
-  &.nui-btn--large {
-    font-size: $nui-text-base;
-  }
-
-  &.nui-btn--full {
-    width: 100%;
-    justify-content: center;
-    padding-top: 12px;
-    padding-bottom: 12px;
-  }
-}
-
-.nui-btn--loader {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: inherit;
-  background: inherit;
-  cursor: default;
-
-  div {
-    display: inherit;
-  }
-
-  div > div {
-    background-color: currentColor;
   }
 }

--- a/lib/styles/components/_input.scss
+++ b/lib/styles/components/_input.scss
@@ -66,7 +66,7 @@
     }
 
     &.nui-input--error {
-      border-color: $nui-red;
+      border-color: $nui-error;
 
       &:focus-within:not(.nui-input--naked) {
         box-shadow: 0 0 0 3px $nui-pastel-red;
@@ -150,5 +150,5 @@
 .nui-input__error {
   margin-top: 4px;
   font-size: $nui-text-xs;
-  color: $nui-red;
+  color: $nui-error;
 }

--- a/lib/styles/components/_select.scss
+++ b/lib/styles/components/_select.scss
@@ -1,6 +1,6 @@
 .nui-react-select__container.nui-react-select__container--error {
   .nui-react-select__control {
-    border: thin solid $nui-red;
+    border: thin solid $nui-error;
     box-shadow: 0 0 0 3px $nui-pastel-red;
   }
 }

--- a/lib/styles/components/_table.scss
+++ b/lib/styles/components/_table.scss
@@ -28,12 +28,12 @@
         padding: 16px 48px 16px 0;
 
         a:not(.nui-btn) {
-          color: $nui-indigo;
+          color: $nui-secondary-indigo;
           transition: $nui-transition;
           font-weight: $nui-font-medium;
 
           &:hover {
-            color: darken($nui-indigo, 5%);
+            color: darken($nui-secondary-indigo, 5%);
             text-decoration: underline;
           }
         }

--- a/lib/styles/components/_tag.scss
+++ b/lib/styles/components/_tag.scss
@@ -69,8 +69,8 @@
   }
 
   &.nui-tag--solid {
-    color: $nui-indigo;
+    color: $nui-secondary-indigo;
     background-color: $nui-pastel-blue;
-    border: thin solid $nui-indigo;
+    border: thin solid $nui-secondary-indigo;
   }
 }

--- a/lib/styles/components/_toast.scss
+++ b/lib/styles/components/_toast.scss
@@ -68,27 +68,27 @@
 
     &.Toastify__toast--success {
       background: $nui-pastel-green;
-      border: 1px solid $nui-green;
+      border: 1px solid $nui-success;
     }
 
     &.Toastify__toast--error {
       background: $nui-pastel-red;
-      border: 1px solid $nui-red;
+      border: 1px solid $nui-error;
     }
 
     &.Toastify__toast--info {
       background: $nui-pastel-blue;
-      border: 1px solid $nui-blue;
+      border: 1px solid $nui-info;
     }
 
     &.Toastify__toast--warning {
       background: $nui-pastel-yellow;
-      border: 1px solid $nui-yellow;
+      border: 1px solid $nui-warning;
     }
 
     &.Toastify__toast--default {
       background: $nui-pastel-blue;
-      border: 1px solid $nui-blue;
+      border: 1px solid $nui-info;
     }
 
   }

--- a/lib/styles/index.scss
+++ b/lib/styles/index.scss
@@ -1,5 +1,3 @@
-@import "tailwindcss/utilities";
-
 //Abstracts
 @import "./abstracts/normalize";
 @import "./abstracts/variables";


### PR DESCRIPTION
Fixes #452 

@karthiknmenon _a Please review.

- Removed Tailwind dependency from CSS.
- Updated button class names to match the BEM naming convention.
- Updated button styles to match the design.
- Updated button examples on the docs page.
- Removed icon-only prop from button component (any button can be made icon-only if we don’t provide label property)

<img width="717" alt="Screenshot 2021-09-16 at 1 01 24 PM" src="https://user-images.githubusercontent.com/48869249/133569841-42809ebe-d0a8-40bb-86ff-32c158ba2c69.png">

//cc @edwinbbu @goutham-subramanyam 