### PR TITLE
added anchor links in content doc page

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -21,7 +21,11 @@
     position: relative;
   }
   .sbdocs .sbdocs-a {
-    color: #276ef1;
+    color: #2d36d4;
+  }
+
+  .neeto-language-page h3 .sbdocs-a{
+    color: #1b1f23 !important;
   }
   .sbdocs-h1,
   .sbdocs-h2,

--- a/stories/Foundation/Content.stories.mdx
+++ b/stories/Foundation/Content.stories.mdx
@@ -27,7 +27,9 @@ import { Check, Close } from "@bigbinary/neeto-icons";
 
 <br />
 
-### Headings and subheadings
+<div class="neeto-language-page">
+
+<h3 id="headings-and-subheadings"><a href="#headings-and-subheadings">Headings and subheadings</a></h3>
 
 Headings and subheadings should be:
 
@@ -66,7 +68,7 @@ Informative and descriptive:
 </div>
 <br/>
 
-### Buttons
+<h3 id="buttons"><a href="#buttons">Buttons</a></h3>
 
 Buttons should be:
 
@@ -100,7 +102,7 @@ Clear and predictable:
 </div>
 <br/>
 
-### Links
+<h3 id="links"><a href="#links">Links</a></h3>
 
 Links need to be clear and predictable.
 
@@ -126,7 +128,7 @@ Links need to be clear and predictable.
 </div>
 <br/>
 
-### Confirmations
+<h3 id="confirmations"><a href="#confirmations">Confirmations</a></h3>
 
 Confirmations are presented for actions that can’t be undone or are difficult to undo.
 
@@ -192,7 +194,8 @@ Confirmations are presented for actions that can’t be undone or are difficult 
 </div>
 <br/>
 
-### Directional language
+
+<h3 id="directional-language"><a href="#directional-language">Directional language</a></h3>
 <br/>
 
 #### Save vs done
@@ -209,5 +212,6 @@ Use the adjective “Done” for deferred saves. When the modal or sheet closes,
 
 Most deferred saves happen when confirming changes in Add, Edit, Manage, and Select modals and sheets.
 
+</div>
 
 


### PR DESCRIPTION
Fixes #1372 

**Description**

Added : anchor links to jump to a specific part of a page in content docs.

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish is required)
- [ ] I have followed the suggested description format and styling

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
