### PR TITLE
ActionDropdown `buttonProps` fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [3.3.9]
+
+- Fixed: _ActionDropdown_ issues with common props for button and dropdown
+
 ## [3.3.7]
 
 - Changed: Updated React version to 17.0.2.

--- a/lib/components/ActionDropdown.js
+++ b/lib/components/ActionDropdown.js
@@ -20,25 +20,25 @@ const ActionDropdown = ({
   size = "default",
   disabled = false,
   onClick = noop,
-  buttonProps = {},
+  buttonProps: { style: buttonStyle, size: buttonSize, ...buttonProps } = {},
   dropdownProps = {},
   className = "",
   children,
 }) => (
   <div className={classnames(["neeto-ui-action-dropdown", className])}>
     <Button
-      style={style}
+      style={buttonStyle ?? style}
       data-testid="action-dropdown-btn"
       label={label}
-      size={size}
+      size={buttonSize ?? size}
       disabled={disabled}
       onClick={onClick}
       {...buttonProps}
     />
     <Dropdown
-      buttonStyle={style}
+      buttonStyle={buttonStyle ?? style}
       disabled={disabled}
-      buttonProps={{ size: size, ...buttonProps }}
+      buttonProps={{ size: buttonSize ?? size }}
       {...dropdownProps}
     >
       {children}


### PR DESCRIPTION
- Fixes #1109 
- Share only styling props between `Button` and `Dropdown` in `ActionDropdown` through `buttonProps`

@ajmaln _a