### PR TITLE
Changed action block button label to sentence case

### DIFF
--- a/lib/components/formik/ActionBlock.js
+++ b/lib/components/formik/ActionBlock.js
@@ -19,7 +19,7 @@ const ActionBlock = ({ className, submitButtonProps, cancelButtonProps }) => {
     <div className={classnames(["neeto-ui-action-block__wrapper", className])}>
       <SubmitButton
         style="primary"
-        label="Save Changes"
+        label="Save changes"
         type="submit"
         data-test-id="save-changes-button"
         data-cy="save-changes-button"


### PR DESCRIPTION
Fixes #1354 

**Description**
- Changed action block button label to sentence case.

**Checklist**
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
- @amaldinesh7 