### PR TITLE
Fixed issue with column header overlapping on fixed column type tables

### DIFF
--- a/lib/styles/components/_table.scss
+++ b/lib/styles/components/_table.scss
@@ -4,6 +4,11 @@
   width: 100%;
   border-collapse: collapse;
 
+  table tr th.ant-table-selection-column,
+  table tr td.ant-table-selection-column {
+    z-index: 9999;
+  }
+
   .ant-table-cell-fix-left,
   .ant-table-cell-fix-right {
     background-color: rgb(var(--neeto-ui-white));

--- a/lib/styles/vendors/_antd-table.scss
+++ b/lib/styles/vendors/_antd-table.scss
@@ -813,7 +813,7 @@ table tr td.ant-table-selection-column {
   padding-right: 8px;
   padding-left: 8px;
   text-align: center;
-  z-index: 9999;
+  z-index: 1;
 }
 table tr th.ant-table-selection-column .ant-radio-wrapper,
 table tr td.ant-table-selection-column .ant-radio-wrapper {


### PR DESCRIPTION
Fixes #1429 

**Description**
Fixed: Issue with overlapping column headers for fixed columns in tables.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@praveen-murali-ind _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
