### PR TITLE
Fixed placeholder overflow issue in select

### DIFF
--- a/lib/styles/components/_select.scss
+++ b/lib/styles/components/_select.scss
@@ -1,5 +1,5 @@
 .neeto-ui-react-select__container.neeto-ui-react-select__container--error {
-  .neeto-ui-react-select__control{
+  .neeto-ui-react-select__control {
     border: thin solid $neeto-ui-error;
   }
   .neeto-ui-react-select__control.neeto-ui-react-select__control--is-focused {
@@ -8,7 +8,8 @@
   }
 }
 
-.neeto-ui-react-select__container, .neeto-ui-react-select__menu-portal {
+.neeto-ui-react-select__container,
+.neeto-ui-react-select__menu-portal {
   width: 100%;
   font-size: $neeto-ui-text-sm;
 
@@ -81,6 +82,9 @@
   .neeto-ui-react-select__placeholder {
     color: $neeto-ui-gray-400;
     font-size: inherit;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .neeto-ui-react-select__input {


### PR DESCRIPTION
Fixes #1159 

**Description**

- Fixed : placeholder content extending into multiple lines in _Select_ component.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@ajmaln _a
cc: @praveen-murali-ind 

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
