### PR TITLE
Prevent submission on hitting enter key in textArea

### DIFF
--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -3,8 +3,10 @@ import PropTypes from "prop-types";
 import { Form as FormikForm, useFormikContext } from "formik";
 
 const FormWrapper = forwardRef(
-  ({ className, formProps, children, onSubmit, setHasFormSubmitted }, formRef) => {
-
+  (
+    { className, formProps, children, onSubmit, setHasFormSubmitted },
+    formRef
+  ) => {
     const {
       submitCount,
       values,
@@ -19,6 +21,7 @@ const FormWrapper = forwardRef(
     const handleKeyDown = useCallback(
       (event) => {
         if (event.key !== "Enter") return;
+        if (event.target.tagName === "TEXTAREA" && !event.metaKey) return;
 
         event.preventDefault();
 

--- a/tests/formik/Form.test.js
+++ b/tests/formik/Form.test.js
@@ -34,7 +34,7 @@ const EmptyMultiLineForm = ({ onSubmit }) => {
   return (
     <Form
       formikProps={{
-        initialValues: {address: ""},
+        initialValues: { address: "" },
         validationSchema: yup.object().shape({
           address: yup.string().trim("").required("Address is required"),
         }),
@@ -93,7 +93,13 @@ describe("formik/Form", () => {
 
   it("should not validate form on value change or field blur until form is submitted once", async () => {
     const onSubmit = jest.fn();
-    render(<FormikForm validateOnBlur={true} validateOnChange={true} onSubmit={onSubmit} />);
+    render(
+      <FormikForm
+        validateOnBlur={true}
+        validateOnChange={true}
+        onSubmit={onSubmit}
+      />
+    );
 
     const formWrapper = screen.getByTestId("neeto-ui-form-wrapper");
     const input = screen.getByLabelText("First Name");
@@ -105,13 +111,19 @@ describe("formik/Form", () => {
     expect(screen.queryByText("Name is required")).not.toBeInTheDocument();
 
     userEvent.click(button); // Try submitting form with empty value.
-    await waitFor(() => expect(screen.getByText("Name is required")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("Name is required")).toBeInTheDocument()
+    );
     // Check error is removed when user types in value.
     userEvent.type(input, "Oliver Smith");
-    await waitFor(() => expect(screen.queryByText("Name is required")).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText("Name is required")).not.toBeInTheDocument()
+    );
     // Clear values and make sure error is shown for the onChange event.
     userEvent.type(input, "{selectall}{backspace}");
-    await waitFor(() => expect(screen.getByText("Name is required")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("Name is required")).toBeInTheDocument()
+    );
 
     userEvent.type(input, "Oliver");
     await waitFor(() => expect(button).not.toBeDisabled());
@@ -131,13 +143,24 @@ describe("formik/Form", () => {
 
     // Form is dirty and hence it's validated for the second enter press
     // and submit is called since there is no error.
-    userEvent.type(addressInput, "Address Line 1{enter}{enter}");
+    userEvent.type(addressInput, "Address Line 1 {meta}{enter}");
     expect(screen.queryByText("Address is required")).not.toBeInTheDocument();
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
 
     // Form is cleared and the second enter should trigger validation
     // and since there's no value, the error message should be rendered.
-    userEvent.type(addressInput, "{selectall}{backspace} {enter}{enter}");
+    userEvent.type(addressInput, "{selectall}{backspace} {meta}{enter}");
     expect(await screen.findByText("Address is required")).toBeInTheDocument();
+  });
+
+  it("should not call submit on hitting enter with EmptyMultiLineForm", async () => {
+    const onSubmit = jest.fn();
+    render(<EmptyMultiLineForm onSubmit={onSubmit} />);
+
+    const addressInput = screen.getByLabelText("Address");
+
+    userEvent.type(addressInput, "{enter}");
+    expect(screen.queryByText("Address is required")).not.toBeInTheDocument();
+    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
Fixes #1443 
**Description**
Fixed: Prevents form submission when the `enter` key is pressed.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@amaldinesh7 _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
