### PR TITLE
Fixes issue with closeOnEsc in Pane.

### DIFF
--- a/lib/components/Pane/index.js
+++ b/lib/components/Pane/index.js
@@ -54,7 +54,16 @@ const Pane = ({
     closeOnOutsideClick ? onClose : noop
   );
 
-  useHotkeys("esc", closeOnEsc ? onClose : noop);
+  const onCloseRef = useRef();
+  onCloseRef.current = onClose;
+
+  useHotkeys(
+    "esc",
+    () => {
+      closeOnEsc ? onCloseRef.current() : noop();
+    },
+    [onCloseRef]
+  );
 
   return (
     <Portal rootId="neeto-ui-portal">


### PR DESCRIPTION
Fixes #1198
**Description**
- Fixed: issue with closeOnEsc prop when the Pane is controlled.

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@amaldinesh7 _A

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
