### PR TITLE
Fix Modal/Alert Style Issues

### DIFF
--- a/lib/components/Alert.js
+++ b/lib/components/Alert.js
@@ -79,6 +79,7 @@ const Alert = ({
               >
                 {closeButton && (
                   <Button
+                    aria-label="Close"
                     style="text"
                     icon={Close}
                     className="neeto-ui-modal__close"

--- a/lib/components/Alert.js
+++ b/lib/components/Alert.js
@@ -14,9 +14,9 @@ import PageLoader from "./PageLoader";
 
 const noop = () => {};
 const sizes = {
+  xs: "xs",
   sm: "sm",
   md: "md",
-  lg: "lg",
 };
 
 const Alert = ({
@@ -71,9 +71,9 @@ const Alert = ({
                 key="modal-wrapper"
                 exit={{ scale: 1, opacity: 0, y: 20, filter: BLUR_FINAL }}
                 className={classnames("neeto-ui-modal__wrapper", {
+                  "neeto-ui-modal__wrapper--xs": size === sizes.xs,
                   "neeto-ui-modal__wrapper--sm": size === sizes.sm,
                   "neeto-ui-modal__wrapper--md": size === sizes.md,
-                  "neeto-ui-modal__wrapper--lg": size === sizes.lg,
                   [className]: className,
                 })}
               >
@@ -109,22 +109,25 @@ const Alert = ({
 };
 
 Alert.propTypes = {
+  /**
+   * To specify the size of the Alert.
+   */
   size: PropTypes.oneOf(Object.values(sizes)),
   /**
-   * To render the Alert Component.
+   * To specify whether the Alert is open or not.
    */
   isOpen: PropTypes.bool,
   /**
-   * To close the Alert Component.
+   * To specify the callback which will be invoked when the Alert is closed.
    */
   onClose: PropTypes.func,
   onSubmit: PropTypes.func,
   /**
-   * To add Title to Alert Component.
+   * To provide Title to the Alert.
    */
   title: PropTypes.string,
   /**
-   * To add alert message the Alert Component.
+   * To provide Description to the Alert.
    */
   message: PropTypes.string,
   loading: PropTypes.bool,
@@ -133,10 +136,13 @@ Alert.propTypes = {
    */
   isSubmitting: PropTypes.bool,
   /**
-   * To add className to Alert Component.
+   * To provide external classNames to the Alert.
    */
   className: PropTypes.string,
   closeOnEsc: PropTypes.bool,
+  /**
+   * To specify whether the close button of the Alert should be displayed or not.
+   */
   closeButton: PropTypes.bool,
   /**
    * Label for submit button.

--- a/lib/components/Button.js
+++ b/lib/components/Button.js
@@ -95,12 +95,13 @@ const Button = React.forwardRef((props, ref) => {
           /* When Icon is present, animate between the icon and the spinner*/
             loading ? (
               <Spinner
+                aria-hidden="true"
                 key="1"
                 size={iconSize}
                 className="neeto-ui-btn__spinner"
               />
             ) : (
-              <Icon key="2" size={iconSize} className="neeto-ui-btn__icon" />
+              <Icon aria-hidden="true" key="2" size={iconSize} className="neeto-ui-btn__icon" />
             )
           ) : (
           /* When Icon is not present, animate the margin from 0 to the needed value*/
@@ -116,7 +117,7 @@ const Button = React.forwardRef((props, ref) => {
                 exit={{ [spinnerMarginSide]: 0, width: 0, scale: 0 }}
                 transition={{ bounce: false }}
               >
-                <Spinner key="3" />
+                <Spinner aria-hidden="true" key="3" />
               </motion.div>
             )
           )}

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -60,6 +60,8 @@ const Modal = ({
             )}
           >
             <motion.div
+              role="dialog"
+              aria-modal={true}
               variants={animationVariants}
               initial="closed"
               animate="open"
@@ -80,6 +82,7 @@ const Modal = ({
             >
               {closeButton && (
                 <Button
+                  aria-label="Close"
                   style="text"
                   icon={Close}
                   className="neeto-ui-modal__close"

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -100,26 +100,26 @@ const Modal = ({
 
 Modal.propTypes = {
   /**
-   * To specify the size of the modal.
+   * To specify the size of the Modal.
    */
   size: PropTypes.oneOf(Object.values(sizes)),
   /**
-   * To specify whether the modal is open or not.
+   * To specify whether the Modal is open or not.
    */
   isOpen: PropTypes.bool,
   /**
-   * To specify the callback which will be invoked when the modal is closed.
+   * To specify the callback which will be invoked when the Modal is closed.
    */
   onClose: PropTypes.func,
   loading: PropTypes.bool,
   children: PropTypes.node,
   /**
-   * To provide external classNames to the modal.
+   * To provide external classNames to the Modal.
    */
   className: PropTypes.string,
   closeOnEsc: PropTypes.bool,
   /**
-   * To specify whether the close button of the modal should be displayed or not.
+   * To specify whether the close button of the Modal should be displayed or not.
    */
   closeButton: PropTypes.bool,
   backdropClassName: PropTypes.string,

--- a/lib/components/Pane.js
+++ b/lib/components/Pane.js
@@ -85,6 +85,7 @@ const Pane = ({
             >
               {closeButton && (
                 <Button
+                  aria-label="Close"
                   style="text"
                   icon={Close}
                   className="neeto-ui-pane__close"

--- a/lib/styles/components/_modal.scss
+++ b/lib/styles/components/_modal.scss
@@ -7,16 +7,13 @@
   height: 100vh;
   overflow-y: auto;
   overflow-x: hidden;
-  display: flex;
-  flex-direction: row;
+  display: grid;
   justify-content: center;
   align-items: center;
 
   .neeto-ui-modal__wrapper {
     width: 50%;
     max-width: 100%;
-    max-height: 100vh;
-    overflow-y: visible;
     position: relative;
     background-color: $neeto-ui-white;
     border-radius: $neeto-ui-rounded-sm;

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -259,7 +259,7 @@ export const SelectInModal = () => {
       <Button label="Open Modal" onClick={() => setIsOpen(true)} />
       <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
         <Modal.Header>
-          <Typography style="h1">Modal</Typography>
+          <Typography style="h2">Modal</Typography>
         </Modal.Header>
         <Modal.Body>
           <Select
@@ -296,7 +296,7 @@ export const SelectInPane = () => {
       <Button label="Open Pane" onClick={() => setIsOpen(true)} />
       <Pane isOpen={isOpen} onClose={() => setIsOpen(false)}>
         <Pane.Header>
-          <Typography style="h1">Modal</Typography>
+          <Typography style="h2">Modal</Typography>
         </Pane.Header>
         <Pane.Body className="w-full">
           <Select

--- a/stories/Overlays/Alert.stories.jsx
+++ b/stories/Overlays/Alert.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import Alert from "../../lib/components/Alert";
 import Button from "../../lib/components/Button";
@@ -6,6 +6,7 @@ import Button from "../../lib/components/Button";
 export default {
   title: "Overlays/Alert",
   component: Alert,
+  subcomponents: { Button },
   parameters: {
     layout: "padded",
     docs: {
@@ -16,17 +17,13 @@ export default {
   },
 };
 
-export const AlertStory = ({ isOpen, onClose, onSubmit, ...args }) => {
+export const Default = () => {
   const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    setOpen(isOpen);
-  }, [isOpen]);
 
   return (
     <div className="p-4">
       <Button
-        label="Click here to open Alert Component"
+        label="Show Alert"
         style="primary"
         onClick={() => setOpen(true)}
       />
@@ -36,17 +33,54 @@ export const AlertStory = ({ isOpen, onClose, onSubmit, ...args }) => {
         message="Are you sure you want to continue? All of your unsaved changes will be lost."
         onClose={() => setOpen(false)}
         onSubmit={() => setOpen(false)}
-        {...args}
       />
     </div>
   );
 };
 
-AlertStory.args = {
-  isOpen: false,
-  title: "You have unsaved changes!",
-  message:
-    "Are you sure you want to continue? All of your unsaved changes will be lost.",
-  isSubmitting: false,
+export const AlertSizing = () => {
+  const [showAlertExtraSmall, setShowAlertExtraSmall] = useState(false);
+  const [showAlertSmall, setShowAlertSmall] = useState(false);
+  const [showAlertMedium, setShowAlertMedium] = useState(false);
+
+  return (
+    <div className="w-full">
+      <div className="space-y-6">
+        <div className="w-1/2 space-y-8">
+          <div className="flex flex-row items-center justify-start space-x-6">
+            <Button
+              label="Extra Small"
+              onClick={() => setShowAlertExtraSmall(true)}
+            />
+            <Button label="Small" onClick={() => setShowAlertSmall(true)} />
+            <Button label="Medium" onClick={() => setShowAlertMedium(true)} />
+          </div>
+          <Alert
+            size="xs"
+            isOpen={showAlertExtraSmall}
+            title="You have unsaved changes!"
+            message="Are you sure you want to continue? All of your unsaved changes will be lost."
+            onClose={() => setShowAlertExtraSmall(false)}
+            onSubmit={() => setShowAlertExtraSmall(false)}
+          />
+          <Alert
+            size="sm"
+            isOpen={showAlertSmall}
+            title="You have unsaved changes!"
+            message="Are you sure you want to continue? All of your unsaved changes will be lost."
+            onClose={() => setShowAlertSmall(false)}
+            onSubmit={() => setShowAlertSmall(false)}
+          />
+          <Alert
+            size="md"
+            isOpen={showAlertMedium}
+            title="You have unsaved changes!"
+            message="Are you sure you want to continue? All of your unsaved changes will be lost."
+            onClose={() => setShowAlertMedium(false)}
+            onSubmit={() => setShowAlertMedium(false)}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
-AlertStory.storyName = "Alert";

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -41,7 +41,7 @@ export const Default = () => {
           </Typography>
         </Modal.Header>
         <Modal.Body>
-          <Typography style="body2" lineHeight="normal" id="dialog1Desc">
+          <Typography style="body2" lineHeight="normal">
             Somewhere out in space live The Herculoids! Zok, the laser-ray
             dragon! Igoo, the giant rock ape! Tundro, the tremendous! Gloop and
             Gleep, the formless, fearless wonders! With Zandor, their leader,

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -32,12 +32,19 @@ export const Default = () => {
         </div>
       </div>
 
-      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+      <Modal
+        aria-labelledby="dialog1Title"
+        aria-describedby="dialog1Desc"
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+      >
         <Modal.Header>
-          <Typography style="h2">They're creepy & they're kooky</Typography>
+          <Typography style="h2" id="dialog1Title">
+            They're creepy & they're kooky
+          </Typography>
         </Modal.Header>
         <Modal.Body>
-          <Typography style="body2" lineHeight="normal">
+          <Typography style="body2" lineHeight="normal" id="dialog1Desc">
             Somewhere out in space live The Herculoids! Zok, the laser-ray
             dragon! Igoo, the giant rock ape! Tundro, the tremendous! Gloop and
             Gleep, the formless, fearless wonders! With Zandor, their leader,
@@ -86,15 +93,19 @@ export const ModalSizing = () => {
       </div>
 
       <Modal
+        aria-labelledby="dialog2Title"
+        aria-describedby="dialog2Desc"
         isOpen={showModalExtraSmall}
         onClose={() => setShowModalExtraSmall(false)}
         size="xs"
       >
         <Modal.Header>
-          <Typography style="h2">They're creepy & they're kooky</Typography>
+          <Typography style="h2" id="dialog2Title">
+            They're creepy & they're kooky
+          </Typography>
         </Modal.Header>
         <Modal.Body>
-          <Typography style="body2" lineHeight="normal">
+          <Typography style="body2" lineHeight="normal" id="dialog2Desc">
             Somewhere out in space live The Herculoids! Zok, the laser-ray
             dragon! Igoo, the giant rock ape! Tundro, the tremendous!
           </Typography>

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Check } from "@bigbinary/neeto-icons";
 
 import Button from "../../lib/components/Button";
 import Modal from "../../lib/components/Modal";
@@ -55,7 +54,6 @@ export const Default = () => {
         </Modal.Body>
         <Modal.Footer className="space-x-2">
           <Button
-            icon={Check}
             label="Continue"
             onClick={() => setShowModal(false)}
             size="large"
@@ -112,7 +110,6 @@ export const ModalSizing = () => {
         </Modal.Body>
         <Modal.Footer className="space-x-2">
           <Button
-            icon={Check}
             size="large"
             label="Continue"
             onClick={() => setShowModalExtraSmall(false)}
@@ -142,7 +139,6 @@ export const ModalSizing = () => {
         </Modal.Body>
         <Modal.Footer className="space-x-2">
           <Button
-            icon={Check}
             size="large"
             label="Continue"
             onClick={() => setShowModalSmall(false)}
@@ -176,7 +172,6 @@ export const ModalSizing = () => {
         </Modal.Body>
         <Modal.Footer className="space-x-2">
           <Button
-            icon={Check}
             size="large"
             label="Continue"
             onClick={() => setShowModalMedium(false)}

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -32,8 +32,6 @@ export const Default = () => {
       </div>
 
       <Modal
-        aria-labelledby="dialog1Title"
-        aria-describedby="dialog1Desc"
         isOpen={showModal}
         onClose={() => setShowModal(false)}
       >
@@ -91,19 +89,17 @@ export const ModalSizing = () => {
       </div>
 
       <Modal
-        aria-labelledby="dialog2Title"
-        aria-describedby="dialog2Desc"
         isOpen={showModalExtraSmall}
         onClose={() => setShowModalExtraSmall(false)}
         size="xs"
       >
         <Modal.Header>
-          <Typography style="h2" id="dialog2Title">
+          <Typography style="h2">
             They're creepy & they're kooky
           </Typography>
         </Modal.Header>
         <Modal.Body>
-          <Typography style="body2" lineHeight="normal" id="dialog2Desc">
+          <Typography style="body2" lineHeight="normal">
             Somewhere out in space live The Herculoids! Zok, the laser-ray
             dragon! Igoo, the giant rock ape! Tundro, the tremendous!
           </Typography>

--- a/stories/Overlays/Pane.stories.jsx
+++ b/stories/Overlays/Pane.stories.jsx
@@ -27,15 +27,8 @@ export default {
   },
 };
 
-export const Panes = ({ isOpen, onClose, ...args }) => {
+export const Panes = () => {
   const [showPane, setShowPane] = useState(false);
-  useEffect(() => {
-    setShowPane(isOpen);
-  }, [isOpen]);
-  const handleClose = () => {
-    setShowPane(false);
-    onClose();
-  };
   return (
     <div className="w-full">
       <div className="space-y-6">
@@ -46,7 +39,7 @@ export const Panes = ({ isOpen, onClose, ...args }) => {
         </div>
       </div>
 
-      <Pane isOpen={showPane} onClose={handleClose} {...args}>
+      <Pane isOpen={showPane} onClose={() => setShowPane(false)}>
         <Pane.Header>
           <Typography style="h2" weight="semibold">
             Typography
@@ -81,19 +74,12 @@ export const Panes = ({ isOpen, onClose, ...args }) => {
   );
 };
 
-export const PaneWithModalAndAlert = ({ isOpen, onClose, ...args }) => {
+export const PaneWithModalAndAlert = () => {
   const [showPane, setShowPane] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
   const [inputValue, setInputValue] = useState("");
 
-  useEffect(() => {
-    setShowPane(isOpen);
-  }, [isOpen]);
-  const handleClose = () => {
-    setShowPane(false);
-    onClose();
-  };
   return (
     <div className="w-full">
       <div className="space-y-6">
@@ -104,7 +90,7 @@ export const PaneWithModalAndAlert = ({ isOpen, onClose, ...args }) => {
         </div>
       </div>
 
-      <Pane isOpen={showPane} onClose={handleClose} {...args}>
+      <Pane isOpen={showPane} onClose={() => setShowPane(false)}>
         <Pane.Header>
           <Typography style="h2" weight="semibold">
             Typography


### PR DESCRIPTION
Fixes #883 
Fixes #881

- Added `aria-hidden="true"` props to Button icons/svg (purely decorative content) to hide the content from assistive technology
- Added `role="dialog"` prop to Modal container.
- Added `aria-label="Close"` to Modal, Alert and Pane icon only close buttons.
- Fixed inconsistencies in Alert `size` prop.
- Fixed content overflow issue in Modal/Alert.
- Fixed style inconsistencies in Select component documentation.
- Fixed issues in Alert documentation - made the source code readable.

@karthiknmenon _a Please review.