### PR TITLE
Adds ability to pass config to toastr

### DIFF
--- a/lib/components/Toastr/index.js
+++ b/lib/components/Toastr/index.js
@@ -39,12 +39,26 @@ const TOAST_ICON = {
 
 const toastrList = new UniqueArray();
 
+const parseToastrConfig = (config) => {
+  if (typeof config[0] === "object") {
+    const {
+      buttonLabel,
+      onClick,
+      ...customConfig
+    } = config[0];
+    return { buttonLabel, onClick, customConfig };
+  } else {
+    const [buttonLabel, onClick, customConfig] = config;
+    return { buttonLabel, onClick, customConfig };
+  }
+};
+
 const withUniqueCheck = (type, toastFunc) => (
   message,
-  buttonLabel,
-  onClick,
-  customConfig = {},
+  ...toastrConfig
 ) => {
+  const {buttonLabel, onClick, customConfig = {}} = parseToastrConfig(toastrConfig);
+
   if (toastrList.add({ type, message, buttonLabel })) {
     const config = {
       ...TOAST_CONFIG,
@@ -104,9 +118,7 @@ const isString = (s) => typeof s === "string" || s instanceof String;
 
 const withParsedErrorMsg = (toastrFunc) => (
   errorObject,
-  buttonLabel,
-  onClick,
-  customConfig = {},
+  ...toastrConfig
 ) => {
   let errorMessage;
   if (isAxiosError(errorObject)) {
@@ -117,7 +129,11 @@ const withParsedErrorMsg = (toastrFunc) => (
   else if (isString(errorObject)) errorMessage = errorObject;
   else errorMessage = "Something went wrong.";
 
-  toastrFunc(errorMessage, buttonLabel, onClick, {
+  const { buttonLabel, onClick, customConfig } = parseToastrConfig(toastrConfig);
+
+  toastrFunc(errorMessage, {
+    buttonLabel,
+    onClick,
     role: "alert",
     autoClose: 7000,
     ...customConfig

--- a/lib/components/Toastr/index.js
+++ b/lib/components/Toastr/index.js
@@ -106,7 +106,7 @@ const withParsedErrorMsg = (toastrFunc) => (
   errorObject,
   buttonLabel,
   onClick,
-  customConfig,
+  customConfig = {},
 ) => {
   let errorMessage;
   if (isAxiosError(errorObject)) {

--- a/lib/components/Toastr/index.js
+++ b/lib/components/Toastr/index.js
@@ -117,7 +117,11 @@ const withParsedErrorMsg = (toastrFunc) => (
   else if (isString(errorObject)) errorMessage = errorObject;
   else errorMessage = "Something went wrong.";
 
-  toastrFunc(errorMessage, buttonLabel, onClick, customConfig);
+  toastrFunc(errorMessage, buttonLabel, onClick, {
+    role: "alert",
+    autoClose: 7000,
+    ...customConfig
+  });
 };
 
 const showErrorToastr = withParsedErrorMsg(
@@ -129,11 +133,7 @@ const showErrorToastr = withParsedErrorMsg(
         buttonLabel={buttonLabel}
         onClick={onClick}
       />,
-      {
-        ...config,
-        role: "alert",
-        autoClose: 7000,
-      }
+      config,
     )
   )
 );

--- a/lib/components/Toastr/index.js
+++ b/lib/components/Toastr/index.js
@@ -42,13 +42,15 @@ const toastrList = new UniqueArray();
 const withUniqueCheck = (type, toastFunc) => (
   message,
   buttonLabel,
-  onClick
+  onClick,
+  customConfig = {},
 ) => {
   if (toastrList.add({ type, message, buttonLabel })) {
     const config = {
       ...TOAST_CONFIG,
       icon: TOAST_ICON[type],
       onClose: () => toastrList.remove({ type, message, buttonLabel }),
+      ...customConfig,
     };
     toastFunc({ message, buttonLabel, onClick, config });
   }
@@ -103,7 +105,8 @@ const isString = (s) => typeof s === "string" || s instanceof String;
 const withParsedErrorMsg = (toastrFunc) => (
   errorObject,
   buttonLabel,
-  onClick
+  onClick,
+  customConfig,
 ) => {
   let errorMessage;
   if (isAxiosError(errorObject)) {
@@ -114,7 +117,7 @@ const withParsedErrorMsg = (toastrFunc) => (
   else if (isString(errorObject)) errorMessage = errorObject;
   else errorMessage = "Something went wrong.";
 
-  toastrFunc(errorMessage, buttonLabel, onClick);
+  toastrFunc(errorMessage, buttonLabel, onClick, customConfig);
 };
 
 const showErrorToastr = withParsedErrorMsg(

--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -63,33 +63,6 @@ export const Toastrs = () => {
               )
             }
           />
-          <Button
-            label="Custom config 1"
-            onClick={() =>
-              Toastr.info(
-                "This toastr has a custom configuration along with buttonLabel and onClick callback as separate arguments",
-                "Okay",
-                () => {},
-                {
-                  hideProgressBar: false,
-                  duration: 5000,
-                }
-              )
-            }
-          />
-          <Button
-            label="Custom config 2"
-            onClick={() =>
-              Toastr.show(
-                "This toastr has a custom configuration passed which includes buttonLabel and onClick in the same config object",
-                {
-                  buttonLabel: "Custom button label impl 2",
-                  onClick: () => {},
-                  duration: 3000,
-                }
-              )
-            }
-          />
         </div>
       </div>
     </>
@@ -156,3 +129,39 @@ export const ErrorToastr = () => {
     </>
   );
 };
+
+export const CustomConfigToastr = () =>
+  <>
+    <ToastContainer />
+    <div className="space-x-6">
+      <Button
+        label="Custom config 1"
+        onClick={() =>
+          Toastr.info(
+            "This toastr has a custom configuration along with buttonLabel and onClick callback as separate arguments",
+            "Okay",
+            () => {},
+            {
+              hideProgressBar: false,
+              duration: 5000,
+            }
+          )
+        }
+      />
+      <Button
+        label="Custom config 2"
+        onClick={() =>
+          Toastr.show(
+            "This toastr has a custom configuration passed which includes buttonLabel and onClick in the same config object",
+            {
+              buttonLabel: "Okay",
+              onClick: () => {},
+              duration: 3000,
+            }
+          )
+        }
+      />
+    </div>
+  </>;
+
+CustomConfigToastr.storyName = "Custom config toastr";

--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -67,7 +67,7 @@ export const Toastrs = () => {
             label="Custom config"
             onClick={() =>
               Toastr.info(
-                "This toastr have a custom config passed",
+                "This toastr has a custom config passed",
                 null,
                 null,
                 {

--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -64,15 +64,28 @@ export const Toastrs = () => {
             }
           />
           <Button
-            label="Custom config"
+            label="Custom config 1"
             onClick={() =>
               Toastr.info(
-                "This toastr has a custom config passed",
-                null,
-                null,
+                "This toastr has a custom configuration along with buttonLabel and onClick callback as separate arguments",
+                "Okay",
+                () => {},
                 {
                   hideProgressBar: false,
-                  delay: 5000,
+                  duration: 5000,
+                }
+              )
+            }
+          />
+          <Button
+            label="Custom config 2"
+            onClick={() =>
+              Toastr.show(
+                "This toastr has a custom configuration passed which includes buttonLabel and onClick in the same config object",
+                {
+                  buttonLabel: "Custom button label impl 2",
+                  onClick: () => {},
+                  duration: 3000,
                 }
               )
             }

--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -63,6 +63,20 @@ export const Toastrs = () => {
               )
             }
           />
+          <Button
+            label="Custom config"
+            onClick={() =>
+              Toastr.info(
+                "This toastr have a custom config passed",
+                null,
+                null,
+                {
+                  hideProgressBar: false,
+                  delay: 5000,
+                }
+              )
+            }
+          />
         </div>
       </div>
     </>

--- a/tests/Toastr.test.js
+++ b/tests/Toastr.test.js
@@ -272,7 +272,7 @@ describe("Toastr", () => {
       const progressBar = await screen.findByRole("progressbar");
       expect(progressBar).toBeInTheDocument();
 
-      if (type !== "Error") { // Error toast have hardcoded role `alert`
+      if (type !== "Error") {
         const toastrRole = await screen.findByRole("custom-role");
         expect(toastrRole).toBeInTheDocument();
       }

--- a/tests/Toastr.test.js
+++ b/tests/Toastr.test.js
@@ -18,16 +18,22 @@ const renderToastrButton = (
   return screen.getByText(`${type} Toastr`);
 };
 
-describe("Toastr", () => {
-  ["Success", "Info", "Warning", "Error"].forEach((type) => {
-    it(`should render ${type} Toastr without error`, async () => {
-      const button = renderToastrButton(type);
-      userEvent.click(button);
-      const toastr = await screen.findByText(`This is a ${type} toastr.`);
-      expect(toastr).toBeInTheDocument();
-    });
-  });
+const renderCustomConfigToastrButton = type => {
+  const customConfig = {
+    hideProgressBar: false,
+    role: "custom-role",
+  };
+  const onClick = () => Toastr[type.toLowerCase()](`This is a ${type} toastr.`, "Close", () => {}, customConfig);
+  render(
+    <>
+      <ToastContainer />
+      <Button label={`${type} Toastr`} onClick={onClick} />
+    </>
+  );
+  return screen.getByText(`${type} Toastr`);
+};
 
+describe("Toastr", () => {
   ["Success", "Info", "Warning", "Error"].forEach((type) => {
     it(`should render ${type} Toastr without error`, async () => {
       const button = renderToastrButton(type);
@@ -253,5 +259,23 @@ describe("Toastr", () => {
     userEvent.click(button);
     const errorToastr = await screen.findByText("Something went wrong.");
     expect(errorToastr).toBeInTheDocument();
+  });
+
+  ["Success", "Info", "Warning", "Error"].forEach((type) => {
+    it(`should render ${type} Toastr when custom config is passed`, async () => {
+      const button = renderCustomConfigToastrButton(type);
+      userEvent.click(button);
+
+      const toastr = await screen.findByText(`This is a ${type} toastr.`);
+      expect(toastr).toBeInTheDocument();
+
+      const progressBar = await screen.findByRole("progressbar");
+      expect(progressBar).toBeInTheDocument();
+
+      if (type !== "Error") { // Error toast have hardcoded role `alert`
+        const toastrRole = await screen.findByRole("custom-role");
+        expect(toastrRole).toBeInTheDocument();
+      }
+    });
   });
 });


### PR DESCRIPTION
Fixes #1370 

**Description**
- Added: ability to pass custom config to Toastr.

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@karthiknmenon 
<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
