### PR TITLE
Automated release creation process

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION ✨'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,31 +1,57 @@
-name: "Publish"
+
+name: "Publish and create releases"
 on:
-  push:
+  pull_request:
     branches:
-      - master
+      - main
+    types: [closed]
 jobs:
   release:
     name: "Release"
     runs-on: macos-latest
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.2.0
       - name: node
         uses: actions/setup-node@v2
         with:
           node-version: "14"
       - run: yarn install
       - run: yarn build
-      - run: yarn version --patch --no-git-tag-version
+      - run: yarn config set version-tag-prefix "v"
+
+      - name: Bump version and create tag
+        if: contains(github.event.pull_request.labels.*.name, 'Release')
+        run: yarn version --patch
+
+      - name: Bump version
+        if: "!contains(github.event.pull_request.labels.*.name, 'Release')"
+        run: yarn version --patch --no-git-tag-version
+
       - run: git config core.hooksPath /dev/null
       - uses: EndBug/add-and-commit@v7
         with:
-          branch: master
+          branch: main
           message: 'New version release'
+
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read package.json
+        uses: tyankatsu0105/read-package-version-actions@v1
+        id: package-version
+
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5.15.0
+        if: ${{contains(github.event.pull_request.labels.*.name, 'Release')}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: v${{ steps.package-version.outputs.version }}
+          publish: true
       - name: "Publish"
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,13 @@ name: "Publish and create releases"
 on:
   pull_request:
     branches:
-      - main
+      - master
     types: [closed]
 jobs:
   release:
     name: "Release"
     runs-on: macos-latest
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2.2.0
@@ -22,11 +22,11 @@ jobs:
       - run: yarn config set version-tag-prefix "v"
 
       - name: Bump version and create tag
-        if: contains(github.event.pull_request.labels.*.name, 'Release')
+        if: contains(github.event.pull_request.labels.*.name, 'release')
         run: yarn version --patch
 
       - name: Bump version
-        if: "!contains(github.event.pull_request.labels.*.name, 'Release')"
+        if: "!contains(github.event.pull_request.labels.*.name, 'release')"
         run: yarn version --patch --no-git-tag-version
 
       - run: git config core.hooksPath /dev/null
@@ -46,7 +46,7 @@ jobs:
 
       - name: Release Drafter
         uses: release-drafter/release-drafter@v5.15.0
-        if: ${{contains(github.event.pull_request.labels.*.name, 'Release')}}
+        if: ${{contains(github.event.pull_request.labels.*.name, 'release')}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Fixes #631 

- Any PR with the label `Release` will trigger release
- Releases notes content will be PR names
- Labels like `feature`, `bug`, `enhancement` on any PR will categorize the corresponding PR in release notes.

@edwinbbu _a Please review

cc: @karthiknmenon 