### PR TITLE
Updated pagination styles

### DIFF
--- a/lib/components/Pagination.js
+++ b/lib/components/Pagination.js
@@ -102,7 +102,7 @@ const Pagination = ({
           onClick={onPrevious}
         >
           <a>
-            <Left />
+            <Left size={18} />
           </a>
         </li>
         {paginationRange.map((pageNumber, index) => {
@@ -146,7 +146,7 @@ const Pagination = ({
           onClick={onNext}
         >
           <a>
-            <Right />
+            <Right size={18} />
           </a>
         </li>
       </ul>

--- a/lib/styles/components/_pagination.scss
+++ b/lib/styles/components/_pagination.scss
@@ -5,14 +5,15 @@
   align-items: center;
   list-style: none;
 
-  .neeto-ui-pagination__item:not(.neeto-ui-pagination__item--dots, .neeto-ui-pagination__item--navigate) {
+  .neeto-ui-pagination__item:not(.neeto-ui-pagination__item--dots) {
     margin: 0 4px;
-    background-color: $neeto-ui-gray-200;
+    background-color: $neeto-ui-white;
+    border: 1px solid $neeto-ui-gray-300;
     border-radius: $neeto-ui-rounded-sm;
     overflow: hidden;
 
     &:hover:not(.disabled, .active) {
-      background-color: $neeto-ui-gray-300;
+      border-color: $neeto-ui-gray-800;
     }
   }
 
@@ -20,10 +21,10 @@
     width: 32px;
     min-width: 32px;
     height: 32px;
-    line-height: 32px;
+    line-height: 30px;
     font-size: $neeto-ui-text-sm;
-    font-weight: $neeto-ui-font-semibold;
-    color: $neeto-ui-gray-700;
+    font-weight: $neeto-ui-font-medium;
+    color: $neeto-ui-gray-800;
     transition: $neeto-ui-transition;
     user-select: none;
 
@@ -40,8 +41,7 @@
     }
 
     &.active {
-      background-color: $neeto-ui-gray-800;
-      color: $neeto-ui-white;
+      border-color: $neeto-ui-gray-800;
     }
 
     &.neeto-ui-pagination__item--dots {
@@ -51,7 +51,7 @@
 
     &.neeto-ui-pagination__item--navigate {
       text-align: center;
-      color: $neeto-ui-gray-500;
+      color: $neeto-ui-gray-800;
       display: flex;
       flex-direction: row;
       justify-content: center;
@@ -59,7 +59,7 @@
 
       &:hover:not(.disabled),
       &:active {
-        color: $neeto-ui-gray-600;
+        color: $neeto-ui-gray-800;
       }
 
       &.disabled {


### PR DESCRIPTION
Fixes #801 

@karthiknmenon _a Please review.

Updated pagination styles to match antD table pagination styles. 

Old
<img width="285" alt="Screenshot 2022-02-01 at 12 55 00 PM" src="https://user-images.githubusercontent.com/48869249/151930664-b8c97ac1-db5d-40b1-8281-8fbeee5996b4.png">

New
<img width="310" alt="Screenshot 2022-02-01 at 1 19 37 PM" src="https://user-images.githubusercontent.com/48869249/151930819-602bac82-ef71-4e56-8537-1538e6333112.png">

