### PR TITLE
SVG Animation fixes

### DIFF
--- a/lib/components/PageLoader.js
+++ b/lib/components/PageLoader.js
@@ -1,34 +1,19 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import Typography from "./Typography";
-import { motion, useAnimation } from "framer-motion";
+import { motion } from "framer-motion";
 import PropTypes from "prop-types";
 
 import { PATH_VARIANTS, ROTATE_VARIANTS } from "../constants/pageLoader";
 
 const PageLoader = ({ text = null, ...otherProps }) => {
-
-  const pathControls = useAnimation();
-  const rotateControls = useAnimation();
-
-  const sequence = async () => {
-    await pathControls.start("visible");
-    await rotateControls.start("rotate");
-    await pathControls.start("hidden");
-    await rotateControls.start("initial");
-    return await sequence();
-  };
-
-  useEffect(() => {
-    sequence();
-  }, []);
   return (
     <div className="neeto-ui-pageloader__wrapper" {...otherProps}>
       <div className="neeto-ui-pageloader">
         <div className="neeto-ui-page-loader__content relative flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-md p-2 mb-4">
           <motion.div
             variants={ROTATE_VARIANTS}
-            animate={rotateControls}
+            animate="rotate"
             initial="initial"
             className="neeto-ui-bg-gray-800 absolute left-0 top-0 h-14 w-14 rounded-md"
           />
@@ -54,8 +39,8 @@ const PageLoader = ({ text = null, ...otherProps }) => {
               strokeWidth="2.5"
               d="M10.44 18.069l-4.1 4.381c-1 1-4.2 1.393-4.3-2-.09-3.104 0-8.372 0-10.636 0-3.13 2.46-2.715 3.8-1.414 2 1.94 6.617 6.554 8.95 8.818 1.063 1.031 3.65 1.345 3.65-1.76V4.785c0-2.171-2.14-3.542-3.8-2.335-2.117 1.541-3.766 3.951-4.6 4.76"
               variants={PATH_VARIANTS}
-              animate={pathControls}
               initial="hidden"
+              animate="visible"
             ></motion.path>
           </motion.svg>
         </div>

--- a/lib/constants/pageLoader.js
+++ b/lib/constants/pageLoader.js
@@ -3,6 +3,8 @@ export const PATH_VARIANTS = {
     pathLength: 1,
     transition: {
       duration: 1,
+      repeat: Infinity,
+      repeatDelay: 1,
     },
   },
   hidden: {
@@ -23,7 +25,10 @@ export const ROTATE_VARIANTS = {
   rotate: {
     rotate: 180,
     transition: {
+      delay: 1,
       duration: 1,
+      repeat: Infinity,
+      repeatDelay: 1,
     },
   },
 };


### PR DESCRIPTION
Fixes #855 

1. Removed the `useAnimation` and `useEffect` Hooks from the PageLoader.
2. Removed recursive function calls for animating SVG paths.
3. Rewrote SVG animations using `delay` and `repeatDelay`.

@praveen-murali-ind _a

