### PR TITLE
Allowed `hideOnSinglePage` override in `Table`

### DIFF
--- a/example/src/Pages/Layouts.js
+++ b/example/src/Pages/Layouts.js
@@ -228,7 +228,7 @@ const Layouts = () => {
           iconProps={[
             {
               icon: () => <Search size={20} />,
-              onClick: () => setIsSearchCollapsed(!isSearchCollapsed),
+              onClick: () => setIsSearchCollapsed(isSearchCollapsed => !isSearchCollapsed),
             },
           ]}
         >

--- a/lib/components/Table.js
+++ b/lib/components/Table.js
@@ -113,13 +113,13 @@ const Table = ({
       }}
       showSorterTooltip={false}
       pagination={{
+        hideOnSinglePage: true,
+        ...paginationProps,
         total: totalCount ?? 0,
         current: currentPageNumber ?? 1,
         defaultPageSize: defaultPageSize ?? 100,
         onChange: handlePageChange,
-        hideOnSinglePage: true,
         itemRender: itemRender,
-        ...paginationProps,
       }}
       onRow={(record, rowIndex) => {
         return {

--- a/lib/components/Table.js
+++ b/lib/components/Table.js
@@ -113,13 +113,13 @@ const Table = ({
       }}
       showSorterTooltip={false}
       pagination={{
-        ...paginationProps,
         total: totalCount ?? 0,
         current: currentPageNumber ?? 1,
         defaultPageSize: defaultPageSize ?? 100,
         onChange: handlePageChange,
         hideOnSinglePage: true,
         itemRender: itemRender,
+        ...paginationProps,
       }}
       onRow={(record, rowIndex) => {
         return {

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -438,7 +438,7 @@ export const TableInLayout = (args) => {
           iconProps={[
             {
               icon: () => <Search size={20} />,
-              onClick: () => setIsSearchCollapsed(!isSearchCollapsed),
+              onClick: () => setIsSearchCollapsed(isSearchCollapsed => !isSearchCollapsed),
             },
           ]}
         >

--- a/stories/Layouts.stories.jsx
+++ b/stories/Layouts.stories.jsx
@@ -226,7 +226,7 @@ export const Page = () => {
           iconProps={[
             {
               icon: Search,
-              onClick: () => setIsSearchCollapsed(!isSearchCollapsed),
+              onClick: () => setIsSearchCollapsed(isSearchCollapsed => !isSearchCollapsed),
             },
           ]}
         >

--- a/stories/Layouts/MenuBar.stories.jsx
+++ b/stories/Layouts/MenuBar.stories.jsx
@@ -39,7 +39,7 @@ export const MenuBarStory = () => {
           iconProps={[
             {
               icon: Search,
-              onClick: () => setIsSearchCollapsed(!isSearchCollapsed),
+              onClick: () => setIsSearchCollapsed(isSearchCollapsed => !isSearchCollapsed),
             },
           ]}
         >


### PR DESCRIPTION
Fixes #1316 
Fixes #1315 

**Description**

- Changed: Allowed `hideOnSinglePage` override in _Table_ `paginationProps`

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@amaldinesh7 _a Please review

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
