### PR TITLE
Added help text to EmailInput component

### DIFF
--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -9,6 +9,7 @@ import {
   EMAIL_SEPARATION_REGEX,
   CUSTOM_STYLES,
   formatEmailInputOptions,
+  pruneDuplicates,
 } from "../constants/EmailInput";
 import { hyphenize } from "../common";
 import Typography from "./Typography";
@@ -42,7 +43,7 @@ const EmailInput = ({
   const handleEmailChange = () => {
     const inputValues = inputValue.match(EMAIL_SEPARATION_REGEX);
     const emails = inputValues.map(email => formatEmailInputOptions(email));
-    onChange([...value, ...emails]);
+    onChange(pruneDuplicates([...value, ...emails]));
     setInputValue("");
   };
 

--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -92,12 +92,12 @@ const EmailInput = ({
         {...otherProps}
       />
       <div>
-        <Typography style="body3" className="neeto-ui-text-error mt-1">
-          {!!error && Array.isArray(error)
-            ? "Please make sure all emails are valid."
-            : error}
-        </Typography>
-        {helpText && <Typography style="body3">{helpText}</Typography>}
+        {!!error && (
+          <Typography style="body3" className="neeto-ui-text-error mt-1">
+            {error}
+          </Typography>
+        )}
+        {!!helpText && <Typography style="body3">{helpText}</Typography>}
       </div>
     </div>
   );
@@ -123,7 +123,7 @@ EmailInput.propTypes = {
   /**
    * To specify the error message to be shown below the input field.
    */
-  error: PropTypes.oneOfType([String, Array]),
+  error: PropTypes.string,
   /**
    * To specify whether the input field is disabled or not.
    */

--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -27,11 +27,12 @@ const CUSTOM_COMPONENTS = {
 };
 
 const EmailInput = ({
-  label = "",
+  label = "Email(s)",
   placeholder = "",
+  helpText = "",
   value = [],
   onChange,
-  error,
+  error = "",
   onBlur,
   disabled = false,
   ...otherProps
@@ -95,6 +96,7 @@ const EmailInput = ({
             ? "Please make sure all emails are valid."
             : error}
         </Typography>
+        {helpText && <Typography style="body3">{helpText}</Typography>}
       </div>
     </div>
   );
@@ -110,13 +112,17 @@ EmailInput.propTypes = {
    */
   placeholder: PropTypes.string,
   /**
+   * The helper text message to be displayed below the input field.
+   */
+  helpText: PropTypes.string,
+  /**
    * The values to be displayed inside the input field.
    */
   value: PropTypes.array,
   /**
-   * To specify the error message to be shown in the input field.
+   * To specify the error message to be shown below the input field.
    */
-  error: PropTypes.string,
+  error: PropTypes.oneOfType([String, Array]),
   /**
    * To specify whether the input field is disabled or not.
    */

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -10,8 +10,8 @@ import Checkbox from "./Checkbox";
 import ColorPicker from "./ColorPicker";
 import DatePicker from "./DatePicker";
 import Dropdown from "./Dropdown";
-import Input from "./Input";
 import EmailInput from "./EmailInput";
+import Input from "./Input";
 import Label from "./Label";
 import Modal from "./Modal";
 import PageLoader from "./PageLoader";
@@ -41,8 +41,8 @@ export {
   ColorPicker,
   DatePicker,
   Dropdown,
-  Input,
   EmailInput,
+  Input,
   Label,
   Modal,
   PageLoader,

--- a/lib/constants/EmailInput.js
+++ b/lib/constants/EmailInput.js
@@ -26,3 +26,9 @@ export const formatEmailInputOptions = label => ({
   value: label,
   valid: EMAIL_REGEX.test(label),
 });
+
+export const pruneDuplicates = inputValues => {
+  const values = inputValues.map(({ value }) => value);
+  const uniqueValues = [...new Set(values)];
+  return uniqueValues.map(email => formatEmailInputOptions(email));
+};

--- a/stories/Components/EmailInput.stories.jsx
+++ b/stories/Components/EmailInput.stories.jsx
@@ -57,13 +57,11 @@ export const FormikEmail = () => {
     emails: yup
       .array()
       .min(1, "Please enter atleast one email.")
-      .of(
-        yup.object().shape({
-          label: yup.string().email(),
-          value: yup.string().email(),
-        })
+      .test(
+        "are-all-emails-valid",
+        "Please make sure all emails are valid.",
+        emails => emails.every(({ valid }) => valid)
       )
-      .required("Please enter an email address.")
       .nullable(),
   });
 

--- a/stories/Components/EmailInput.stories.jsx
+++ b/stories/Components/EmailInput.stories.jsx
@@ -40,10 +40,14 @@ Controlled.args = {
 };
 
 export const Error = () => (
-  <EmailInput label="Email(s)" error="Please make sure all emails are valid." />
+  <EmailInput error="Please make sure all emails are valid." />
 );
 
-export const Disabled = () => <EmailInput label="Email(s)" disabled />;
+export const Disabled = () => <EmailInput disabled />;
+
+export const HelpText = () => (
+  <EmailInput helpText="This is the help text for this component." />
+);
 
 export const FormikEmail = () => {
   const [emails, setEmails] = useState([]);
@@ -80,9 +84,7 @@ export const FormikEmail = () => {
           style="primary"
           data-cy="add-member-submit-button"
         />
-        <Typography style="body1">
-            Emails: {JSON.stringify(emails)}
-        </Typography>
+        <Typography style="body1">Emails: {JSON.stringify(emails)}</Typography>
       </Form>
     </Formik>
   );


### PR DESCRIPTION
Fixes #845 
- Added help text to EmailInput component and its story.
- Added default props for `error` and `label`.
- Rearranged the `index.js` file in alphabetic order.
- Added feature to prune similar values.
- Added a custom yup validation test.