### PR TITLE
Removed extra space in link in Toastr

### DIFF
--- a/lib/components/Toastr.js
+++ b/lib/components/Toastr.js
@@ -51,7 +51,7 @@ const ToastrComponent = ({
       <Linkify
         componentDecorator={(decoratedHref, decoratedText, key) => (
           <a target="_blank" href={decoratedHref} key={key} rel="noreferrer">
-            &nbsp;{decoratedText}&nbsp;
+            {decoratedText}
           </a>
         )}
       >


### PR DESCRIPTION
Fixes #725 

- Removed extra space given in link part of Toastr component