### PR TITLE
Fixed issue with close on esc when dropdown is controlled

### DIFF
--- a/lib/components/Dropdown.js
+++ b/lib/components/Dropdown.js
@@ -44,9 +44,10 @@ const TRIGGERS = {
 const hideOnEsc = {
   name: "hideOnEsc",
   defaultValue: true,
-  fn({ hide, props: { hideOnEsc } }) {
+  fn({ hide, props: { hideOnEsc, onClose } }) {
     function onKeyDown(event) {
       if (event.key.toLowerCase() === "escape" && hideOnEsc) {
+        onClose();
         hide();
       }
     }
@@ -114,6 +115,7 @@ const Dropdown = ({
   return (
     <Tippy
       role="dropdown"
+      onClose={onClose}
       trigger={TRIGGERS[trigger]}
       plugins={[hideOnEsc]}
       hideOnEsc={closeOnEsc}

--- a/stories/Components/Dropdown.stories.jsx
+++ b/stories/Components/Dropdown.stories.jsx
@@ -152,10 +152,10 @@ export const ControlledDropdown = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div className="flex flex-col items-start space-y-6">
-      <Button
-        label={`${isOpen ? "Close" : "Open"} Dropdown`}
-        onClick={() => setIsOpen((open) => !open)}
-      />
+      <div className="flex items-center space-x-4">
+        <Button label="Open Dropdown" onClick={() => setIsOpen(true)} />
+        <Button label="Close Dropdown" onClick={() => setIsOpen(false)} />
+      </div>
       <Dropdown
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/stories/Components/Dropdown.stories.jsx
+++ b/stories/Components/Dropdown.stories.jsx
@@ -156,7 +156,11 @@ export const ControlledDropdown = () => {
         label={`${isOpen ? "Close" : "Open"} Dropdown`}
         onClick={() => setIsOpen((open) => !open)}
       />
-      <Dropdown isOpen={isOpen} label="Controlled Dropdown">
+      <Dropdown
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        label="Controlled Dropdown"
+      >
         {listItems.map((item, idx) => (
           <li key={idx}>{item}</li>
         ))}


### PR DESCRIPTION
Fixes #1133 

**Description**

- Fixed: issue with `closeOnEsc` prop when the _Dropdown_ is controlled.

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@ajmaln _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
