### PR TITLE
Prevents showing error until form is submitted if validateOnBlur and vaidateOnChange is set to true

### DIFF
--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -3,11 +3,11 @@ import PropTypes from "prop-types";
 import { Form as FormikForm, useFormikContext } from "formik";
 
 const FormWrapper = forwardRef(
-  ({ className, formProps, children, onSubmit }, ref) => {
+  ({ className, formProps, children, onSubmit, setDidSubmitForm }, ref) => {
     const internalFormWrapperRef = useRef(null);
     const formRef = ref || internalFormWrapperRef;
 
-    const { values, validateForm, setErrors, setTouched } = useFormikContext();
+    const { submitCount, values, validateForm, setErrors, setTouched } = useFormikContext();
 
     const handleKeyDown = useCallback(
       (event) => {
@@ -30,6 +30,12 @@ const FormWrapper = forwardRef(
       },
       [values, validateForm, setErrors, setTouched, onSubmit]
     );
+
+    useEffect(() => {
+      if (submitCount === 1) {
+        setDidSubmitForm(true);
+      }
+    }, [submitCount]);
 
     useEffect(() => {
       formRef?.current.addEventListener("keydown", handleKeyDown);

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Form as FormikForm, useFormikContext } from "formik";
 
 const FormWrapper = forwardRef(
-  ({ className, formProps, children, onSubmit, setDidSubmitForm }, ref) => {
+  ({ className, formProps, children, onSubmit, setHasFormSubmitted }, ref) => {
     const internalFormWrapperRef = useRef(null);
     const formRef = ref || internalFormWrapperRef;
 
@@ -33,7 +33,7 @@ const FormWrapper = forwardRef(
 
     useEffect(() => {
       if (submitCount === 1) {
-        setDidSubmitForm(true);
+        setHasFormSubmitted(true);
       }
     }, [submitCount]);
 

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -41,7 +41,7 @@ const FormWrapper = forwardRef(
       formRef?.current.addEventListener("keydown", handleKeyDown);
 
       return () => {
-        formRef?.current.removeEventListener("keydown", handleKeyDown);
+        formRef?.current?.removeEventListener("keydown", handleKeyDown);
       };
     }, [onSubmit, values, handleKeyDown, formRef]);
 

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -9,8 +9,8 @@ const Form = forwardRef(
     const [didSubmitForm, setDidSubmitForm] = useState(false);
     return (
       <Formik {...formikProps}
-        validateOnBlur={formikProps.validateOnBlur && didSubmitForm}
-        validateOnChange={formikProps.validateOnChange && didSubmitForm}>
+        validateOnBlur={formikProps?.validateOnBlur && didSubmitForm}
+        validateOnChange={formikProps?.validateOnChange && didSubmitForm}>
         {(props) => (
           <FormWrapper
             ref={ref}

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -9,8 +9,8 @@ const Form = forwardRef(
     const [didSubmitForm, setDidSubmitForm] = useState(false);
     return (
       <Formik {...formikProps}
-        validateOnBlur={formikProps.validateOnBlur && !!didSubmitForm}
-        validateOnChange={formikProps.validateOnChange && !!didSubmitForm}>
+        validateOnBlur={formikProps.validateOnBlur && didSubmitForm}
+        validateOnChange={formikProps.validateOnChange && didSubmitForm}>
         {(props) => (
           <FormWrapper
             ref={ref}

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useState } from "react";
 import { Formik } from "formik";
 import PropTypes from "prop-types";
 
@@ -6,14 +6,18 @@ import FormWrapper from "./FormWrapper";
 
 const Form = forwardRef(
   ({ className, children, formikProps, formProps }, ref) => {
+    const [didSubmitForm, setDidSubmitForm] = useState(false);
     return (
-      <Formik {...formikProps}>
+      <Formik {...formikProps}
+        validateOnBlur={formikProps.validateOnBlur && !!didSubmitForm}
+        validateOnChange={formikProps.validateOnChange && !!didSubmitForm}>
         {(props) => (
           <FormWrapper
             ref={ref}
             formProps={formProps}
             className={className}
             onSubmit={formikProps?.onSubmit}
+            setDidSubmitForm={setDidSubmitForm}
           >
             {typeof children === "function" ? children(props) : children}
           </FormWrapper>

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -6,18 +6,20 @@ import FormWrapper from "./FormWrapper";
 
 const Form = forwardRef(
   ({ className, children, formikProps, formProps }, ref) => {
-    const [didSubmitForm, setDidSubmitForm] = useState(false);
+    const [hasFormSubmitted, setHasFormSubmitted] = useState(false);
     return (
-      <Formik {...formikProps}
-        validateOnBlur={formikProps?.validateOnBlur && didSubmitForm}
-        validateOnChange={formikProps?.validateOnChange && didSubmitForm}>
+      <Formik
+        {...formikProps}
+        validateOnBlur={formikProps?.validateOnBlur && hasFormSubmitted}
+        validateOnChange={formikProps?.validateOnChange && hasFormSubmitted}
+      >
         {(props) => (
           <FormWrapper
             ref={ref}
             formProps={formProps}
             className={className}
             onSubmit={formikProps?.onSubmit}
-            setDidSubmitForm={setDidSubmitForm}
+            setHasFormSubmitted={setHasFormSubmitted}
           >
             {typeof children === "function" ? children(props) : children}
           </FormWrapper>

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { Button, Input, Form } from "../../lib/components/formik";
 import * as yup from "yup";
 
-const FormikForm = ({ onSubmit }) => {
+const FormikForm = ({ onSubmit, validateOnBlur, validateOnChange }) => {
   const handleSubmit = (values) => {
     onSubmit(values);
   };
@@ -16,6 +16,8 @@ const FormikForm = ({ onSubmit }) => {
           name: yup.string().required("Name is required"),
         }),
         onSubmit: handleSubmit,
+        validateOnBlur,
+        validateOnChange,
       }}
       className="nui-form-wrapper"
     >
@@ -64,6 +66,33 @@ describe("formik/Form", () => {
     const button = screen.getByRole("button");
     userEvent.type(input, "{selectall}{backspace}");
     await waitFor(() => expect(button).toBeDisabled());
+    userEvent.click(button);
+    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
+  });
+
+  it("should not validate form on value change or field blur until form is submitted once", async () => {
+    const onSubmit = jest.fn();
+    render(<FormikForm validateOnBlur={true} validateOnChange={true} onSubmit={onSubmit} />);
+
+    const formWrapper = screen.getByTestId("neeto-ui-form-wrapper");
+    const input = screen.getByLabelText("First Name");
+    const button = screen.getByRole("button");
+
+    // clear initial values and blur field.
+    userEvent.type(input, "{selectall}{backspace}");
+    userEvent.click(formWrapper);
+    expect(screen.queryByText("Name is required")).not.toBeInTheDocument();
+
+    userEvent.click(button); // Try submitting form with empty value.
+    await waitFor(() => expect(screen.getByText("Name is required")).toBeInTheDocument());
+    // Check error is removed when user types in value.
+    userEvent.type(input, "Oliver Smith");
+    await waitFor(() => expect(screen.queryByText("Name is required")).not.toBeInTheDocument());
+    // Clear values and make sure error is shown for the onChange event.
+    userEvent.type(input, "{selectall}{backspace}");
+    await waitFor(() => expect(screen.getByText("Name is required")).toBeInTheDocument());
+
+    userEvent.type(input, "Oliver Smith");
     userEvent.click(button);
     await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
   });

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -92,8 +92,9 @@ describe("formik/Form", () => {
     userEvent.type(input, "{selectall}{backspace}");
     await waitFor(() => expect(screen.getByText("Name is required")).toBeInTheDocument());
 
-    userEvent.type(input, "Oliver Smith");
+    userEvent.type(input, "Oliver");
+    await waitFor(() => expect(button).not.toBeDisabled());
     userEvent.click(button);
-    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
Fixes #1414 

**Description**
 - Fixed: `validateOnBlur` and `validateOnChange` getting triggered before the first submission of the _Form_.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
