### PR TITLE
Updated Formik textarea component to show error only when touched

### DIFF
--- a/lib/components/formik/Textarea.js
+++ b/lib/components/formik/Textarea.js
@@ -7,15 +7,15 @@ import Textarea from "../Textarea";
 function FormikTextarea({ name, ...rest }) {
   return (
     <Field name={name}>
-      {({ field, form: { errors }}) => (
-        <Textarea error={errors[field.name]} {...rest} {...field} />
+      {({ field, meta }) => (
+        <Textarea error={meta.touched && meta.error} {...rest} {...field} />
       )}
     </Field>
   );
 }
 
 FormikTextarea.propTypes = {
-  name: PropTypes.string
+  name: PropTypes.string,
 };
 
 export default FormikTextarea;


### PR DESCRIPTION
Fixes #731 
- Updated Formik Textarea component to show error only when it is touched.
Ref: #24.

Demo: https://vimeo.com/661152400/ea58dfce0e

@karthiknmenon _a please have a look.