### PR TITLE
Added the start value for email counter prop

### DIFF
--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -65,9 +65,8 @@ const EmailInput = ({
   ...otherProps
 }) => {
   const [inputValue, setInputValue] = useState("");
-  const hasStartCount =
-    counter?.startsFrom && getEmailsCount(value) >= counter.startsFrom;
-  const isCounterVisible = typeof counter === "boolean" || hasStartCount;
+
+  const isCounterVisible = !!counter && (!counter.startsFrom || getEmailsCount(value) >= counter.startsFrom);
 
   const handleFilterEmails = () => onChange(renderValidEmails(value));
 

--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -66,7 +66,9 @@ const EmailInput = ({
 }) => {
   const [inputValue, setInputValue] = useState("");
 
-  const isCounterVisible = !!counter && (!counter.startsFrom || getEmailsCount(value) >= counter.startsFrom);
+  const isCounterVisible =
+    !!counter &&
+    (!counter.startsFrom || getEmailsCount(value) >= counter.startsFrom);
 
   const handleFilterEmails = () => onChange(renderValidEmails(value));
 
@@ -216,10 +218,13 @@ EmailInput.propTypes = {
   /**
    * To add an email counter next to the label.
    */
-  counter: PropTypes.shape({
-    label: PropTypes.string,
-    startsFrom: PropTypes.number,
-  }),
+  counter: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      label: PropTypes.string,
+      startsFrom: PropTypes.number,
+    }),
+  ]),
   /**
    * To specify the action to be triggered on modifying the input field.
    */

--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -65,6 +65,7 @@ const EmailInput = ({
   ...otherProps
 }) => {
   const [inputValue, setInputValue] = useState("");
+  const isCounterGreaterThan3 = getEmailsCount(value) > 3;
 
   const handleFilterEmails = () => onChange(renderValidEmails(value));
 
@@ -105,7 +106,7 @@ const EmailInput = ({
             {label}
           </Label>
         )}
-        {counter && (
+        {counter && isCounterGreaterThan3 && (
           <Label
             className="neeto-ui-email-input__counter"
             data-cy={`${hyphenize(label)}-email-counter`}

--- a/lib/components/EmailInput.js
+++ b/lib/components/EmailInput.js
@@ -65,7 +65,9 @@ const EmailInput = ({
   ...otherProps
 }) => {
   const [inputValue, setInputValue] = useState("");
-  const isCounterGreaterThan3 = getEmailsCount(value) > 3;
+  const hasStartCount =
+    counter?.startsFrom && getEmailsCount(value) >= counter.startsFrom;
+  const isCounterVisible = typeof counter === "boolean" || hasStartCount;
 
   const handleFilterEmails = () => onChange(renderValidEmails(value));
 
@@ -106,7 +108,7 @@ const EmailInput = ({
             {label}
           </Label>
         )}
-        {counter && isCounterGreaterThan3 && (
+        {isCounterVisible && (
           <Label
             className="neeto-ui-email-input__counter"
             data-cy={`${hyphenize(label)}-email-counter`}
@@ -215,7 +217,10 @@ EmailInput.propTypes = {
   /**
    * To add an email counter next to the label.
    */
-  counter: PropTypes.shape({ label: PropTypes.string }),
+  counter: PropTypes.shape({
+    label: PropTypes.string,
+    startsFrom: PropTypes.number,
+  }),
   /**
    * To specify the action to be triggered on modifying the input field.
    */

--- a/stories/Components/EmailInput.stories.jsx
+++ b/stories/Components/EmailInput.stories.jsx
@@ -9,6 +9,7 @@ import { suffixes, prefixes } from "../constants";
 import { EmailInput as FormikEmailInput } from "../../lib/components/formik";
 import Button from "../../lib/components/Button";
 import Typography from "../../lib/components/Typography";
+import EmailInputDocs from "!raw-loader!./EmailInputDocs.mdx";
 
 export default {
   title: "Components/Email Input",
@@ -75,20 +76,40 @@ export const HelpText = () => (
 );
 
 export const Counter = () => {
-  const [emails, setEmails] = useState([]);
+  const [emails, setEmails] = useState([{
+    "label": "test@example.com",
+    "value": "test@example.com",
+    "valid": true
+  },
+  {
+    "label": "test2@example.com",
+    "value": "test2@example.com",
+    "valid": true
+  },
+  {
+    "label": "test3@example.com",
+    "value": "test3@example.com",
+    "valid": true
+  }]);
 
   return (
     <EmailInput
-      counter
+      counter={{ startsFrom: 3 }}
       value={emails}
       onChange={emails => setEmails(emails)}
     />
   );
 };
 
+Counter.parameters = {
+  docs: {
+    description: { story: EmailInputDocs },
+  }
+};
+
 export const WithPrefixAndSuffix = (args) => {
   const [emails, setEmails] = useState(args.value);
-  
+
   return (
     <EmailInput
       {...args}

--- a/stories/Components/EmailInputDocs.mdx
+++ b/stories/Components/EmailInputDocs.mdx
@@ -1,5 +1,3 @@
-If you want to use `counter` prop on `EmailInput` component, then, please follow the below syntax.
-
 For the basic implementation, see the following example:
 
 ```jsx
@@ -12,7 +10,7 @@ For specifying the counter label for i18n purposes, see the following example:
 <EmailInput counter={{ label: "E-mail" }} />
 ```
 
-For specifying the counter to start counting after a specific number of emails, then see the following example:
+To start showing the counter label only from a specific number of emails, then see the following example:
 
 ```jsx
 <EmailInput counter={{ startsFrom: 3 }} />

--- a/stories/Components/EmailInputDocs.mdx
+++ b/stories/Components/EmailInputDocs.mdx
@@ -4,7 +4,7 @@ For the basic implementation, see the following example:
 <EmailInput counter />
 ```
 
-For specifying the counter label for i18n purposes, see the following example:
+Use the below example to show the counter only from a specific number:
 
 ```jsx
 <EmailInput counter={{ label: "E-mail" }} />

--- a/stories/Components/EmailInputDocs.mdx
+++ b/stories/Components/EmailInputDocs.mdx
@@ -1,16 +1,16 @@
-Use the below example for the basic implementation:
+Basic implementation:
 
 ```jsx
 <EmailInput counter />
 ```
 
-Use the below example for specifying the counter label for i18n purposes:
+Specify the counter label for i18n purposes:
 
 ```jsx
 <EmailInput counter={{ label: "E-mail" }} />
 ```
 
-Use the below example to show the counter only from a specific number:
+Start showing counter label after a specific number of emails:
 
 ```jsx
 <EmailInput counter={{ startsFrom: 3 }} />

--- a/stories/Components/EmailInputDocs.mdx
+++ b/stories/Components/EmailInputDocs.mdx
@@ -1,10 +1,10 @@
-For the basic implementation, see the following example:
+Use the below example for the basic implementation:
 
 ```jsx
 <EmailInput counter />
 ```
 
-For specifying the counter label for i18n purposes, see the following example:
+Use the below example for specifying the counter label for i18n purposes:
 
 ```jsx
 <EmailInput counter={{ label: "E-mail" }} />

--- a/stories/Components/EmailInputDocs.mdx
+++ b/stories/Components/EmailInputDocs.mdx
@@ -1,0 +1,19 @@
+If you want to use `counter` prop on `EmailInput` component, then, please follow the below syntax.
+
+For the basic implementation, see the following example:
+
+```jsx
+<EmailInput counter />
+```
+
+For specifying the counter label for i18n purposes, see the following example:
+
+```jsx
+<EmailInput counter={{ label: "E-mail" }} />
+```
+
+For specifying the counter to start counting after a specific number of emails, then see the following example:
+
+```jsx
+<EmailInput counter={{ startsFrom: 3 }} />
+```

--- a/stories/Components/EmailInputDocs.mdx
+++ b/stories/Components/EmailInputDocs.mdx
@@ -4,13 +4,13 @@ For the basic implementation, see the following example:
 <EmailInput counter />
 ```
 
-Use the below example to show the counter only from a specific number:
+For specifying the counter label for i18n purposes, see the following example:
 
 ```jsx
 <EmailInput counter={{ label: "E-mail" }} />
 ```
 
-To start showing the counter label only from a specific number of emails, then see the following example:
+Use the below example to show the counter only from a specific number:
 
 ```jsx
 <EmailInput counter={{ startsFrom: 3 }} />

--- a/tests/EmailInput.test.js
+++ b/tests/EmailInput.test.js
@@ -43,14 +43,18 @@ describe("EmailInput", () => {
     expect(screen.getByText("Error message")).toBeInTheDocument();
   });
 
-  it("should not render email counter when the email count <= 3", () => {
-    render(<EmailInput counter value={SAMPLE_EMAILS.slice(2)} />);
-    expect(screen.queryByText("3 emails")).not.toBeInTheDocument();
+  it("should not render email counter when the email count start from 3 and count is 2", () => {
+    render(
+      <EmailInput counter={{ startsFrom: 3 }} value={SAMPLE_EMAILS.slice(3)} />
+    );
+    expect(screen.queryByText("2 emails")).not.toBeInTheDocument();
   });
 
-  it("should not render email counter when the email count > 3", () => {
-    render(<EmailInput counter value={SAMPLE_EMAILS.slice(1)} />);
-    expect(screen.getByText("4 emails")).toBeInTheDocument();
+  it("should render email counter when the email count start from 3 and count is 3", () => {
+    render(
+      <EmailInput counter={{ startsFrom: 3 }} value={SAMPLE_EMAILS.slice(2)} />
+    );
+    expect(screen.getByText("3 emails")).toBeInTheDocument();
   });
 
   it("should render default counter text when no label is provided", () => {

--- a/tests/EmailInput.test.js
+++ b/tests/EmailInput.test.js
@@ -3,6 +3,30 @@ import { EmailInput } from "../lib/components";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const SAMPLE_EMAILS = [
+  { label: "test@example.com", value: "test@example.com", valid: true },
+  {
+    label: "test2@example.com",
+    value: "test2@example.com",
+    valid: true,
+  },
+  {
+    label: "test3@example.com",
+    value: "test3@example.com",
+    valid: true,
+  },
+  {
+    label: "test4@example.com",
+    value: "test4@example.com",
+    valid: true,
+  },
+  {
+    label: "test5@example.com",
+    value: "test5@example.com",
+    valid: true,
+  },
+];
+
 describe("EmailInput", () => {
   it("should render without error", () => {
     render(<EmailInput />);
@@ -19,42 +43,23 @@ describe("EmailInput", () => {
     expect(screen.getByText("Error message")).toBeInTheDocument();
   });
 
-  it("should render correct number of emails", () => {
-    render(
-      <EmailInput
-        value={[
-          { label: "test@example.com", value: "test@example.com", valid: true },
-        ]}
-        counter={{ label: "email" }}
-      />
-    );
-    expect(screen.getByText("1 email")).toBeInTheDocument();
+  it("should not render email counter when the email count <= 3", () => {
+    render(<EmailInput counter value={SAMPLE_EMAILS.slice(2)} />);
+    expect(screen.queryByText("3 emails")).not.toBeInTheDocument();
+  });
+
+  it("should not render email counter when the email count > 3", () => {
+    render(<EmailInput counter value={SAMPLE_EMAILS.slice(1)} />);
+    expect(screen.getByText("4 emails")).toBeInTheDocument();
   });
 
   it("should render default counter text when no label is provided", () => {
     const { rerender } = render(
-      <EmailInput
-        value={[
-          { label: "test@example.com", value: "test@example.com", valid: true },
-        ]}
-        counter={{}}
-      />
+      <EmailInput counter value={SAMPLE_EMAILS.slice(1)} />
     );
-    expect(screen.getByText("1 email")).toBeInTheDocument();
-    rerender(
-      <EmailInput
-        value={[
-          { label: "test@example.com", value: "test@example.com", valid: true },
-          {
-            label: "test2@example.com",
-            value: "test2@example.com",
-            valid: true,
-          },
-        ]}
-        counter={{}}
-      />
-    );
-    expect(screen.getByText("2 emails")).toBeInTheDocument();
+    expect(screen.getByText("4 emails")).toBeInTheDocument();
+    rerender(<EmailInput counter value={SAMPLE_EMAILS} />);
+    expect(screen.getByText("5 emails")).toBeInTheDocument();
   });
 
   it("should call onBlur when focus from the input field changes", () => {


### PR DESCRIPTION
Fixes #1177 

**Description**
 - Added: `startsFrom` to `counter` prop of _EmailInput_ component.
 
**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@amaldinesh7 _a