### PR TITLE
More applications added to app switcher

### DIFF
--- a/example/src/Playground.js
+++ b/example/src/Playground.js
@@ -60,7 +60,6 @@ const Playground = () => {
       <AppSwitcher
         isOpen={appSwitcher}
         onClose={() => toggleAppSwitcher(false)}
-        neetoApps={["Desk", "Chat", "KB", "Form"]}
       />
     </Router>
   );

--- a/lib/constants/clientApps.js
+++ b/lib/constants/clientApps.js
@@ -5,6 +5,12 @@ import {
   NeetoForm,
   NeetoAnalytics,
   NeetoChangelog,
+  NeetoInsights,
+  NeetoInterview,
+  NeetoInvisible,
+  NeetoQuiz,
+  NeetoReplay,
+  NeetoWireframe
 } from "@bigbinary/neeto-icons";
 
 export const getClientApp = (subdomain) => {
@@ -88,36 +94,36 @@ export const getClientApp = (subdomain) => {
     },
     {
       name: "Insights",
-      icon: NeetoForm,
+      icon: NeetoInsights,
       description: "Business Insights App",
       url: {
         development: "http://spinkart.lvh.me:9010",
         staging: `https://${subdomain}.neetoinsights.net`,
         production: `https://${subdomain}.neetoinsights.com`,
       },
-      isActive: false,
+      isActive: true,
     },
     {
       name: "Quiz",
-      icon: NeetoForm,
+      icon: NeetoQuiz,
       description: "Quiz App",
       url: {
         development: "http://spinkart.lvh.me:9011",
         staging: `https://${subdomain}.neetoquiz.net`,
         production: `https://${subdomain}.neetoquiz.com`,
       },
-      isActive: false,
+      isActive: true,
     },
     {
       name: "Interview",
-      icon: NeetoForm,
+      icon: NeetoInterview,
       description: "Interview App",
       url: {
         development: "http://spinkart.lvh.me:9012",
         staging: `https://${subdomain}.neetointerview.net`,
         production: `https://${subdomain}.neetointerview.com`,
       },
-      isActive: false,
+      isActive: true,
     },
     {
       name: "Planner",
@@ -132,34 +138,34 @@ export const getClientApp = (subdomain) => {
     },
     {
       name: "Replay",
-      icon: NeetoForm,
+      icon: NeetoReplay,
       description: "Replay App",
       url: {
         development: "http://spinkart.lvh.me:9020",
-        staging: `https://${subdomain}.neetodesk.net`,
-        production: `https://${subdomain}.neetodesk.com`,
+        staging: `https://${subdomain}.neetoreplay.net`,
+        production: `https://${subdomain}.neetoreplay.com`,
       },
       isActive: false,
     },
     {
       name: "Wireframe",
-      icon: NeetoForm,
+      icon: NeetoWireframe,
       description: "Wireframe App",
       url: {
         development: "http://spinkart.lvh.me:9021",
-        staging: `https://${subdomain}.neetodesk.net`,
-        production: `https://${subdomain}.neetodesk.com`,
+        staging: `https://${subdomain}.neetowireframe.net`,
+        production: `https://${subdomain}.neetowireframe.com`,
       },
-      isActive: false,
+      isActive: true,
     },
     {
       name: "Invisible",
-      icon: NeetoForm,
+      icon: NeetoInvisible,
       description: "Invisible",
       url: {
         development: "http://spinkart.lvh.me:9014",
-        staging: `https://${subdomain}.neetodesk.net`,
-        production: `https://${subdomain}.neetodesk.com`,
+        staging: `https://${subdomain}.neetoinvisible.net`,
+        production: `https://${subdomain}.neetoinvisible.com`,
       },
       isActive: false,
     },

--- a/lib/styles/layout/_appswitcher.scss
+++ b/lib/styles/layout/_appswitcher.scss
@@ -1,7 +1,7 @@
 .neeto-ui-app-switcher__backdrop {
   position: fixed;
   z-index: 99999;
-  left: 80px;
+  left: 72px;
   top: 0;
   width: 100vw;
   height: 100vh;


### PR DESCRIPTION
Fixes #511 

<img width="941" alt="Screenshot 2021-10-10 at 12 58 18 PM" src="https://user-images.githubusercontent.com/17916573/136686814-c0dd55a9-4d33-413d-874a-3a26f24f6687.png">

- Icons added for all the applications for which the design is available. (Referred PR https://github.com/bigbinary/neeto-auth-web/pull/638)
- Application that has a production account is only enabled. 
- Changed a CSS value from 80 to 72 in order to support v1 styles.

