### PR TITLE
Dynamic pagination based on viewport

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -362,7 +362,7 @@ export interface TableProps {
     scrollToFirstRowOnChange?: boolean;
   };
   rowSelection?: any;
-  shouldDynamicallyRenderRowSize: boolean;
+  shouldDynamicallyRenderRowSize?: boolean;
   [key: string]: any;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -362,6 +362,7 @@ export interface TableProps {
     scrollToFirstRowOnChange?: boolean;
   };
   rowSelection?: any;
+  shouldDynamicallyRenderRowSize: boolean;
   [key: string]: any;
 }
 

--- a/lib/components/Table.js
+++ b/lib/components/Table.js
@@ -167,6 +167,10 @@ Table.propTypes = {
    */
   allowRowClick: PropTypes.bool,
   /**
+   * Dynamically renders the number of rows based on the viewport height.
+   */
+  shouldDynamicallyRenderRowSize: PropTypes.bool,
+  /**
    * Custom classnames for each row.
    */
   className: PropTypes.string,

--- a/lib/components/Table.js
+++ b/lib/components/Table.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef, useState, useMemo } from "react";
 import { Table as AntTable } from "antd";
 import classnames from "classnames";
 import PropTypes from "prop-types";
@@ -30,6 +30,7 @@ const Table = ({
   paginationProps = {},
   scroll,
   rowSelection,
+  shouldDynamicallyRenderRowSize = true,
   ...otherProps
 }) => {
   const [containerHeight, setContainerHeight] = useState(null);
@@ -94,6 +95,29 @@ const Table = ({
     return originalElement;
   };
 
+  const calculateRowsPerPage = () => {
+    const viewportHeight = window.innerHeight;
+    const rowsPerPage = Math.floor(
+      ((viewportHeight - TABLE_PAGINATION_HEIGHT) / 52) * 3
+    );
+    return Math.ceil(rowsPerPage / 10) * 10;
+  };
+
+  const calculatePageSizeOptions = () => {
+    const rowsPerPage = shouldDynamicallyRenderRowSize
+      ? calculateRowsPerPage()
+      : defaultPageSize;
+
+    const pageSizeOptions = [...Array(5).keys()].map(
+      (i) => (i + 1) * rowsPerPage
+    );
+
+    return pageSizeOptions;
+  };
+
+  const memoizedRowsPerPage = useMemo(() => calculateRowsPerPage(), []);
+  const memoizedPageSizeOptions = useMemo(() => calculatePageSizeOptions(), []);
+
   return (
     <AntTable
       ref={tableRef}
@@ -117,7 +141,10 @@ const Table = ({
         ...paginationProps,
         total: totalCount ?? 0,
         current: currentPageNumber,
-        defaultPageSize: defaultPageSize,
+        defaultPageSize: shouldDynamicallyRenderRowSize
+          ? memoizedRowsPerPage
+          : defaultPageSize,
+        pageSizeOptions: memoizedPageSizeOptions,
         onChange: handlePageChange,
         itemRender: itemRender,
       }}

--- a/lib/components/Table.js
+++ b/lib/components/Table.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState, useMemo } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Table as AntTable } from "antd";
 import classnames from "classnames";
 import PropTypes from "prop-types";
@@ -12,6 +12,7 @@ const noop = () => {};
 
 const TABLE_PAGINATION_HEIGHT = 64;
 const TABLE_STICKY_HEADER_HEIGHT = 40;
+const TABLE_ROW_HEIGHT = 52;
 
 const Table = ({
   allowRowClick = true,
@@ -98,7 +99,7 @@ const Table = ({
   const calculateRowsPerPage = () => {
     const viewportHeight = window.innerHeight;
     const rowsPerPage = Math.floor(
-      ((viewportHeight - TABLE_PAGINATION_HEIGHT) / 52) * 3
+      ((viewportHeight - TABLE_PAGINATION_HEIGHT) / TABLE_ROW_HEIGHT) * 3
     );
     return Math.ceil(rowsPerPage / 10) * 10;
   };
@@ -114,9 +115,6 @@ const Table = ({
 
     return pageSizeOptions;
   };
-
-  const memoizedRowsPerPage = useMemo(() => calculateRowsPerPage(), []);
-  const memoizedPageSizeOptions = useMemo(() => calculatePageSizeOptions(), []);
 
   return (
     <AntTable
@@ -142,9 +140,9 @@ const Table = ({
         total: totalCount ?? 0,
         current: currentPageNumber,
         defaultPageSize: shouldDynamicallyRenderRowSize
-          ? memoizedRowsPerPage
+          ? calculateRowsPerPage()
           : defaultPageSize,
-        pageSizeOptions: memoizedPageSizeOptions,
+        pageSizeOptions: calculatePageSizeOptions(),
         onChange: handlePageChange,
         itemRender: itemRender,
       }}

--- a/tests/Table.test.js
+++ b/tests/Table.test.js
@@ -5,10 +5,10 @@ import userEvent from "@testing-library/user-event";
 
 const columnData = [
   {
-    dataIndex: 'id',
-    key: 'id',
-    title: 'ID',
-    width: 150
+    dataIndex: "id",
+    key: "id",
+    title: "ID",
+    width: 150,
   },
   {
     title: "First Name",
@@ -21,106 +21,75 @@ const columnData = [
     dataIndex: "last_name",
     key: "last_name",
     width: 150,
-  }
-]
+  },
+];
 
 const rowData = [
   {
     id: 1,
     first_name: "Oliver",
-    last_name: "Smith"
+    last_name: "Smith",
   },
   {
     id: 2,
     first_name: "Sam",
-    last_name: "Smith"
+    last_name: "Smith",
   },
   {
     id: 3,
     first_name: "Eve",
-    last_name: "Smith"
+    last_name: "Smith",
   },
   {
     id: 4,
     first_name: "Mark",
-    last_name: "Smith"
-  }
-]
+    last_name: "Smith",
+  },
+];
 
 describe("Table", () => {
   it("should render column data without error", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-      />
-    )
-    const column = screen.getByText("ID")
+    render(<Table columnData={columnData} rowData={rowData} />);
+    const column = screen.getByText("ID");
     expect(column).toBeInTheDocument();
   });
 
   it("should render row data without error", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-      />
-    )
-    const row = screen.getByText("1")
+    render(<Table columnData={columnData} rowData={rowData} />);
+    const row = screen.getByText("1");
     expect(row).toBeInTheDocument();
   });
 
   it("should render all the rows", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-      />
-    )
-    const row = screen.getAllByRole("row")
+    render(<Table columnData={columnData} rowData={rowData} />);
+    const row = screen.getAllByRole("row");
     expect(row.length).toBe(4);
   });
 
   it("should render all the columns", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-      />
-    )
-    const column1 = screen.getByText("ID")
+    render(<Table columnData={columnData} rowData={rowData} />);
+    const column1 = screen.getByText("ID");
     expect(column1).toBeInTheDocument();
-    const column2 = screen.getByText("First Name")
+    const column2 = screen.getByText("First Name");
     expect(column2).toBeInTheDocument();
-    const column3 = screen.getByText("Last Name")
+    const column3 = screen.getByText("Last Name");
     expect(column3).toBeInTheDocument();
   });
 
   it("should have checkbox to select table row if rowSelection is set to true", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-        rowSelection
-      />
-    )
-    const checkboxes = screen.getAllByRole("checkbox")
+    render(<Table columnData={columnData} rowData={rowData} rowSelection />);
+    const checkboxes = screen.getAllByRole("checkbox");
     expect(checkboxes.length).not.toBe(0);
   });
 
   it("should not have checkbox to select table row by default", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-      />
-    )
-    const checkbox = screen.queryByRole("checkbox")
+    render(<Table columnData={columnData} rowData={rowData} />);
+    const checkbox = screen.queryByRole("checkbox");
     expect(checkbox).not.toBeInTheDocument();
   });
 
   it("should call onRowSelect on row selection", () => {
-    const onRowSelect = jest.fn()
+    const onRowSelect = jest.fn();
     render(
       <Table
         columnData={columnData}
@@ -128,28 +97,28 @@ describe("Table", () => {
         onRowSelect={onRowSelect}
         rowSelection
       />
-    )
-    const checkbox = screen.getAllByRole("checkbox")
-    userEvent.click(checkbox[0])
+    );
+    const checkbox = screen.getAllByRole("checkbox");
+    userEvent.click(checkbox[0]);
     expect(onRowSelect).toHaveBeenCalledTimes(1);
   });
 
   it("should call onRowClick on row click by default", () => {
-    const onRowClick = jest.fn()
+    const onRowClick = jest.fn();
     render(
       <Table
         columnData={columnData}
         rowData={rowData}
         onRowClick={onRowClick}
       />
-    )
-    const row = screen.getByText("1")
-    userEvent.click(row)
+    );
+    const row = screen.getByText("1");
+    userEvent.click(row);
     expect(onRowClick).toHaveBeenCalledTimes(1);
   });
 
   it("should not call onRowClick on row click when allowRowClick is disabled", () => {
-    const onRowClick = jest.fn()
+    const onRowClick = jest.fn();
     render(
       <Table
         columnData={columnData}
@@ -157,21 +126,15 @@ describe("Table", () => {
         onRowClick={onRowClick}
         allowRowClick={false}
       />
-    )
-    const row = screen.getByText("1")
-    userEvent.click(row)
+    );
+    const row = screen.getByText("1");
+    userEvent.click(row);
     expect(onRowClick).toHaveBeenCalledTimes(0);
   });
 
   it("should render table with fixed height ", () => {
-    render(
-      <Table
-        columnData={columnData}
-        rowData={rowData}
-        fixedHeight
-      />
-    )
-    const row = screen.getByText("1")
+    render(<Table columnData={columnData} rowData={rowData} fixedHeight />);
+    const row = screen.getByText("1");
     expect(row).toBeInTheDocument();
   });
 
@@ -181,24 +144,26 @@ describe("Table", () => {
         columnData={columnData}
         rowData={rowData}
         defaultPageSize={2}
+        shouldDynamicallyRenderRowSize={false}
       />
-    )
-    const row = screen.getAllByRole("row")
+    );
+    const row = screen.getAllByRole("row");
     expect(row.length).toBe(2);
   });
 
   it("should call handlePageChange when page is changed ", () => {
-    const handlePageChange = jest.fn()
+    const handlePageChange = jest.fn();
     render(
       <Table
         columnData={columnData}
         rowData={rowData}
         defaultPageSize={2}
         handlePageChange={handlePageChange}
+        shouldDynamicallyRenderRowSize={false}
       />
-    )
-    const pages = screen.getAllByRole("listitem")
-    userEvent.click(pages[2])
+    );
+    const pages = screen.getAllByRole("listitem");
+    userEvent.click(pages[2]);
     expect(handlePageChange).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fixes #1445 

Old UI in 34" monitor - 

![image](https://user-images.githubusercontent.com/41678651/205241457-7f592dd9-223c-449a-b731-bf4982aa8774.png)


New UI in 34" monitor - 

![image](https://user-images.githubusercontent.com/41678651/205241503-699b7d9e-53a9-41ac-b43b-ffd3a8236223.png)


**Description**
Added: `shouldDynamicallyRenderRowSize` to calculate rows per page dynamically based on viewport height.

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
