### PR TITLE
Wraps Checkbox and MultiEmailInput with forwardref

### DIFF
--- a/lib/components/Checkbox.js
+++ b/lib/components/Checkbox.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 import { useId } from "@reach/auto-id";
@@ -6,14 +6,14 @@ import { useId } from "@reach/auto-id";
 import { hyphenize } from "../common";
 import Label from "./Label";
 
-const Checkbox = ({
+const Checkbox = forwardRef(({
   label = "",
   error = "",
   className = "",
   required = false,
   labelProps,
   ...otherProps
-}) => {
+}, ref) => {
   const id = useId(otherProps.id);
   const errorId = `error_${id}`;
 
@@ -27,6 +27,7 @@ const Checkbox = ({
           className="neeto-ui-checkbox"
           required={required}
           aria-invalid={!!error}
+          ref={ref}
           {...otherProps}
         />
         {label && (
@@ -51,7 +52,7 @@ const Checkbox = ({
       )}
     </div>
   );
-};
+});
 
 Checkbox.propTypes = {
   /**

--- a/lib/components/MultiEmailInput.js
+++ b/lib/components/MultiEmailInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, forwardRef } from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 import { components } from "react-select";
@@ -60,7 +60,7 @@ const CUSTOM_COMPONENTS = {
   MultiValueRemove: MultiValueRemove,
 };
 
-const MultiEmailInput = ({
+const MultiEmailInput = forwardRef(({
   label = "Email(s)",
   placeholder = "",
   helpText = "",
@@ -74,7 +74,7 @@ const MultiEmailInput = ({
   maxHeight = 200,
   labelProps,
   ...otherProps
-}) => {
+}, ref) => {
   const [inputValue, setInputValue] = useState("");
 
   const isCounterVisible =
@@ -163,6 +163,7 @@ const MultiEmailInput = ({
           }),
         }}
         isDisabled={disabled}
+        ref={ref}
         {...otherProps}
       />
       <div className="neeto-ui-email-input__bottom-info">
@@ -198,7 +199,7 @@ const MultiEmailInput = ({
       </div>
     </div>
   );
-};
+});
 
 MultiEmailInput.propTypes = {
   /**

--- a/lib/components/formik/Checkbox.js
+++ b/lib/components/formik/Checkbox.js
@@ -1,21 +1,22 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Field } from "formik";
 import PropTypes from "prop-types";
 
 import CheckboxField from "../Checkbox";
 
-const Checkbox = ({ name, ...rest }) => (
+const Checkbox = forwardRef(({ name, ...rest }, ref) => (
   <Field name={name}>
     {({ field, meta }) => (
       <CheckboxField
         checked={field.value}
         {...field}
         error={meta.touched && meta.error}
+        ref={ref}
         {...rest}
       />
     )}
   </Field>
-);
+));
 
 Checkbox.propTypes = {
   /**


### PR DESCRIPTION
Fixes #1471 

**Description**

Added: _Checkbox_ and _MultiEmailInput_ are wrapped with `forwardref`.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@amaldinesh7 

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
