### PR TITLE
Sets validateOnBlur and validateOnChange to true after first form validation

### DIFF
--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -4,7 +4,7 @@ import { Form as FormikForm, useFormikContext } from "formik";
 
 const FormWrapper = forwardRef(
   (
-    { className, formProps, children, onSubmit, setHasFormSubmitted },
+    { className, formProps, children, onSubmit, setEnableChangeAndBlurValidation },
     formRef
   ) => {
     const {
@@ -34,6 +34,7 @@ const FormWrapper = forwardRef(
           if (!isFormDirty) return;
 
           validateForm().then((errors) => {
+            setEnableChangeAndBlurValidation(true);
             if (Object.keys(errors).length > 0) {
               setErrors(errors);
               setTouched(errors);
@@ -48,7 +49,7 @@ const FormWrapper = forwardRef(
 
     useEffect(() => {
       if (submitCount === 1) {
-        setHasFormSubmitted(true);
+        setEnableChangeAndBlurValidation(true);
       }
     }, [submitCount]);
 

--- a/lib/components/formik/Form/index.js
+++ b/lib/components/formik/Form/index.js
@@ -6,12 +6,12 @@ import FormWrapper from "./FormWrapper";
 
 const Form = forwardRef(
   ({ className, children, formikProps, formProps }, ref) => {
-    const [hasFormSubmitted, setHasFormSubmitted] = useState(false);
+    const [enabledChangeAndBlurValidation, setEnableChangeAndBlurValidation] = useState(false);
     return (
       <Formik
         {...formikProps}
-        validateOnBlur={formikProps?.validateOnBlur && hasFormSubmitted}
-        validateOnChange={formikProps?.validateOnChange && hasFormSubmitted}
+        validateOnBlur={formikProps?.validateOnBlur && enabledChangeAndBlurValidation}
+        validateOnChange={formikProps?.validateOnChange && enabledChangeAndBlurValidation}
       >
         {(props) => (
           <FormWrapper
@@ -19,7 +19,7 @@ const Form = forwardRef(
             formProps={formProps}
             className={className}
             onSubmit={formikProps?.onSubmit}
-            setHasFormSubmitted={setHasFormSubmitted}
+            setEnableChangeAndBlurValidation={setEnableChangeAndBlurValidation}
           >
             {typeof children === "function" ? children(props) : children}
           </FormWrapper>


### PR DESCRIPTION
Fixes #1469 

**Description**
 - Fixed: __Form__ `validateOnChange` and `validateOnBlur` is not being triggered after the form is submitted by pressing enter key and there are validation errors.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
