### PR TITLE
Added support for Full Screen in Modal

### DIFF
--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -65,7 +65,9 @@ const Modal = ({
           ref={backdropRef}
           key="modal-backdrop"
           data-testid="backdrop"
-          className={classnames("neeto-ui-modal__backdrop", backdropClassName)}
+          className={classnames("neeto-ui-modal__backdrop", {
+            "neeto-ui-modal__backdrop--fullscreen" : size === SIZES.fullScreen
+          }, backdropClassName)}
         >
           <div
             role="dialog"

--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -13,7 +13,7 @@ import { Portal, Backdrop } from "../../atoms";
 import { useOverlay } from "../../hooks/useOverlay";
 import { useOverlayManager } from "../../hooks/useOverlayManager";
 
-const SIZES = { small: "small", medium: "medium", large: "large" };
+const SIZES = { small: "small", medium: "medium", large: "large", fullScreen: "fullScreen" };
 
 const Modal = ({
   size = SIZES.medium,
@@ -76,6 +76,7 @@ const Modal = ({
               "neeto-ui-modal__wrapper--small": size === SIZES.small,
               "neeto-ui-modal__wrapper--medium": size === SIZES.medium,
               "neeto-ui-modal__wrapper--large": size === SIZES.large,
+              "neeto-ui-modal__wrapper--fullscreen": size === SIZES.fullScreen,
               [className]: className,
             })}
             {...otherProps}

--- a/lib/styles/components/_modal.scss
+++ b/lib/styles/components/_modal.scss
@@ -61,6 +61,16 @@
       width: 720px;
     }
 
+    &.neeto-ui-modal__wrapper--fullscreen {
+      width: 100%;
+      height: 100%;
+      max-width: 100vw;
+      max-height: 100vh;
+      border-radius: var(--neeto-ui-rounded-none);
+      transform: scale(1);
+      animation: nuifadeIn 0.3s forwards;
+    }
+
     .neeto-ui-modal__header {
       padding: var(--neeto-ui-modal-spacing) 64px 16px
         var(--neeto-ui-modal-spacing);

--- a/lib/styles/components/_modal.scss
+++ b/lib/styles/components/_modal.scss
@@ -68,7 +68,7 @@
       max-height: 100vh;
       border-radius: var(--neeto-ui-rounded-none);
       transform: scale(1);
-      animation: nuifadeIn 0.3s forwards;
+      animation: nuifadeIn 0s forwards;
     }
 
     .neeto-ui-modal__header {

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -87,7 +87,7 @@ export const Sizes = () => {
             />
             <Button label="Medium" onClick={() => setShowModalMedium(true)} />
             <Button label="Large" onClick={() => setShowModalLarge(true)} />
-            <Button label="Full Screen" onClick={() => setShowModalFullScreen(true)} />
+            <Button label="Full screen" onClick={() => setShowModalFullScreen(true)} />
           </div>
         </div>
       </div>
@@ -190,11 +190,11 @@ export const Sizes = () => {
           </Typography>
         </Modal.Body>
         <Modal.Footer className="space-x-2">
-          <Button label="Continue" onClick={() => setShowModalLarge(false)} />
+          <Button label="Continue" onClick={() => setShowModalFullScreen(false)} />
           <Button
             style="text"
             label="Cancel"
-            onClick={() => setShowModalLarge(false)}
+            onClick={() => setShowModalFullScreen(false)}
           />
         </Modal.Footer>
       </Modal>

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -74,6 +74,7 @@ export const Sizes = () => {
   const [showModalExtraSmall, setShowModalExtraSmall] = useState(false);
   const [showModalMedium, setShowModalMedium] = useState(false);
   const [showModalLarge, setShowModalLarge] = useState(false);
+  const [showModalFullScreen, setShowModalFullScreen] = useState(false);
 
   return (
     <div className="w-full">
@@ -86,6 +87,7 @@ export const Sizes = () => {
             />
             <Button label="Medium" onClick={() => setShowModalMedium(true)} />
             <Button label="Large" onClick={() => setShowModalLarge(true)} />
+            <Button label="Full Screen" onClick={() => setShowModalFullScreen(true)} />
           </div>
         </div>
       </div>
@@ -145,6 +147,34 @@ export const Sizes = () => {
         isOpen={showModalLarge}
         onClose={() => setShowModalLarge(false)}
         size="large"
+      >
+        <Modal.Header>
+          <Typography style="h2">They're creepy & they're kooky</Typography>
+        </Modal.Header>
+        <Modal.Body>
+          <Typography style="body2" lineHeight="normal">
+            Somewhere out in space live the Herculoids! Zok, the laser-ray
+            dragon! Igoo, the giant rock ape! Tundro, the tremendous! Gloop and
+            Gleep, the formless, fearless wonders! With Zandor, their leader,
+            and his wife, Tara, and son, Dorno, they team up to protect their
+            planet from sinister invaders! All-strong! All-brave! All-heroes!
+            They're the Herculoids!
+          </Typography>
+        </Modal.Body>
+        <Modal.Footer className="space-x-2">
+          <Button label="Continue" onClick={() => setShowModalLarge(false)} />
+          <Button
+            style="text"
+            label="Cancel"
+            onClick={() => setShowModalLarge(false)}
+          />
+        </Modal.Footer>
+      </Modal>
+
+      <Modal
+        isOpen={showModalFullScreen}
+        onClose={() => setShowModalFullScreen(false)}
+        size="fullScreen"
       >
         <Modal.Header>
           <Typography style="h2">They're creepy & they're kooky</Typography>

--- a/stories/Overlays/Pane.stories.jsx
+++ b/stories/Overlays/Pane.stories.jsx
@@ -335,6 +335,82 @@ export const MultiplePanes = () => {
 };
 MultiplePanes.storyName = "Nested panes with modals";
 
+export const Sizes = () => {
+  const [showPaneExtraSmall, setShowPaneExtraSmall] = useState(false);
+  const [showPaneLarge, setShowPaneLarge] = useState(false);
+
+  return (
+    <div className="w-full">
+      <div className="space-y-6">
+        <div className="w-1/2 space-y-8">
+          <div className="flex flex-row items-center justify-start space-x-6">
+            <Button
+              label="Small"
+              onClick={() => setShowPaneExtraSmall(true)}
+            />
+            <Button label="Large" onClick={() => setShowPaneLarge(true)} />
+          </div>
+        </div>
+      </div>
+
+      <Pane
+        isOpen={showPaneExtraSmall}
+        onClose={() => setShowPaneExtraSmall(false)}
+        size="small"
+      >
+        <Pane.Header>
+          <Typography style="h2">They're creepy & they're kooky</Typography>
+        </Pane.Header>
+        <Pane.Body>
+          <Typography style="body2" lineHeight="normal">
+            Somewhere out in space live the Herculoids! Zok, the laser-ray
+            dragon! Igoo, the giant rock ape! Tundro, the tremendous!
+          </Typography>
+        </Pane.Body>
+        <Pane.Footer className="space-x-2">
+          <Button
+            label="Continue"
+            onClick={() => setShowPaneExtraSmall(false)}
+          />
+          <Button
+            style="text"
+            label="Cancel"
+            onClick={() => setShowPaneExtraSmall(false)}
+          />
+        </Pane.Footer>
+      </Pane>
+
+      <Pane
+        isOpen={showPaneLarge}
+        onClose={() => setShowPaneLarge(false)}
+        size="large"
+      >
+        <Pane.Header>
+          <Typography style="h2">They're creepy & they're kooky</Typography>
+        </Pane.Header>
+        <Pane.Body>
+          <Typography style="body2" lineHeight="normal">
+            Somewhere out in space live the Herculoids! Zok, the laser-ray
+            dragon! Igoo, the giant rock ape! Tundro, the tremendous! Gloop and
+            Gleep, the formless, fearless wonders! With Zandor, their leader,
+            and his wife, Tara, and son, Dorno, they team up to protect their
+            planet from sinister invaders! All-strong! All-brave! All-heroes!
+            They're the Herculoids!
+          </Typography>
+        </Pane.Body>
+        <Pane.Footer className="space-x-2">
+          <Button label="Continue" onClick={() => setShowPaneLarge(false)} />
+          <Button
+            style="text"
+            label="Cancel"
+            onClick={() => setShowPaneLarge(false)}
+          />
+        </Pane.Footer>
+      </Pane>
+    </div>
+  );
+};
+
 export const PaneWithOverlayManager = () => {
   const [isFirstPaneVisible, setIsFirstPaneVisible] = useState(false);
   const [isSecondPaneVisible, setIsSecondPaneVisible] = useState(false);

--- a/stories/Overlays/Pane.stories.jsx
+++ b/stories/Overlays/Pane.stories.jsx
@@ -82,6 +82,82 @@ export const Default = () => {
   );
 };
 
+export const Sizes = () => {
+  const [showPaneExtraSmall, setShowPaneExtraSmall] = useState(false);
+  const [showPaneLarge, setShowPaneLarge] = useState(false);
+
+  return (
+    <div className="w-full">
+      <div className="space-y-6">
+        <div className="w-1/2 space-y-8">
+          <div className="flex flex-row items-center justify-start space-x-6">
+            <Button
+              label="Small"
+              onClick={() => setShowPaneExtraSmall(true)}
+            />
+            <Button label="Large" onClick={() => setShowPaneLarge(true)} />
+          </div>
+        </div>
+      </div>
+
+      <Pane
+        isOpen={showPaneExtraSmall}
+        onClose={() => setShowPaneExtraSmall(false)}
+        size="small"
+      >
+        <Pane.Header>
+          <Typography style="h2">They're creepy & they're kooky</Typography>
+        </Pane.Header>
+        <Pane.Body>
+          <Typography style="body2" lineHeight="normal">
+            Somewhere out in space live the Herculoids! Zok, the laser-ray
+            dragon! Igoo, the giant rock ape! Tundro, the tremendous!
+          </Typography>
+        </Pane.Body>
+        <Pane.Footer className="space-x-2">
+          <Button
+            label="Continue"
+            onClick={() => setShowPaneExtraSmall(false)}
+          />
+          <Button
+            style="text"
+            label="Cancel"
+            onClick={() => setShowPaneExtraSmall(false)}
+          />
+        </Pane.Footer>
+      </Pane>
+
+      <Pane
+        isOpen={showPaneLarge}
+        onClose={() => setShowPaneLarge(false)}
+        size="large"
+      >
+        <Pane.Header>
+          <Typography style="h2">They're creepy & they're kooky</Typography>
+        </Pane.Header>
+        <Pane.Body>
+          <Typography style="body2" lineHeight="normal">
+            Somewhere out in space live the Herculoids! Zok, the laser-ray
+            dragon! Igoo, the giant rock ape! Tundro, the tremendous! Gloop and
+            Gleep, the formless, fearless wonders! With Zandor, their leader,
+            and his wife, Tara, and son, Dorno, they team up to protect their
+            planet from sinister invaders! All-strong! All-brave! All-heroes!
+            They're the Herculoids!
+          </Typography>
+        </Pane.Body>
+        <Pane.Footer className="space-x-2">
+          <Button label="Continue" onClick={() => setShowPaneLarge(false)} />
+          <Button
+            style="text"
+            label="Cancel"
+            onClick={() => setShowPaneLarge(false)}
+          />
+        </Pane.Footer>
+      </Pane>
+    </div>
+  );
+};
+
 export const PaneWithLongTitle = () => {
   const [showPane, setShowPane] = useState(false);
   const inputRef = React.useRef(null);
@@ -334,82 +410,6 @@ export const MultiplePanes = () => {
   );
 };
 MultiplePanes.storyName = "Nested panes with modals";
-
-export const Sizes = () => {
-  const [showPaneExtraSmall, setShowPaneExtraSmall] = useState(false);
-  const [showPaneLarge, setShowPaneLarge] = useState(false);
-
-  return (
-    <div className="w-full">
-      <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
-            <Button
-              label="Small"
-              onClick={() => setShowPaneExtraSmall(true)}
-            />
-            <Button label="Large" onClick={() => setShowPaneLarge(true)} />
-          </div>
-        </div>
-      </div>
-
-      <Pane
-        isOpen={showPaneExtraSmall}
-        onClose={() => setShowPaneExtraSmall(false)}
-        size="small"
-      >
-        <Pane.Header>
-          <Typography style="h2">They're creepy & they're kooky</Typography>
-        </Pane.Header>
-        <Pane.Body>
-          <Typography style="body2" lineHeight="normal">
-            Somewhere out in space live the Herculoids! Zok, the laser-ray
-            dragon! Igoo, the giant rock ape! Tundro, the tremendous!
-          </Typography>
-        </Pane.Body>
-        <Pane.Footer className="space-x-2">
-          <Button
-            label="Continue"
-            onClick={() => setShowPaneExtraSmall(false)}
-          />
-          <Button
-            style="text"
-            label="Cancel"
-            onClick={() => setShowPaneExtraSmall(false)}
-          />
-        </Pane.Footer>
-      </Pane>
-
-      <Pane
-        isOpen={showPaneLarge}
-        onClose={() => setShowPaneLarge(false)}
-        size="large"
-      >
-        <Pane.Header>
-          <Typography style="h2">They're creepy & they're kooky</Typography>
-        </Pane.Header>
-        <Pane.Body>
-          <Typography style="body2" lineHeight="normal">
-            Somewhere out in space live the Herculoids! Zok, the laser-ray
-            dragon! Igoo, the giant rock ape! Tundro, the tremendous! Gloop and
-            Gleep, the formless, fearless wonders! With Zandor, their leader,
-            and his wife, Tara, and son, Dorno, they team up to protect their
-            planet from sinister invaders! All-strong! All-brave! All-heroes!
-            They're the Herculoids!
-          </Typography>
-        </Pane.Body>
-        <Pane.Footer className="space-x-2">
-          <Button label="Continue" onClick={() => setShowPaneLarge(false)} />
-          <Button
-            style="text"
-            label="Cancel"
-            onClick={() => setShowPaneLarge(false)}
-          />
-        </Pane.Footer>
-      </Pane>
-    </div>
-  );
-};
 
 export const PaneWithOverlayManager = () => {
   const [isFirstPaneVisible, setIsFirstPaneVisible] = useState(false);


### PR DESCRIPTION
Fixes #1450 

- Added `fullScreen` size for _Modal_ component
- Added Sizes block in _Pane_ storybook

**Checklist**

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@praveen-murali-ind _a Please check and merge.

<img width="1904" alt="Screenshot 2022-12-06 at 3 22 34 PM" src="https://user-images.githubusercontent.com/24496302/205878756-5786dc10-fc04-417c-9263-36a8f6bbf0e0.png">
<img width="1904" alt="Screenshot 2022-12-06 at 3 22 39 PM" src="https://user-images.githubusercontent.com/24496302/205878805-eda23718-38d4-4341-9422-860af266748b.png">
<img width="1904" alt="Screenshot 2022-12-06 at 3 22 57 PM" src="https://user-images.githubusercontent.com/24496302/205878813-e08b2f1c-f4ee-4d81-8388-3f51bd16c851.png">
<img width="1904" alt="Screenshot 2022-12-06 at 3 23 01 PM" src="https://user-images.githubusercontent.com/24496302/205878822-1a28174f-806b-4a26-bdef-fce67b6ba847.png">


<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
