### PR TITLE
Improvises the documentation to migrate neetoUI to v4

### DIFF
--- a/stories/Migration-Guide/v3tov4.stories.mdx
+++ b/stories/Migration-Guide/v3tov4.stories.mdx
@@ -18,19 +18,35 @@ This document will help you upgrade from neetoUI `3.x` version to neetoUI `4.x` 
 
 1. Update neetoUI package version to `4.x.x`
 
-2. Install the missing peer-dependencies as shown in the terminal.
+```shell
+yarn upgrade @bigbinary/neetoui@4.0.13
+```
 
-3. As we have removed the dependencies from the neetoUI package, you will have to install them separately, if any such package missing errors are shown in the terminal.
+2. **Commit the changes** to `package.json` and `yarn.lock` immediately.
 
-4. You can manually check the code one by one against the [list for modification](/docs/changelog--page). In addition, we also provide a codemod cli tool [@bigbinary/neetoui-codemod-v4](https://github.com/bigbinary/neetoui-codemod-v4) To help you quickly upgrade to v4.
+```shell
+git commit -m "Upgraded neetoui to v4"
+```
 
-Before running codemod cli, please submit your local code changes.
+3. As we have removed the dependencies from the neetoUI package, you will have to install them separately.
+
+```shell
+yarn add @emotion/is-prop-valid@1.2.0 antd@4.23.6
+```
+
+4. We provide a codemod cli tool [@bigbinary/neetoui-codemod-v4](https://github.com/bigbinary/neetoui-codemod-v4) To help you quickly upgrade to v4.
+
+> **Before running codemod cli command, ensure the following:**
+> 1. __The changes related to upgrading neetoUI to v4 should be committed.__ That is, changes to package.json and yarn.lock should be committed.
+> 2. All other changes, you can either [stash](https://www.atlassian.com/git/tutorials/saving-changes/git-stash) them if those changes are not yet commit ready or directly commit them via git.
+
+> This script will migrate all the direct props changes of components. Changes in the nested props have to done manually.
+> E.g.: `Dropdown` component has a prop `buttonProps` which is an object. If you are using any of the nested props of `buttonProps` like `buttonProps={{ size: "large" }}` then you have to change it manually.
 
 ```shell
 # Run directly through npx
 npx @bigbinary/neetoui-codemod-v4 src
 ```
-
 Or
 
 ```shell
@@ -49,14 +65,14 @@ neetoui-codemod-v4 src
   </span>
 </div>
 
-> This script will migrate all the direct props changes of components. Changes in the nested props have to done manually.
-> E.g.: `Dropdown` component has a prop `buttonProps` which is an object. If you are using any of the nested props of `buttonProps` like `buttonProps={{ size: "large" }}` then you have to change it manually.
+__Exceptions__
+  - Implementation of **Dropdown** and **ActionDropdown** component
+  - Complex usage of `style`(old: `color`) prop of **Tag** component
+  - Usage of nested props. Eg. `buttonProps` of **Dropdown** component
 
-### Exceptions
+<br />
 
-1. Implementation of **Dropdown** and **ActionDropdown** component
-2. Complex usage of `style`(old: `color`) prop of **Tag** component
-3. Usage of nested props. Eg. `buttonProps` of **Dropdown** component
+5. You can manually check the code one by one against the [list for modification](/docs/changelog--page).
 
 <br />
 <br />

--- a/stories/Migration-Guide/v3tov4.stories.mdx
+++ b/stories/Migration-Guide/v3tov4.stories.mdx
@@ -25,7 +25,7 @@ yarn upgrade @bigbinary/neetoui@4.0.13
 2. **Commit the changes** to `package.json` and `yarn.lock` immediately.
 
 ```shell
-git commit -m "Upgraded neetoui to v4"
+git commit -m "Upgraded neetoUI to v4"
 ```
 
 3. As we have removed the dependencies from the neetoUI package, you will have to install them separately.
@@ -37,7 +37,8 @@ yarn add @emotion/is-prop-valid@1.2.0 antd@4.23.6
 4. We provide a codemod cli tool [@bigbinary/neetoui-codemod-v4](https://github.com/bigbinary/neetoui-codemod-v4) To help you quickly upgrade to v4.
 
 > **Before running codemod cli command, ensure the following:**
-> 1. __The changes related to upgrading neetoUI to v4 should be committed.__ That is, changes to package.json and yarn.lock should be committed.
+>
+> 1. **The changes related to upgrading neetoUI to v4 should be committed.** That is, changes to package.json and yarn.lock should be committed.
 > 2. All other changes, you can either [stash](https://www.atlassian.com/git/tutorials/saving-changes/git-stash) them if those changes are not yet commit ready or directly commit them via git.
 
 > This script will migrate all the direct props changes of components. Changes in the nested props have to done manually.
@@ -47,6 +48,7 @@ yarn add @emotion/is-prop-valid@1.2.0 antd@4.23.6
 # Run directly through npx
 npx @bigbinary/neetoui-codemod-v4 src
 ```
+
 Or
 
 ```shell
@@ -65,10 +67,11 @@ neetoui-codemod-v4 src
   </span>
 </div>
 
-__Exceptions__
-  - Implementation of **Dropdown** and **ActionDropdown** component
-  - Complex usage of `style`(old: `color`) prop of **Tag** component
-  - Usage of nested props. Eg. `buttonProps` of **Dropdown** component
+**Exceptions**
+
+- Implementation of **Dropdown** and **ActionDropdown** component
+- Complex usage of `style`(old: `color`) prop of **Tag** component
+- Usage of nested props. Eg. `buttonProps` of **Dropdown** component
 
 <br />
 

--- a/stories/Migration-Guide/v3tov4.stories.mdx
+++ b/stories/Migration-Guide/v3tov4.stories.mdx
@@ -31,7 +31,7 @@ git commit -m "Upgraded neetoUI to v4"
 3. As we have removed the dependencies from the neetoUI package, you will have to install them separately.
 
 ```shell
-yarn add @emotion/is-prop-valid@1.2.0 antd@4.23.6
+yarn add antd@4.23.6
 ```
 
 4. We provide a codemod cli tool [@bigbinary/neetoui-codemod-v4](https://github.com/bigbinary/neetoui-codemod-v4) To help you quickly upgrade to v4.


### PR DESCRIPTION
Fixes #1332 

**Description**
Changed documentation to migrate neetoUI to v4.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
