### PR TITLE
Made Tag color prop as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -383,7 +383,7 @@ export interface TagProps {
     | "secondary"
     | "info";
   /** @deprecated Prop deprecated. Use `style` prop instead*/
-  color: string;
+  color?: string;
   /** @deprecated Prop deprecated. Use `indicatorStyle` prop instead*/
   indicatorColor?: string;
 }


### PR DESCRIPTION
Fixes #1456

**Description**

- Changed: `color` prop in _Tag_ component as optional in type definition.

**Checklist**

- [x] I have performed a self-review of my code
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
