### PR TITLE
Allowed overrides for components

### DIFF
--- a/lib/components/Select.js
+++ b/lib/components/Select.js
@@ -50,6 +50,7 @@ const Select = ({
   labelProps,
   value,
   defaultValue,
+  components: componentOverrides,
   ...otherProps
 }) => {
   const inputId = useId(id);
@@ -94,12 +95,7 @@ const Select = ({
     );
   };
 
-  const {
-    options,
-    defaultOptions,
-    getOptionValue,
-    components: componentOverrides,
-  } = otherProps;
+  const { options, defaultOptions, getOptionValue } = otherProps;
 
   const getRealOptionValue = (option) => {
     if (typeof getOptionValue !== "function") {


### PR DESCRIPTION
Fixes #1622 

**Description**

- Fixed: Issue with overriding components in _Select_ component

**Checklist**

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish is required)
- [ ] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
