### PR TITLE
Adds check whether form is being submitted when submit on enter is triggered.

### DIFF
--- a/lib/components/formik/Form/FormWrapper.js
+++ b/lib/components/formik/Form/FormWrapper.js
@@ -16,7 +16,7 @@ const FormWrapper = forwardRef(
       ...formikBag
     } = useFormikContext();
 
-    const isFormDirty = formikBag.dirty;
+    const { dirty: isFormDirty, isSubmitting } = formikBag;
 
     const handleKeyDown = useCallback(
       (event) => {
@@ -31,7 +31,7 @@ const FormWrapper = forwardRef(
         if (event.shiftKey) {
           return;
         } else {
-          if (!isFormDirty) return;
+          if (!isFormDirty || isSubmitting) return;
 
           validateForm().then((errors) => {
             setEnableChangeAndBlurValidation(true);
@@ -44,7 +44,7 @@ const FormWrapper = forwardRef(
           });
         }
       },
-      [values, validateForm, setErrors, setTouched, onSubmit, isFormDirty]
+      [values, validateForm, setErrors, setTouched, onSubmit, isFormDirty, isSubmitting]
     );
 
     useEffect(() => {


### PR DESCRIPTION
Fixes #1501 

**Description**

- Fixed: Submit on enter triggered when _Form_ was being submitted.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**
@amaldinesh7 

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
