### PR TITLE
Added size type large to Modal documentation

### DIFF
--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -141,7 +141,11 @@ export const Sizes = () => {
         </Modal.Footer>
       </Modal>
 
-      <Modal isOpen={showModalLarge} onClose={() => setShowModalLarge(false)}>
+      <Modal
+        isOpen={showModalLarge}
+        onClose={() => setShowModalLarge(false)}
+        size="large"
+      >
         <Modal.Header>
           <Typography style="h2">They're creepy & they're kooky</Typography>
         </Modal.Header>


### PR DESCRIPTION
**Description**
- Added size type large to Modal documentation stories.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@praveen-murali-ind Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
