### PR TITLE
Prevents fom validation on `cmd+enter` if form is clean

### DIFF
--- a/lib/components/MultiEmailInput.js
+++ b/lib/components/MultiEmailInput.js
@@ -163,7 +163,6 @@ const MultiEmailInput = ({
           }),
         }}
         isDisabled={disabled}
-        id="test"
         {...otherProps}
       />
       <div className="neeto-ui-email-input__bottom-info">

--- a/lib/components/MultiEmailInput.js
+++ b/lib/components/MultiEmailInput.js
@@ -87,10 +87,8 @@ const MultiEmailInput = ({
     const emailMatches =
       inputValue.match(UNSTRICT_EMAIL_REGEX) || inputValues || [];
     const emails = emailMatches.map((email) => formatEmailInputOptions(email));
-    const isValidEmail = emails[0].valid;
     onChange(pruneDuplicates([...value, ...emails]));
     setInputValue("");
-    return { isValidEmail };
   };
 
   const handleKeyDown = (event) => {
@@ -101,9 +99,9 @@ const MultiEmailInput = ({
     case "Tab":
     case ",":
     case " ": {
-      const { isValidEmail } = handleEmailChange();
+      handleEmailChange();
       event.preventDefault();
-      isValidEmail && event.stopPropagation();
+      event.stopPropagation();
     }
     }
   };

--- a/lib/components/MultiEmailInput.js
+++ b/lib/components/MultiEmailInput.js
@@ -87,8 +87,10 @@ const MultiEmailInput = ({
     const emailMatches =
       inputValue.match(UNSTRICT_EMAIL_REGEX) || inputValues || [];
     const emails = emailMatches.map((email) => formatEmailInputOptions(email));
+    const isValidEmail = emails[0].valid;
     onChange(pruneDuplicates([...value, ...emails]));
     setInputValue("");
+    return { isValidEmail };
   };
 
   const handleKeyDown = (event) => {
@@ -99,8 +101,9 @@ const MultiEmailInput = ({
     case "Tab":
     case ",":
     case " ": {
-      handleEmailChange();
+      const { isValidEmail } = handleEmailChange();
       event.preventDefault();
+      isValidEmail && event.stopPropagation();
     }
     }
   };
@@ -160,6 +163,7 @@ const MultiEmailInput = ({
           }),
         }}
         isDisabled={disabled}
+        id="test"
         {...otherProps}
       />
       <div className="neeto-ui-email-input__bottom-info">

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -22,13 +22,12 @@ const FormWrapper = forwardRef(
       (event) => {
         if (event.key !== "Enter") return;
 
+        event.preventDefault();
+
         if (event.shiftKey) {
           return;
         } else {
-          if (!isFormDirty) {
-            event.preventDefault();
-            return;
-          }
+          if (!isFormDirty) return;
 
           validateForm().then((errors) => {
             if (Object.keys(errors).length > 0) {
@@ -38,7 +37,6 @@ const FormWrapper = forwardRef(
               onSubmit(values, formikBag);
             }
           });
-          event.preventDefault();
         }
       },
       [values, validateForm, setErrors, setTouched, onSubmit, isFormDirty]
@@ -50,24 +48,19 @@ const FormWrapper = forwardRef(
       }
     }, [submitCount]);
 
-    useEffect(() => {
-      formRef?.current.addEventListener("keydown", handleKeyDown);
-
-      return () => {
-        formRef?.current?.removeEventListener("keydown", handleKeyDown);
-      };
-    }, [onSubmit, values, handleKeyDown, formRef]);
-
     return (
-      <FormikForm
-        noValidate
-        className={className}
-        ref={formRef}
-        data-testid="neeto-ui-form-wrapper"
-        {...formProps}
-      >
-        {children}
-      </FormikForm>
+      <div>
+        <FormikForm
+          onKeyDown={handleKeyDown}
+          noValidate
+          className={className}
+          ref={formRef}
+          data-testid="neeto-ui-form-wrapper"
+          {...formProps}
+        >
+          {children}
+        </FormikForm>
+      </div>
     );
   }
 );

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -1,11 +1,9 @@
-import React, { useEffect, useCallback, useRef, forwardRef } from "react";
+import React, { useEffect, useCallback, forwardRef } from "react";
 import PropTypes from "prop-types";
 import { Form as FormikForm, useFormikContext } from "formik";
 
 const FormWrapper = forwardRef(
-  ({ className, formProps, children, onSubmit, setHasFormSubmitted }, ref) => {
-    const internalFormWrapperRef = useRef(null);
-    const formRef = ref || internalFormWrapperRef;
+  ({ className, formProps, children, onSubmit, setHasFormSubmitted }, formRef) => {
 
     const {
       submitCount,
@@ -49,18 +47,16 @@ const FormWrapper = forwardRef(
     }, [submitCount]);
 
     return (
-      <div>
-        <FormikForm
-          onKeyDown={handleKeyDown}
-          noValidate
-          className={className}
-          ref={formRef}
-          data-testid="neeto-ui-form-wrapper"
-          {...formProps}
-        >
-          {children}
-        </FormikForm>
-      </div>
+      <FormikForm
+        onKeyDown={handleKeyDown}
+        noValidate
+        className={className}
+        ref={formRef}
+        data-testid="neeto-ui-form-wrapper"
+        {...formProps}
+      >
+        {children}
+      </FormikForm>
     );
   }
 );

--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -16,14 +16,20 @@ const FormWrapper = forwardRef(
       ...formikBag
     } = useFormikContext();
 
+    const isFormDirty = formikBag.dirty;
+
     const handleKeyDown = useCallback(
       (event) => {
         if (event.key !== "Enter") return;
 
         if (event.shiftKey) {
-          event.preventDefault();
           return;
         } else {
+          if (!isFormDirty) {
+            event.preventDefault();
+            return;
+          }
+
           validateForm().then((errors) => {
             if (Object.keys(errors).length > 0) {
               setErrors(errors);
@@ -35,7 +41,7 @@ const FormWrapper = forwardRef(
           event.preventDefault();
         }
       },
-      [values, validateForm, setErrors, setTouched, onSubmit]
+      [values, validateForm, setErrors, setTouched, onSubmit, isFormDirty]
     );
 
     useEffect(() => {

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -138,6 +138,6 @@ describe("formik/Form", () => {
     // Form is cleared and the second enter should trigger validation
     // and since there's no value, the error message should be rendered.
     userEvent.type(addressInput, "{selectall}{backspace} {enter}{enter}");
-    await waitFor(() => expect(screen.getByText("Address is required")).toBeInTheDocument());
+   expect(await screen.findByText("Address is required")).toBeInTheDocument();
   });
 });

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Button, Input, Form } from "../../lib/components/formik";
+import { Button, Input, Form, Textarea } from "../../lib/components/formik";
 import * as yup from "yup";
 
 const FormikForm = ({ onSubmit, validateOnBlur, validateOnChange }) => {
@@ -22,6 +22,27 @@ const FormikForm = ({ onSubmit, validateOnBlur, validateOnChange }) => {
       className="nui-form-wrapper"
     >
       <Input name="name" label="First Name" />
+      <Button type="submit">Submit</Button>
+    </Form>
+  );
+};
+
+const EmptyMultiLineForm = ({ onSubmit }) => {
+  const handleSubmit = (values) => {
+    onSubmit(values);
+  };
+  return (
+    <Form
+      formikProps={{
+        initialValues: {address: ""},
+        validationSchema: yup.object().shape({
+          address: yup.string().trim("").required("Address is required"),
+        }),
+        onSubmit: handleSubmit,
+      }}
+      className="nui-form-wrapper"
+    >
+      <Textarea id="address" name="address" label="Address" />
       <Button type="submit">Submit</Button>
     </Form>
   );
@@ -96,5 +117,27 @@ describe("formik/Form", () => {
     await waitFor(() => expect(button).not.toBeDisabled());
     userEvent.click(button);
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it("should not validate the form until form is dirty", async () => {
+    const onSubmit = jest.fn();
+    render(<EmptyMultiLineForm onSubmit={onSubmit} />);
+
+    const addressInput = screen.getByLabelText("Address");
+
+    // Form is not dirty and hence it's not validated for the enter press.
+    userEvent.type(addressInput, "{enter}");
+    expect(screen.queryByText("Address is required")).not.toBeInTheDocument();
+
+    // Form is dirty and hence it's validated for the second enter press
+    // and submit is called since there is no error.
+    userEvent.type(addressInput, "Address Line 1{enter}{enter}");
+    expect(screen.queryByText("Address is required")).not.toBeInTheDocument();
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    // Form is cleared and the second enter should trigger validation
+    // and since there's no value, the error message should be rendered.
+    userEvent.type(addressInput, "{selectall}{backspace} {enter}{enter}");
+    await waitFor(() => expect(screen.getByText("Address is required")).toBeInTheDocument());
   });
 });

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -138,6 +138,6 @@ describe("formik/Form", () => {
     // Form is cleared and the second enter should trigger validation
     // and since there's no value, the error message should be rendered.
     userEvent.type(addressInput, "{selectall}{backspace} {enter}{enter}");
-   expect(await screen.findByText("Address is required")).toBeInTheDocument();
+    expect(await screen.findByText("Address is required")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #1431 

**Description**
Fixed: Form validation triggered with incorrect values from MultiEmailInput.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
