### PR TITLE
Updated Toastr Error handling method

### DIFF
--- a/lib/components/Toastr.js
+++ b/lib/components/Toastr.js
@@ -115,12 +115,17 @@ const showWarningToastr = (message, buttonLabel, onClick) => {
 };
 
 const isError = (e) => e && e.stack && e.message;
+const isAxiosError = (e) => typeof e === "object" && e.isAxiosError === true;
+const isString = (s) => typeof s === "string" || s instanceof String;
 
 const showErrorToastr = (errorObject, buttonLabel, onClick) => {
   let errorMessage;
-  if (isError(errorObject)) errorMessage = errorObject.message;
-  else if (errorObject.error) errorMessage = errorObject.error;
-  else if (errorObject.errors) errorMessage = join("\n", errorObject.errors);
+  if (isAxiosError(errorObject)) {
+    const { error, errors } = errorObject.response.data;
+    errorMessage = error || (errors && join("\n", errors)) || errorObject.message;
+  }
+  else if (isError(errorObject)) errorMessage = errorObject.message;
+  else if (isString(errorObject)) errorMessage = errorObject;
   else errorMessage = "Something went wrong.";
   toast.error(
     <ToastrComponent

--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -112,7 +112,7 @@ export const ErrorToastr = () => {
     <>
       <ToastContainer />
       <div className="space-x-6">
-        <Button label="Plain  Error" onClick={onStringError} />
+        <Button label="String Error" onClick={onStringError} />
         <Button label="Throw an axios error" onClick={onAxiosStringError} />
         <Button
           label="Throw an axios error with array of error messages"

--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -61,3 +61,64 @@ export const Toastrs = () => {
     </>
   );
 };
+
+export const ErrorToastr = () => {
+  const onStringError = () => {
+    Toastr.error("This is a plain text error toastr!");
+  };
+
+  const onAxiosStringError = () => {
+    try {
+      // Dummy axios error object
+      const axiosError = {
+        isAxiosError: true,
+        config: {
+          url: "https://api.github.com/users/org",
+        },
+        response: {
+          data: {
+            error: "Not Found",
+          },
+          status: 404,
+        },
+      };
+      throw axiosError;
+    } catch (e) {
+      Toastr.error(e);
+    }
+  };
+
+  const onAxiosArrayError = () => {
+    try {
+      // Dummy axios error object
+      const axiosError = {
+        isAxiosError: true,
+        config: {
+          url: "https://api.github.com/users/org",
+        },
+        response: {
+          data: {
+            errors: ["A is required", "B is required"],
+          },
+        },
+      };
+      throw axiosError;
+    } catch (e) {
+      Toastr.error(e);
+    }
+  };
+
+  return (
+    <>
+      <ToastContainer />
+      <div className="space-x-6">
+        <Button label="Plain  Error" onClick={onStringError} />
+        <Button label="Throw an axios error" onClick={onAxiosStringError} />
+        <Button
+          label="Throw an axios error with array of error messages"
+          onClick={onAxiosArrayError}
+        />
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
- Fixes #429 
- Added `isAxiosError` validation, to get error message from `errorObject.response.data.error` and `errorObject.response.data.errors`
- Added string argument support for `Toastr.error()`

@ajmaln _a