### PR TITLE
Added className to Form component

### DIFF
--- a/formik.d.ts
+++ b/formik.d.ts
@@ -22,9 +22,10 @@ export interface BlockNavigationProps {
 }
 
 export interface Form {
+  className?: string;
   children: React.ReactNode | ((props: FormikProps<any>) => React.ReactNode);
   formikProps: {[key: string]: any};
-  formProps: {[key: string]: any};
+  formProps?: {[key: string]: any};
 }
 
 export const ActionBlock: React.FC<ActionBlockProps>;

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -40,7 +40,13 @@ const FormWrapper = forwardRef(
     }, [onSubmit, values, handleKeyDown, formRef]);
 
     return (
-      <FormikForm noValidate className={className} ref={formRef} {...formProps}>
+      <FormikForm
+        noValidate
+        className={className}
+        ref={formRef}
+        data-testid="neeto-ui-form-wrapper"
+        {...formProps}
+      >
         {children}
       </FormikForm>
     );

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -2,48 +2,50 @@ import React, { useEffect, useCallback, useRef, forwardRef } from "react";
 import PropTypes from "prop-types";
 import { Form as FormikForm, useFormikContext } from "formik";
 
-const FormWrapper = forwardRef(({ formProps, children, onSubmit }, ref) => {
-  const internalFormWrapperRef = useRef(null);
-  const formRef = ref || internalFormWrapperRef;
+const FormWrapper = forwardRef(
+  ({ className, formProps, children, onSubmit }, ref) => {
+    const internalFormWrapperRef = useRef(null);
+    const formRef = ref || internalFormWrapperRef;
 
-  const { values, validateForm, setErrors, setTouched } = useFormikContext();
+    const { values, validateForm, setErrors, setTouched } = useFormikContext();
 
-  const handleKeyDown = useCallback(
-    (event) => {
-      if (event.key !== "Enter") return;
+    const handleKeyDown = useCallback(
+      (event) => {
+        if (event.key !== "Enter") return;
 
-      if (event.shiftKey) {
-        event.preventDefault();
-        return;
-      } else {
-        validateForm().then((errors) => {
-          if (Object.keys(errors).length > 0) {
-            setErrors(errors);
-            setTouched(errors);
-          } else {
-            onSubmit(values);
-          }
-        });
-        event.preventDefault();
-      }
-    },
-    [values, validateForm, setErrors, setTouched, onSubmit]
-  );
+        if (event.shiftKey) {
+          event.preventDefault();
+          return;
+        } else {
+          validateForm().then((errors) => {
+            if (Object.keys(errors).length > 0) {
+              setErrors(errors);
+              setTouched(errors);
+            } else {
+              onSubmit(values);
+            }
+          });
+          event.preventDefault();
+        }
+      },
+      [values, validateForm, setErrors, setTouched, onSubmit]
+    );
 
-  useEffect(() => {
-    formRef?.current.addEventListener("keydown", handleKeyDown);
+    useEffect(() => {
+      formRef?.current.addEventListener("keydown", handleKeyDown);
 
-    return () => {
-      formRef?.current.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onSubmit, values, handleKeyDown, formRef]);
+      return () => {
+        formRef?.current.removeEventListener("keydown", handleKeyDown);
+      };
+    }, [onSubmit, values, handleKeyDown, formRef]);
 
-  return (
-    <FormikForm noValidate ref={formRef} {...formProps}>
-      {children}
-    </FormikForm>
-  );
-});
+    return (
+      <FormikForm noValidate className={className} ref={formRef} {...formProps}>
+        {children}
+      </FormikForm>
+    );
+  }
+);
 
 FormWrapper.propTypes = {
   children: PropTypes.node,

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -24,8 +24,25 @@ const Form = forwardRef(
 );
 
 Form.propTypes = {
+  /**
+   * Pass a function to render children or pass the children directly
+   **/
   children: PropTypes.node,
+  /**
+   * Additional classnames to be passed to the form wrapper
+   **/
+  className: PropTypes.string,
+  /**
+   * Props to be passed to the Formik component like `initialValues`, `validationSchema`, `onSubmit`
+   * Refer to the Formik docs for more details
+   * https://formik.org/docs/api/formik
+   **/
   formikProps: PropTypes.object,
+  /**
+   * Props to be passed to the form element like `className`.
+   * Refer to the Formik docs for more details
+   * https://formik.org/docs/api/form
+   **/
   formProps: PropTypes.object,
 };
 

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -4,21 +4,24 @@ import PropTypes from "prop-types";
 
 import FormWrapper from "./FormWrapper";
 
-const Form = forwardRef(({ children, formikProps, formProps }, ref) => {
-  return (
-    <Formik {...formikProps}>
-      {(props) => (
-        <FormWrapper
-          ref={ref}
-          formProps={formProps}
-          onSubmit={formikProps?.onSubmit}
-        >
-          {typeof children === "function" ? children(props) : children}
-        </FormWrapper>
-      )}
-    </Formik>
-  );
-});
+const Form = forwardRef(
+  ({ className, children, formikProps, formProps }, ref) => {
+    return (
+      <Formik {...formikProps}>
+        {(props) => (
+          <FormWrapper
+            ref={ref}
+            formProps={formProps}
+            className={className}
+            onSubmit={formikProps?.onSubmit}
+          >
+            {typeof children === "function" ? children(props) : children}
+          </FormWrapper>
+        )}
+      </Formik>
+    );
+  }
+);
 
 Form.propTypes = {
   children: PropTypes.node,

--- a/stories/Introduction/Formik.stories.mdx
+++ b/stories/Introduction/Formik.stories.mdx
@@ -73,9 +73,7 @@ import { Form } from "@bigbinary/neetoui/formik";
       email: Yup.string().email("Invalid email").required("Email is required"),
     }),
   }}
-  formProps={{
-    className: "w-full space-y-6",
-  }}
+  className="w-full space-y-6"
 >
   {(props) => {
     return (
@@ -109,9 +107,7 @@ import { Form } from "@bigbinary/neetoui/formik";
       email: Yup.string().email("Invalid email").required("Email is required"),
     }),
   }}
-  formProps={{
-    className: "w-full space-y-6",
-  }}
+  className="w-full space-y-6"
 >
   <>
     <Input {...props} label="Name" name="name" />

--- a/stories/Introduction/Formik.stories.mdx
+++ b/stories/Introduction/Formik.stories.mdx
@@ -56,23 +56,76 @@ You can refer the [formik folder](https://github.com/bigbinary/neeto-ui/tree/mai
 In order to use the neetoUI formik components, you need to wrap your form with the `Form` component.
 
 ```jsx
+import * as Yup from "yup";
 import { Form } from "@bigbinary/neetoui/formik";
 
-<Form>
+<Form
+  formikProps={{
+    initialValues: {
+      name: "",
+      email: "",
+    },
+    onSubmit: (values) => {
+      console.log(values);
+    },
+    validationSchema: Yup.object({
+      name: Yup.string().required("Name is required"),
+      email: Yup.string().email("Invalid email").required("Email is required"),
+    }),
+  }}
+  formProps={{
+    className: "w-full space-y-6",
+  }}
+>
   {(props) => {
     return (
-      <div>
+      <>
         <Input {...props} label="Name" name="name" />
         <Input {...props} label="Email" name="email" />
-      </div>
+        <Button label="Submit" type="submit" style="primary" />
+      </>
     );
   }}
+</Form>;
+```
+
+In case, you wish not to pass `children` as a function, you can use the following syntax:
+
+```jsx
+import * as Yup from "yup";
+import { Form } from "@bigbinary/neetoui/formik";
+
+<Form
+  formikProps={{
+    initialValues: {
+      name: "",
+      email: "",
+    },
+    onSubmit: (values) => {
+      console.log(values);
+    },
+    validationSchema: Yup.object({
+      name: Yup.string().required("Name is required"),
+      email: Yup.string().email("Invalid email").required("Email is required"),
+    }),
+  }}
+  formProps={{
+    className: "w-full space-y-6",
+  }}
+>
+  <>
+    <Input {...props} label="Name" name="name" />
+    <Input {...props} label="Email" name="email" />
+    <Button label="Submit" type="submit" style="primary" />
+  </>
 </Form>;
 ```
 
 The `Form` component accepts the following props:
 
 - `formikProps`: Formik props object. You can pass `initialValues`, `validationSchema`, `onSubmit` etc. as props to the `Form` component.
+- `children`: You can pass a function as `children` to the `Form` component. The function will receive the formik props object as an argument. Or you can directly pass the `children` inside the `Form` component.
+- `className`: You can use this prop to provide a custom class to the form.
 - `formProps`: Form props object. You can pass `className`, `style` etc. as props to the `Form` component.
 
 #### Acceptable props for Components

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -17,6 +17,7 @@ const FormikForm = ({ onSubmit }) => {
         }),
         onSubmit: handleSubmit,
       }}
+      className="nui-form-wrapper"
     >
       <Input name="name" label="First Name" />
       <Button type="submit">Submit</Button>
@@ -46,6 +47,14 @@ describe("formik/Form", () => {
     userEvent.click(button);
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith({ name: "Oliver" })
+    );
+  });
+
+  // expect the html form element to show the custom classname
+  it("should render form with custom classname", () => {
+    render(<FormikForm />);
+    expect(screen.getByTestId("neeto-ui-form-wrapper")).toHaveClass(
+      "nui-form-wrapper"
     );
   });
 

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -50,7 +50,6 @@ describe("formik/Form", () => {
     );
   });
 
-  // expect the html form element to show the custom classname
   it("should render form with custom classname", () => {
     render(<FormikForm />);
     expect(screen.getByTestId("neeto-ui-form-wrapper")).toHaveClass(


### PR DESCRIPTION
Fixes #1411 

**Description**

- Added: `className` as props to _Form_ component.

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@amaldinesh7 Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
