### PR TITLE
Updated Pane story to handle `closeOnEsc` properly

### DIFF
--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -56,7 +56,7 @@ const Modal = ({
     () => {
       closeOnEsc ? onCloseRef.current() : noop();
     },
-    [onCloseRef]
+    [onCloseRef, closeOnEsc]
   );
 
   return (

--- a/lib/components/Pane/index.js
+++ b/lib/components/Pane/index.js
@@ -62,7 +62,7 @@ const Pane = ({
     () => {
       closeOnEsc ? onCloseRef.current() : noop();
     },
-    [onCloseRef]
+    [onCloseRef, closeOnEsc]
   );
 
   return (

--- a/stories/Overlays/Pane.stories.jsx
+++ b/stories/Overlays/Pane.stories.jsx
@@ -90,7 +90,7 @@ export const PaneWithModalAndAlert = () => {
         </div>
       </div>
 
-      <Pane isOpen={showPane} onClose={() => setShowPane(false)}>
+      <Pane isOpen={showPane} onClose={() => setShowPane(false)} closeOnEsc={!(showModal || showAlert)}>
         <Pane.Header>
           <Typography style="h2" weight="semibold">
             Typography


### PR DESCRIPTION
Fixes #issue-number

**Description**

- Changed: Added `closeOnEsc` prop to `useHotkeys` hook dependencies

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
