### PR TITLE
Add type support for all existing components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     logger: true,
     module: true,
     process: true,
+    JSX: true,
   },
   parserOptions: {
     ecmaFeatures: {
@@ -35,7 +36,8 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: "module",
   },
-  parser: "babel-eslint",
+  // babel-eslint is deprecated now. This is the latest package.
+  parser: "@babel/eslint-parser",
   plugins: ["react"],
   rules: {
     indent: [

--- a/formik.d.ts
+++ b/formik.d.ts
@@ -1,0 +1,33 @@
+import React from "react";
+import {
+  Input as PlainInput,
+  Radio as PlainRadio,
+  Switch as PlainSwitch,
+  Textarea as PlainTextarea,
+  Checkbox as PlainCheckbox,
+  Select as PlainSelect,
+  EmailInput as PlainEmailInput,
+  Button as PlainButton,
+  ButtonProps,
+} from "./index";
+
+export interface ActionBlockProps {
+  className?: string;
+  submitButtonProps: ButtonProps;
+  cancelButtonProps: ButtonProps;
+}
+export interface BlockNavigationProps {
+  isDirty: boolean;
+}
+
+export const ActionBlock: React.FC<ActionBlockProps>;
+export const BlockNavigation: React.FC<BlockNavigationProps>;
+
+export const Input: typeof PlainInput;
+export const Radio: typeof PlainRadio;
+export const Switch: typeof PlainSwitch;
+export const Textarea: typeof PlainTextarea;
+export const Checkbox: typeof PlainCheckbox;
+export const Select: typeof PlainSelect;
+export const EmailInput: typeof PlainEmailInput;
+export const Button: typeof PlainButton;

--- a/formik.d.ts
+++ b/formik.d.ts
@@ -13,11 +13,11 @@ import {
 
 export interface ActionBlockProps {
   className?: string;
-  submitButtonProps: ButtonProps;
-  cancelButtonProps: ButtonProps;
+  submitButtonProps?: ButtonProps;
+  cancelButtonProps?: ButtonProps;
 }
 export interface BlockNavigationProps {
-  isDirty: boolean;
+  isDirty?: boolean;
 }
 
 export const ActionBlock: React.FC<ActionBlockProps>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface AccordionProps {
 }
 
 export interface AccordionItemProps {
-  id: string;
+  id?: string;
   title?: string;
   isOpen?: boolean;
   onClick?: () => void;
@@ -66,7 +66,7 @@ export type RadioItemProps = { label: string } & React.DetailedHTMLProps<
 >;
 
 export type TabProps = {
-  size: "large" | "default";
+  size?: "large" | "default";
   noUnderline?: boolean;
   className?: string;
 } & React.DetailedHTMLProps<
@@ -75,7 +75,7 @@ export type TabProps = {
 >;
 
 export type TabItemProps<S> = {
-  active: boolean;
+  active?: boolean;
   className?: string;
   icon?: string | React.ReactNode;
   onClick?: () => void;
@@ -125,10 +125,10 @@ export type AvatarProps = {
 
 export interface ButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  icon?: string | JSX.Element;
+  icon?: string | React.ReactNode;
   iconPosition?: "left" | "right";
   iconSize?: number;
-  label: string;
+  label?: string;
   loading?: boolean;
   to?: string;
   type?: "button" | "reset" | "submit";
@@ -163,8 +163,8 @@ export type CheckboxProps = {
 >;
 
 export type DatePickerProps = {
-  defaultValue: any;
   value: any;
+  defaultValue?: any;
   className?: string;
   label?: string;
   size?: "small" | "large";
@@ -301,7 +301,7 @@ export type SelectProps = {
 };
 
 export type SpinnerProps = {
-  theme: "dark" | "light";
+  theme?: "dark" | "light";
   className?: string;
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,173 @@
+import React from "react";
+
+export interface AccordionProps {
+  className?: string;
+  defaultActiveKey?: number;
+  padded?: boolean;
+  style?: "primary" | "secondary";
+}
+
+export interface AccordionItemProps {
+  id: string;
+  title?: string;
+  isOpen?: boolean;
+  onClick?: () => void;
+  className?: string;
+  titleProps?: React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+  iconProps?: React.SVGProps<SVGSVGElement>;
+}
+
+export interface ColorPickerProps {
+  color: string;
+  onChange: (color: string) => void;
+  colorPaletteProps?: {
+    color: { from: string; to: string };
+    colorList: { from: string; to: string }[];
+    onChange: (from: string, to: string) => void;
+  };
+}
+
+interface PopupProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+  className?: string;
+  closeOnEsc?: boolean;
+  closeButton?: boolean;
+  backdropClassName?: string;
+  closeOnOutsideClick?: boolean;
+  [key: string]: any;
+}
+
+interface PopupContentProps {
+  className?: string;
+}
+
+export type ModalProps = PopupProps & { size?: "xs" | "sm" | "md" };
+
+export type PaneProps = PopupProps & { size?: "sm" | "lg" };
+
+export interface RadioProps {
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  label?: string;
+  stacked?: boolean;
+  className?: string;
+  containerClassName?: string;
+  error?: string;
+  id?: any;
+  value?: any;
+}
+
+export type RadioItemProps = { label: string } & React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>;
+
+export type TabProps = {
+  size: "large" | "default";
+  noUnderline?: boolean;
+  className?: string;
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+export type TabItemProps<S> = {
+  active: boolean;
+  className?: string;
+  icon?: string | React.ReactNode;
+  onClick?: () => void;
+  activeClassName?: string;
+  [key: string]: any;
+};
+
+export interface TooltipProps {
+  content: React.ReactNode;
+  theme?: "dark" | "light";
+  disabled?: boolean;
+  position?:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "bottom"
+    | "right"
+    | "left"
+    | "auto"
+    | "top-start"
+    | "top-end"
+    | "bottom-start"
+    | "bottom-end"
+    | "right-start"
+    | "right-end"
+    | "left-start"
+    | "left-end";
+  interactive?: boolean;
+  hideAfter?: number;
+  hideOnTargetExit?: boolean;
+}
+
+export interface ButtonProps {
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  icon?: string | JSX.Element;
+  iconPosition?: "left" | "right";
+  iconSize?: number;
+  label: string;
+  loading?: boolean;
+  to?: string;
+  type?: "button" | "reset" | "submit";
+  style?: "primary" | "secondary" | "danger" | "danger-text" | "text" | "link";
+  fullWidth?: boolean;
+  className?: string;
+  disabled?: boolean;
+  size?: "large" | "xlarge" | "default";
+  href?: string;
+  tooltipProps?: TooltipProps;
+  [key: string]: any;
+}
+
+// components
+
+export const Accordion: React.FC<AccordionProps> & {
+  Item: React.FC<AccordionItemProps>;
+};
+export const Modal: React.FC<ModalProps> & {
+  Header: React.FC<PopupContentProps>;
+  Body: React.FC<PopupContentProps>;
+  Footer: React.FC<PopupContentProps>;
+};
+export const Pane: React.FC<PaneProps> & {
+  Header: React.FC<PopupContentProps>;
+  Body: React.FC<PopupContentProps & { hasFooter?: boolean }>;
+  Footer: React.FC<PopupContentProps>;
+};
+export const Radio: React.FC<RadioProps> & {
+  Item: React.FC<RadioItemProps>;
+};
+export const Tab: React.FC<TabProps> & {
+  Item: React.FC<TabItemProps<any>>;
+};
+
+type ToastrFunction = (
+  message: React.ReactNode,
+  buttonLabel: React.ReactNode,
+  onClick: () => void
+) => void;
+
+export const Toastr: {
+  show: ToastrFunction;
+  info: ToastrFunction;
+  success: ToastrFunction;
+  error: (
+    message: React.ReactNode | Error,
+    buttonLabel: React.ReactNode,
+    onClick: () => void
+  ) => void;
+  warning: ToastrFunction;
+};
+
+export const ColorPicker: React.FC<ColorPickerProps>;
+export const Button: React.ForwardRefExoticComponent<ButtonProps>;
+export const Tooltip: React.ForwardRefExoticComponent<TooltipProps>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ export type CalloutProps = {
   HTMLDivElement
 >;
 
-export type CheckBoxProps = {
+export type CheckboxProps = {
   label?: string;
   error?: string;
   className?: string;
@@ -515,7 +515,7 @@ export const Alert: React.FC<AlertProps>;
 export const Avatar: React.FC<AvatarProps>;
 export const Button: React.FC<ButtonProps>;
 export const Callout: React.FC<CalloutProps>;
-export const CheckBox: React.FC<CheckBoxProps>;
+export const Checkbox: React.FC<CheckboxProps>;
 export const DatePicker: React.FC<DatePickerProps>;
 export const Dropdown: React.FC<DropdownProps>;
 export const EmailInput: React.FC<EmailInputProps>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -217,7 +217,7 @@ export interface DropdownProps {
   closeOnSelect?: boolean;
   closeOnOutsideClick?: boolean;
   dropdownModifiers?: any[];
-  trigger?: "click" | "mouseenter focus";
+  trigger?: "click" | "hover";
   strategy?: "absolute" | "fixed";
   onClick?: () => void;
   [key: string]: any;
@@ -421,7 +421,7 @@ export interface TooltipProps {
 }
 
 export type TypographyProps = {
-  style?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
+  style?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body1" | "body2" | "body3";
   weight?:
     | "thin"
     | "extralight"

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ export type TabProps = {
 export type TabItemProps<S> = {
   active?: boolean;
   className?: string;
-  icon?: string | React.ReactNode;
+  icon?: string | any;
   onClick?: () => void;
   activeClassName?: string;
   [key: string]: any;
@@ -125,7 +125,7 @@ export type AvatarProps = {
 
 export interface ButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  icon?: string | React.ReactNode;
+  icon?: string | any;
   iconPosition?: "left" | "right";
   iconSize?: number;
   label?: string;
@@ -184,7 +184,7 @@ export type DatePickerProps = {
 };
 
 export interface DropdownProps {
-  icon?: string | React.ReactNode;
+  icon?: string | any;
   label?: React.ReactNode;
   isOpen?: boolean;
   onClose?: () => void;
@@ -262,7 +262,7 @@ export type LabelProps = {
   required?: boolean;
   helpIconProps?: {
     onClick?: () => void;
-    icon?: React.ReactNode;
+    icon?: any;
     tooltipProps?: TooltipProps;
     className?: string;
   } & React.SVGProps<SVGSVGElement>;
@@ -347,7 +347,7 @@ export interface TableProps {
 }
 
 export interface TagProps {
-  icon?: string | React.ReactNode;
+  icon?: string | any;
   size?: "small" | "large";
   label?: string;
   style?: "outline" | "solid";

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,317 @@ export type TabItemProps<S> = {
   [key: string]: any;
 };
 
+export interface ActionDropdownProps {
+  label?: string;
+  style?: "primary" | "secondary";
+  size?: "large" | "default";
+  disabled?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  className?: string;
+  buttonProps?: ButtonProps;
+  dropdownProps?: DropdownProps;
+}
+
+export interface AlertProps {
+  size?: "xs" | "sm" | "md";
+  isOpen?: boolean;
+  isSubmitting?: boolean;
+  className?: string;
+  closeOnEsc?: boolean;
+  closeButton?: boolean;
+  backdropClassName?: string;
+  closeOnOutsideClick?: boolean;
+  onClose?: () => void;
+  onSubmit?: () => void;
+  title?: string;
+  message?: string;
+  submitButtonLabel?: string;
+  cancelButtonLabel?: string;
+}
+
+export type AvatarProps = {
+  size?: "small" | "medium" | "large" | "xlarge";
+  user?: { name: string; imageUrl: string };
+  isSquare?: boolean;
+  status?: "online" | "idle" | "offline";
+  onClick?: React.MouseEventHandler<HTMLSpanElement>;
+  className?: string;
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLSpanElement>,
+  HTMLSpanElement
+>;
+
+export interface ButtonProps {
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  icon?: string | JSX.Element;
+  iconPosition?: "left" | "right";
+  iconSize?: number;
+  label: string;
+  loading?: boolean;
+  to?: string;
+  type?: "button" | "reset" | "submit";
+  style?: "primary" | "secondary" | "danger" | "danger-text" | "text" | "link";
+  fullWidth?: boolean;
+  className?: string;
+  disabled?: boolean;
+  size?: "large" | "xlarge" | "default";
+  href?: string;
+  tooltipProps?: TooltipProps;
+  [key: string]: any;
+}
+
+export type CalloutProps = {
+  icon?: React.SVGProps<SVGSVGElement>;
+  style?: "info" | "warning" | "danger" | "success";
+  className?: string;
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+export type CheckBoxProps = {
+  label?: string;
+  error?: string;
+  className?: string;
+  required?: false;
+  id?: string;
+} & React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>;
+
+export type DatePickerProps = {
+  defaultValue: any;
+  value: any;
+  className?: string;
+  label?: string;
+  size?: "small" | "large";
+  dropdownClassName?: string;
+  dateFormat?: string;
+  timeFormat?: string;
+  onChange?: (date: any, dateString: string) => void;
+  onOk?: () => void;
+  picker?: "date" | "week" | "month" | "quarter" | "year";
+  showTime?: boolean;
+  type?: "range" | "date";
+  nakedInput?: boolean;
+  error?: string;
+  id?: string;
+  disabled?: boolean;
+  [key: string]: any;
+};
+
+export interface DropdownProps {
+  icon?: string | React.ReactNode;
+  label?: React.ReactNode;
+  isOpen?: boolean;
+  onClose?: () => void;
+  ulProps?: React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLUListElement>,
+    HTMLUListElement
+  >;
+  position?:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
+  className?: string;
+  buttonStyle?: "primary" | "secondary" | "text";
+  buttonProps?: ButtonProps;
+  customTarget?: React.ReactNode | (() => React.ReactNode);
+  disabled?: boolean;
+  closeOnEsc?: boolean;
+  closeOnSelect?: boolean;
+  closeOnOutsideClick?: boolean;
+  dropdownModifiers?: any[];
+  trigger?: "click" | "mouseenter focus";
+  strategy?: "absolute" | "fixed";
+  onClick?: () => void;
+  [key: string]: any;
+}
+
+export interface EmailInputProps {
+  label?: string;
+  placeholder?: string;
+  helpText?: string;
+  value?: { label: string; value: string; valid: boolean }[];
+  onChange?: (
+    emails: { label: string; value: string; valid: boolean }[]
+  ) => void;
+  error?: string;
+  onBlur?: () => void;
+  filterInvalidEmails?: { label: string };
+  counter?: boolean | { label: string; startFrom: number };
+  disabled?: boolean;
+  maxHeight?: number;
+  [key: string]: any;
+}
+
+export type InputProps = {
+  size?: "small" | "large";
+  label?: string;
+  error?: string;
+  suffix?: React.ReactNode;
+  prefix?: React.ReactNode;
+  disabled?: boolean;
+  helpText?: string;
+  className?: string;
+  nakedInput?: boolean;
+  contentSize?: number;
+  required?: boolean;
+} & React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>;
+
+export type LabelProps = {
+  className?: string;
+  required?: boolean;
+  helpIconProps?: {
+    onClick?: () => void;
+    icon?: React.ReactNode;
+    tooltipProps?: TooltipProps;
+    className?: string;
+  } & React.SVGProps<SVGSVGElement>;
+} & React.DetailedHTMLProps<
+  React.LabelHTMLAttributes<HTMLLabelElement>,
+  HTMLLabelElement
+>;
+
+export type PageLoaderProps = { text?: string } & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+export interface PaginationProps {
+  pageSize: number;
+  count: number;
+  navigate: (toPage: number) => void;
+  pageNo?: number;
+  siblingCount?: number;
+  className?: string;
+}
+
+export type SelectProps = {
+  size?: "small" | "large";
+  label?: string;
+  required?: boolean;
+  error?: string;
+  helpText?: string;
+  className?: string;
+  innerRef?: React.Ref<HTMLSelectElement>;
+  isCreateable?: boolean;
+  strategy?: "default" | "fixed";
+  id?: string;
+  loadOptions?: boolean;
+  [key: string]: any;
+};
+
+export type SpinnerProps = {
+  theme: "dark" | "light";
+  className?: string;
+};
+
+export type SwitchProps = {
+  label?: string;
+  required?: boolean;
+  className?: string;
+  error?: string;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  checked?: boolean;
+  disabled?: boolean;
+} & React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>;
+
+export interface TableProps {
+  rowData: any[];
+  columnData: any[];
+  allowRowClick?: boolean;
+  className?: string;
+  currentPageNumber?: number;
+  defaultPageSize?: number;
+  handlePageChange?: (page: number, pageSize: number) => void;
+  loading?: boolean;
+  onRowClick?: (
+    event: React.MouseEvent<any, MouseEvent>,
+    record: any,
+    rowIndex: number
+  ) => void;
+  onRowSelect?: (selectedRowKeys: React.Key[], selectedRows: any[]) => void;
+  totalCount?: number;
+  selectedRowKeys?: React.Key[];
+  fixedHeight?: boolean;
+  paginationProps?: any;
+  scroll?: {
+    x?: string | number | true;
+    y?: string | number;
+    scrollToFirstRowOnChange?: boolean;
+  };
+  rowSelection?: any;
+  [key: string]: any;
+}
+
+export interface TagProps {
+  icon?: string | React.ReactNode;
+  size?: "small" | "large";
+  label?: string;
+  style?: "outline" | "solid";
+  onClose?: () => void;
+  disabled?: boolean;
+  className?: string;
+  color?: "green" | "yellow" | "red" | "blue" | "gray";
+  indicatorColor?: "green" | "yellow" | "red" | "blue" | "gray";
+}
+
+export type TextareaProps = {
+  rows?: number;
+  disabled?: boolean;
+  required?: boolean;
+  nakedTextarea?: boolean;
+  helpText?: string;
+  error?: string;
+  label?: string;
+  className?: string;
+  maxLength?: number;
+} & React.DetailedHTMLProps<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  HTMLTextAreaElement
+>;
+
+export type TimePickerProps = {
+  className?: string;
+  label?: string;
+  format?: string;
+  size?: "small" | "large";
+  interval?: {
+    hourStep: number;
+    minuteStep: number;
+    secondStep: number;
+  };
+  onChange?: (value: string) => void;
+  type?: "time" | "range";
+  nakedInput?: boolean;
+  disabled?: boolean;
+  error?: string;
+  defaultValue?: any;
+  value?: any;
+  id?: string;
+  [key: string]: any;
+};
+
 export interface TooltipProps {
   content: React.ReactNode;
   theme?: "dark" | "light";
@@ -109,24 +420,53 @@ export interface TooltipProps {
   hideOnTargetExit?: boolean;
 }
 
-export interface ButtonProps {
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  icon?: string | JSX.Element;
-  iconPosition?: "left" | "right";
-  iconSize?: number;
-  label: string;
-  loading?: boolean;
-  to?: string;
-  type?: "button" | "reset" | "submit";
-  style?: "primary" | "secondary" | "danger" | "danger-text" | "text" | "link";
-  fullWidth?: boolean;
+export type TypographyProps = {
+  style?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
+  weight?:
+    | "thin"
+    | "extralight"
+    | "light"
+    | "normal"
+    | "medium"
+    | "semibold"
+    | "bold"
+    | "extrabold"
+    | "black";
+  lineHeight?: "none" | "tight" | "snug" | "normal" | "relaxed" | "loose";
+  component?:
+    | "h1"
+    | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    | "p"
+    | "span"
+    | "b"
+    | "strong"
+    | "i"
+    | "em"
+    | "mark"
+    | "del"
+    | "s"
+    | "ins"
+    | "sub"
+    | "sup"
+    | "u"
+    | "code"
+    | "blockquote";
+  textTransform?:
+    | "none"
+    | "capitalize"
+    | "uppercase"
+    | "lowercase"
+    | "fullwidth"
+    | "inherit"
+    | "initial"
+    | "revert"
+    | "unset";
   className?: string;
-  disabled?: boolean;
-  size?: "large" | "xlarge" | "default";
-  href?: string;
-  tooltipProps?: TooltipProps;
-  [key: string]: any;
-}
+} & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
 
 // components
 
@@ -169,5 +509,26 @@ export const Toastr: {
 };
 
 export const ColorPicker: React.FC<ColorPickerProps>;
-export const Button: React.ForwardRefExoticComponent<ButtonProps>;
+
+export const ActionDropdown: React.FC<ActionDropdownProps>;
+export const Alert: React.FC<AlertProps>;
+export const Avatar: React.FC<AvatarProps>;
+export const Button: React.FC<ButtonProps>;
+export const Callout: React.FC<CalloutProps>;
+export const CheckBox: React.FC<CheckBoxProps>;
+export const DatePicker: React.FC<DatePickerProps>;
+export const Dropdown: React.FC<DropdownProps>;
+export const EmailInput: React.FC<EmailInputProps>;
+export const Input: React.ForwardRefExoticComponent<InputProps>;
+export const Label: React.FC<LabelProps>;
+export const PageLoader: React.FC<PageLoaderProps>;
+export const Pagination: React.FC<PaginationProps>;
+export const Select: React.ForwardRefExoticComponent<SelectProps>;
+export const Spinner: React.FC<SpinnerProps>;
+export const Switch: React.ForwardRefExoticComponent<SwitchProps>;
+export const Table: React.FC<TableProps>;
+export const Tag: React.FC<TagProps>;
+export const Textarea: React.ForwardRefExoticComponent<TextareaProps>;
+export const TimePicker: React.FC<TimePickerProps>;
+export const Typography: React.ForwardRefExoticComponent<TypographyProps>;
 export const Tooltip: React.ForwardRefExoticComponent<TooltipProps>;

--- a/layouts.d.ts
+++ b/layouts.d.ts
@@ -49,14 +49,14 @@ export type ScrollableProps = {
 type NavLinkItemType = {
   to: string;
   label?: React.ReactNode;
-  icon?: React.ReactNode;
+  icon?: any;
   description?: React.ReactNode;
 } & React.PropsWithoutRef<NavLinkProps<any>> &
   React.RefAttributes<HTMLAnchorElement>;
 
 type FooterLinkType = {
   label?: React.ReactNode;
-  icon?: React.ReactNode;
+  icon?: any;
   href?: string;
   to?: string;
 } & React.DetailedHTMLProps<
@@ -67,9 +67,9 @@ type FooterLinkType = {
   React.RefAttributes<HTMLAnchorElement>;
 
 type LinkType = {
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   label: React.ReactNode;
-  icon: React.ReactNode;
+  icon?: any;
 } & React.DetailedHTMLProps<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
@@ -112,4 +112,4 @@ export const Header: React.FC<HeaderProps>;
 export const MenuBar: React.FC<MenuBarProps>;
 export const Scrollable: React.FC<ScrollableProps>;
 export const Sidebar: React.FC<SidebarProps>;
-export const SubHeader: any;
+export const SubHeader: React.FC<SubHeaderProps>;

--- a/layouts.d.ts
+++ b/layouts.d.ts
@@ -1,0 +1,115 @@
+import React from "react";
+import { NavLinkProps } from "react-router-dom";
+import { AvatarProps, InputProps } from "./index";
+
+export interface AppSwitcherProps {
+  size?: "lg" | "sm";
+  isOpen?: boolean;
+  className?: string;
+  closeOnEsc?: boolean;
+  closeOnOutsideClick?: boolean;
+  environment?: "development" | "staging" | "production";
+  activeApp?: string;
+  subdomain?: string;
+  neetoApps?: string[];
+  recentApps?: string[];
+  isSidebarOpen?: boolean;
+  onClose?: () => void;
+  [key: string]: any;
+}
+
+export interface ContainerProps {
+  isHeaderFixed?: boolean;
+}
+
+export interface HeaderProps {
+  title?: React.ReactNode;
+  menuBarToggle?: () => void;
+  searchProps?: InputProps;
+  className?: string;
+  actionBlock?: React.ReactNode;
+  breadcrumbs?: { text: React.ReactNode; link: string }[];
+}
+
+export interface MenuBarProps {
+  title?: string;
+  className?: string;
+  showMenu?: boolean;
+  "data-cy"?: string;
+}
+
+export type ScrollableProps = {
+  className?: string;
+  size?: "small" | "large" | "viewport";
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+type NavLinkItemType = {
+  to: string;
+  label?: React.ReactNode;
+  icon?: React.ReactNode;
+  description?: React.ReactNode;
+} & React.PropsWithoutRef<NavLinkProps<any>> &
+  React.RefAttributes<HTMLAnchorElement>;
+
+type FooterLinkType = {
+  label?: React.ReactNode;
+  icon?: React.ReactNode;
+  href?: string;
+  to?: string;
+} & React.DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+> &
+  React.PropsWithoutRef<NavLinkProps<any>> &
+  React.RefAttributes<HTMLAnchorElement>;
+
+type LinkType = {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  label: React.ReactNode;
+  icon: React.ReactNode;
+} & React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
+
+export interface SidebarProps {
+  organizationInfo?: {
+    logo?: React.ReactNode;
+    name?: React.ReactNode;
+    subdomain?: React.ReactNode;
+  };
+  navLinks?: NavLinkItemType[];
+  tooltipStyle?: "default" | "featured";
+  footerLinks?: FooterLinkType[];
+  profileInfo?: {
+    name?: string;
+    email?: string;
+    topLinks?: LinkType[];
+    bottomLinks?: LinkType[];
+    customContent?: React.ReactNode;
+    changelogProps?: LinkType;
+    helpProps?: LinkType;
+    "data-cy"?: string;
+  } & AvatarProps;
+  isCollapsed?: boolean;
+  showAppSwitcher?: boolean;
+  onAppSwitcherToggle?: React.MouseEventHandler<HTMLButtonElement>;
+  appName?: string;
+}
+
+export interface SubHeaderProps {
+  className?: string;
+  leftActionBlock?: React.ReactNode;
+  rightActionBlock?: React.ReactNode;
+}
+
+export const AppSwitcher: React.FC<AppSwitcherProps>;
+export const Container: React.ForwardRefExoticComponent<ContainerProps>;
+export const Header: React.FC<HeaderProps>;
+export const MenuBar: React.FC<MenuBarProps>;
+export const Scrollable: React.FC<ScrollableProps>;
+export const Sidebar: React.FC<SidebarProps>;
+export const SubHeader: any;

--- a/molecules.d.ts
+++ b/molecules.d.ts
@@ -1,0 +1,21 @@
+import React from "react";
+import { ButtonProps, SelectProps, TagProps } from "./index";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+export interface TagsProps {
+  label?: string;
+  allTags?: Option[];
+  selectedTags?: Option[];
+  onTagSelect?: (e: any) => void;
+  onTagCreate?: (e: any) => void;
+  onTagDelete?: (e: any) => void;
+  tagProps?: TagProps;
+  selectProps?: SelectProps;
+  buttonProps?: ButtonProps;
+}
+
+export const Tags: React.FC<TagsProps>;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.12",
   "main": "./index.js",
   "module": "./index.js",
+  "types": "./index.d.ts",
   "author": "BigBinary",
   "license": "MIT",
   "description": "neetoUI is the library that drives the experience in all neeto products built at BigBinary",
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.11.6",
+    "@babel/eslint-parser": "^7.18.9",
     "@babel/plugin-transform-runtime": "7.17.0",
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
@@ -61,7 +63,6 @@
     "@testing-library/react": "12.1.3",
     "@testing-library/user-event": "13.5.0",
     "autoprefixer": "9.0.0",
-    "babel-eslint": "10.1.0",
     "babel-jest": "27.3.1",
     "babel-loader": "8.1.0",
     "chromatic": "6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,15 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
+"@babel/eslint-parser@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.18.9.tgz#255a63796819a97b7578751bb08ab9f2a375a031"
+  integrity sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==
+  dependencies:
+    eslint-scope "^5.1.1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.17.9", "@babel/generator@^7.7.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.9.tgz#f4af9fd38fa8de143c29fce3f71852406fc1e2fc"
@@ -462,7 +471,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.16.7", "@babel/parser@^7.17.9", "@babel/parser@^7.7.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.16.7", "@babel/parser@^7.17.9":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
   integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
@@ -1773,7 +1782,7 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/traverse@^7.1.6", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.1.6", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9", "@babel/traverse@^7.7.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.9.tgz#1f9b207435d9ae4a8ed6998b2b82300d83c37a0d"
   integrity sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==
@@ -1805,7 +1814,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.14.5", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.14.5", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
@@ -4857,18 +4866,6 @@ autoprefixer@^9, autoprefixer@^9.6.1, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-babel-eslint@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
-
 babel-jest@27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.3.1.tgz#0636a3404c68e07001e434ac4956d82da8a80022"
@@ -7321,12 +7318,12 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint-visitor-keys@^2.0.0:
+eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==


### PR DESCRIPTION
Fixes #1233 

**Description**
- Added: type support for all exported components. IDE will now auto-predict the component props.
- Changed: Deprecated babel-eslint was replaced with @babel/eslint-parser

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@amaldinesh7 _a we are going to add type support for all frontend packages. neetoui is a good start

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
