### PR TITLE
Ensure click events are not grabbed by icons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -564,7 +564,26 @@ export const Button: React.FC<ButtonProps>;
 export const Callout: React.FC<CalloutProps>;
 export const Checkbox: React.FC<CheckboxProps>;
 export const DatePicker: React.FC<DatePickerProps>;
-export const Dropdown: React.FC<DropdownProps>;
+export const Dropdown: React.FC<DropdownProps> & {
+  Menu: React.FC<
+    React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLUListElement>,
+      HTMLUListElement
+    >
+  >;
+  MenuItem: React.FC<
+    React.DetailedHTMLProps<
+      React.LiHTMLAttributes<HTMLLIElement>,
+      HTMLLIElement
+    >
+  > & { Button: ButtonProps };
+  Divider: React.FC<
+    React.DetailedHTMLProps<
+      React.LiHTMLAttributes<HTMLLIElement>,
+      HTMLLIElement
+    >
+  >;
+};
 export const EmailInput: React.FC<EmailInputProps>;
 export const Input: React.ForwardRefExoticComponent<InputProps>;
 export const Label: React.FC<LabelProps>;

--- a/layouts.d.ts
+++ b/layouts.d.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLinkProps } from "react-router-dom";
-import { AvatarProps, InputProps } from "./index";
+import { AvatarProps, InputProps, ButtonProps } from "./index";
 
 export interface AppSwitcherProps {
   isOpen?: boolean;
@@ -35,6 +35,47 @@ export interface MenuBarProps {
   className?: string;
   showMenu?: boolean;
   "data-cy"?: string;
+  children?: React.ReactNode;
+}
+
+export interface MenuBarBlockProps {
+  label: string;
+  url?: string;
+  icon?: React.ReactNode;
+  count?: number;
+  active?: boolean;
+  onEdit?: Function;
+  onClick?: Function;
+  className?: string;
+  "data-cy"?: string;
+}
+
+export interface MenuBarItemProps
+  extends React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  > {
+  label?: string;
+  description?: string;
+  active?: boolean;
+}
+
+export interface MenuBarSubTitleProps {
+  iconProps?: ButtonProps;
+  "data-cy"?: string;
+}
+
+export interface MenuBarSearchProps extends InputProps {
+  collapse?: boolean;
+  onCollapse?: Function;
+}
+
+export interface MenuBarAddNewProps
+  extends React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  > {
+  label?: string;
 }
 
 export type ScrollableProps = {
@@ -110,7 +151,13 @@ export interface SubHeaderProps {
 export const AppSwitcher: React.FC<AppSwitcherProps>;
 export const Container: React.ForwardRefExoticComponent<ContainerProps>;
 export const Header: React.FC<HeaderProps>;
-export const MenuBar: React.FC<MenuBarProps>;
+export const MenuBar: React.FC<MenuBarProps> & {
+  Block: React.FC<MenuBarBlockProps>;
+  Item: React.FC<MenuBarItemProps>;
+  SubTitle: React.FC<MenuBarSubTitleProps>;
+  Search: React.FC<MenuBarSearchProps>;
+  AddNew: React.FC<MenuBarAddNewProps>;
+};
 export const Scrollable: React.FC<ScrollableProps>;
 export const Sidebar: React.FC<SidebarProps>;
 export const SubHeader: React.FC<SubHeaderProps>;

--- a/lib/styles/components/_button.scss
+++ b/lib/styles/components/_button.scss
@@ -22,6 +22,7 @@
 
     .neeto-ui-btn__icon,
     .neeto-ui-btn__spinner svg {
+      pointer-events: none;
       width: 16px !important;
       height: 16px !important;
     }
@@ -36,6 +37,7 @@
     &.neeto-ui-btn--icon-only {
       .neeto-ui-btn__icon,
       .neeto-ui-btn__spinner svg {
+        pointer-events: none;
         width: 20px !important;
         height: 20px !important;
       }
@@ -79,6 +81,7 @@
 .neeto-ui-btn__icon,
 .neeto-ui-btn__spinner,
 .neeto-ui-btn__spinner-wrapper {
+  pointer-events: none;
   color: inherit;
   svg {
     color: inherit !important;


### PR DESCRIPTION
Fixes #1375 (watch the video in it for better understanding)

**Description**
- Fixed: Icons grabbing away click events & onClick not being triggered when icons are replaced during a state change.
- Fixed: False positive type errors for MenuBar & Dropdown subcomponents

**Checklist**

- [x] I have performed a self-review of my code
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@praveen-murali-ind _a review `lib/styles/components/_button.scss`
@amaldinesh7 review the type definitions

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
