### PR TITLE
Fixes pressing enter key in selectbox to select an option submitting form.

### DIFF
--- a/lib/components/formik/Select.js
+++ b/lib/components/formik/Select.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useRef } from "react";
 import { useField } from "formik";
 import PropTypes from "prop-types";
 
@@ -15,6 +15,8 @@ const SelectField = forwardRef((props, ref) => {
     ...otherProps
   } = props;
   const [field, meta, { setValue, setTouched }] = useField(name);
+
+  const isMenuOpen = useRef(otherProps.defaultMenuIsOpen);
 
   const getRealOptionValue = (option) => {
     if (typeof getOptionValue !== "function") {
@@ -45,6 +47,20 @@ const SelectField = forwardRef((props, ref) => {
       getOptionValue={getOptionValue || ((option) => option.value)}
       isMulti={!!isMulti}
       {...otherProps}
+      onMenuOpen={() => {
+        isMenuOpen.current = true;
+        otherProps.onMenuOpen?.();
+      }}
+      onMenuClose={() => {
+        isMenuOpen.current = false;
+        otherProps.onMenuClose?.();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" && isMenuOpen.current) {
+          event.stopPropagation();
+        }
+        otherProps.onKeyDown?.(event);
+      }}
     />
   );
 });


### PR DESCRIPTION
Fixes #1475 

**Description**
- Fixed: pressing `enter` key in _Select_ to select an option submitting the _Form_.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
