### PR TITLE
Added option to load options without creatable

### DIFF
--- a/lib/components/Select.js
+++ b/lib/components/Select.js
@@ -3,6 +3,7 @@ import classnames from "classnames";
 import PropTypes from "prop-types";
 import SelectInput, { components } from "react-select";
 import AsyncCreatable from "react-select/async-creatable";
+import Async from "react-select/async";
 import Creatable from "react-select/creatable";
 import Label from "./Label";
 import { hyphenize } from "../common";
@@ -56,7 +57,7 @@ const Select = ({
   }
 
   if (otherProps.loadOptions) {
-    Parent = AsyncCreatable;
+    Parent = isCreateable ? AsyncCreatable : Async;
   }
 
   const portalProps = strategy === STRATEGIES.fixed && {


### PR DESCRIPTION
Fixes #1505 

**Description**

- Fixed: respecting the prop `isCreatable` if `loadOptions` prop is provided in _Select_ component

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
