### PR TITLE
Added configuration to remove prop-types imports in production

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,8 +19,10 @@ const plugins = [
     exclude: "node_modules/**",
     presets: ["@babel/preset-env", "@babel/preset-react"],
     plugins: [
-      process.env.NODE_ENV === "production" &&
-        "transform-react-remove-prop-types",
+      process.env.NODE_ENV === "production" && [
+        "babel-plugin-transform-react-remove-prop-types",
+        { removeImport: true },
+      ],
       "@babel/plugin-transform-runtime",
       [
         "import",


### PR DESCRIPTION
**Description**
- Fixed: prop-types imports were not removed while building production bundle

**Checklist**

- [x] I have performed a self-review of my code
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@amaldinesh7 _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
