### PR TITLE
Updated Header and SubHeader layouts as per design

### DIFF
--- a/lib/components/layouts/Header.js
+++ b/lib/components/layouts/Header.js
@@ -1,19 +1,23 @@
-import React from "react";
+import React, { useRef } from "react";
 import classnames from "classnames";
 import { Link } from "react-router-dom";
-import { Right, HamburgerMenu } from "@bigbinary/neeto-icons";
+import { Search, Right, HamburgerMenu } from "@bigbinary/neeto-icons";
 import PropTypes from "prop-types";
 
 import Typography from "../Typography";
 import Button from "../Button";
+import Input from "../Input";
 
 const Header = ({
   title,
   menuBarToggle,
+  searchProps,
   className,
   actionBlock,
   breadcrumbs,
 }) => {
+  const searchRef = useRef();
+
   return (
     <div className={classnames(["neeto-ui-header", className])}>
       <div className="neeto-ui-header__left">
@@ -58,7 +62,19 @@ const Header = ({
           {title}
         </Typography>
       </div>
-      <div className="neeto-ui-header__right">{actionBlock}</div>
+      <div className="gap-3 neeto-ui-header__right">
+        {searchProps && (
+          <Input
+            ref={searchRef}
+            type="search"
+            placeholder="Search"
+            className={classnames(["w-72", searchProps.className])}
+            prefix={<Search />}
+            {...searchProps}
+          />
+        )}
+        {actionBlock}
+      </div>
     </div>
   );
 };
@@ -75,7 +91,12 @@ Header.propTypes = {
   /**
    * To specify the content to be rendered in the right side of the header section.
    */
+
   actionBlock: PropTypes.node,
+  /**
+   * To add a search field to the subheader section.
+   */
+  searchProps: PropTypes.object,
   /**
    * To show breadcrumbs in the header section.
    */

--- a/lib/components/layouts/SubHeader.js
+++ b/lib/components/layouts/SubHeader.js
@@ -1,61 +1,16 @@
-import React, { useRef } from "react";
-import { Search, Delete, Disable } from "@bigbinary/neeto-icons";
+import React from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
-import Button from "../Button";
-import Input from "../Input";
-
-const SubHeader = ({
-  className,
-  searchProps,
-  deleteButtonProps,
-  disableButtonProps,
-  actionBlock,
-}) => {
-
-  const searchRef = useRef();
-
+const SubHeader = ({ className, leftActionBlock, rightActionBlock }) => {
   return (
     <div className={classnames(["neeto-ui-subheader", className])}>
-      <div className="neeto-ui-subheader__left">
-        {searchProps &&
-          <Input
-            ref={searchRef}
-            type="search"
-            placeholder="Search"
-            prefix={<Search />}
-            {...searchProps}
-          />
-        }
-      </div>
-      <div className="neeto-ui-subheader__right">
-        {deleteButtonProps && (
-          <Button
-            style="secondary"
-            label="Delete"
-            icon={Delete}
-            data-test-id="subheader-delete-button"
-            data-cy={deleteButtonProps["data-cy"] || "subheader-delete-button"}
-            {...deleteButtonProps}
-          />
-        )}
-        {disableButtonProps && (
-          <Button
-            style="secondary"
-            label="Disable"
-            icon={Disable}
-            data-test-id="subheader-disable-button"
-            data-cy={deleteButtonProps["data-cy"] || "subheader-disable-button"}
-            {...disableButtonProps}
-          />
-        )}
-        {actionBlock &&
-          <>
-            {actionBlock}
-          </>
-        }
-      </div>
+      {leftActionBlock && (
+        <div className="neeto-ui-subheader__left">{leftActionBlock}</div>
+      )}
+      {rightActionBlock && (
+        <div className="neeto-ui-subheader__right">{rightActionBlock}</div>
+      )}
     </div>
   );
 };
@@ -66,18 +21,13 @@ SubHeader.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * To add a search field to the subheader section.
+   * To specify the content to be rendered in the left side of the subheader section.
    */
-  searchProps: PropTypes.object,
+  leftActionBlock: PropTypes.node,
   /**
-   * To add delete button to the subheader section.
+   * To specify the content to be rendered in the right side of the subheader section.
    */
-  deleteButtonProps: PropTypes.object,
-  disableButtonProps: PropTypes.object,
-  /**
-   * To specify the content to be rendered in the right side of the header section.
-   */
-  actionBlock: PropTypes.node,
+  rightActionBlock: PropTypes.node,
 };
 
 export default SubHeader;

--- a/stories/Layouts/Header.stories.jsx
+++ b/stories/Layouts/Header.stories.jsx
@@ -26,7 +26,17 @@ const Template = (args) => (
 export const BasicUsage = Template.bind({});
 BasicUsage.args = {
   title: "Layouts",
-  actionBlock: <Button label="Primary Action" />,
+  actionBlock: <Button size="large" label="Primary Action" />,
+};
+
+export const WithSearchInput = Template.bind({});
+WithSearchInput.args = {
+  title: "Layouts",
+  searchProps: {
+    value: "",
+    onChange: () => {},
+  },
+  actionBlock: <Button size="large" label="Primary Action" />,
 };
 
 export const WithMenuBarToggle = Template.bind({});

--- a/stories/Layouts/SubHeader.stories.jsx
+++ b/stories/Layouts/SubHeader.stories.jsx
@@ -1,6 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 
 import SubHeader from "../../lib/components/layouts/SubHeader";
+import Button from "../../lib/components/Button";
+import Typography from "../../lib/components/Typography";
+
+import { Delete } from "@bigbinary/neeto-icons";
 
 export default {
   title: "Layouts/SubHeader",
@@ -17,23 +21,19 @@ export default {
 };
 
 export const BasicUsage = () => {
-  const [searchString, setSearchString] = useState("");
   return (
     <SubHeader
-      searchProps={{
-        value: searchString,
-        onChange: (e) => setSearchString(e.target.value),
-      }}
-      deleteButtonProps={{
-        count: 0,
-        selectedIDs: [],
-        onClick: () => {},
-      }}
-      disableButtonProps={{
-        count: 0,
-        selectedIDs: [],
-        onClick: () => {},
-      }}
+      leftActionBlock={
+        <Typography style="h4" component="h4">
+          118 Contacts
+        </Typography>
+      }
+      rightActionBlock={
+        <>
+          <Button label="Delete" style="secondary" icon={Delete} />
+          <Button label="Disable" style="secondary" />
+        </>
+      }
     />
   );
 };


### PR DESCRIPTION
Fixes #708

- Moved search input from subheader to the header.
- Removed default buttons (Delete and Disable) from the subheader and the props for them.
- Modified the `actionBlock` prop in subheader to `rightActionBlock` and added a new prop called `leftActionBlock` to add items to the left side.
- Stories updated for both

@praveen-murali-ind _a Please review

cc: @karthiknmenon @ajmaln @edwinbbu 