### PR TITLE
Removed react-router-nav-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Starting `3.0.x`, neetoUI stylesheet has been separated from the bundle. To get 
 **neetoUI** has few peer dependencies which are required to use neetoUI properly. Install the peer dependencies using the below command:
 
 ```
-yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 react-router-nav-prompt@0.4.1
+yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0
 ```
 
 **neetoUI** depends on `react-toastify` for Toasters, so the styles for toaster must be imported to your main `scss` entry point.

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = () => {
       "^utils/(.*)$": path.resolve(__dirname, "src/utils", "$1"),
     },
     transformIgnorePatterns: [
-      "/node_modules/(?!(@babel|react-router-nav-prompt|@bigbinary/neeto-icons|rc-picker|rc-util))",
+      "/node_modules/(?!(@babel|@bigbinary/neeto-icons|rc-picker|rc-util))",
     ],
     testEnvironment: "jsdom",
     setupFilesAfterEnv: ["./jest-setup.js"],

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "react-linkify": "1.0.0-alpha",
     "react-outside-click-handler": "1.3.0",
     "react-router-dom": "5.3.0",
-    "react-router-nav-prompt": "0.4.1",
     "react-select": "5.6.0",
     "react-spring": "8.0.27",
     "react-test-renderer": "17.0.2",
@@ -146,7 +145,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "5.3.0",
-    "react-router-nav-prompt": "0.4.1",
     "react-toastify": "8.0.2"
   },
   "resolutions": {

--- a/stories/Introduction/GettingStarted.stories.mdx
+++ b/stories/Introduction/GettingStarted.stories.mdx
@@ -33,7 +33,7 @@ neetoUI has few peer dependencies which are required to use neetoUI properly. In
 <div className="sbdocs-install-code">
 
 ```
-yarn add react-toastify@8.0.2 formik@2.2.0 react-router-dom@5.2.0 react-router-nav-prompt@0.4.1 antd@4.24.3
+yarn add react-toastify@8.0.2 formik@2.2.0 react-router-dom@5.2.0 antd@4.24.3
 ```
 
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12814,11 +12814,6 @@ react-router-dom@5.3.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router-nav-prompt@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/react-router-nav-prompt/-/react-router-nav-prompt-0.4.1.tgz#d4e09466098efe4cd0bc64a2d843e1ddb39dd0b7"
-  integrity sha512-I7rJln0+OW46/az8JIbygccx+dvg9IzEHX76ikQ3mu1rcAHB6dOqqsXIwIWbIfTeoffm1QlGuLheF9fBy1bz6w==
-
 react-router@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"


### PR DESCRIPTION
Fixes #1591 

**Description**

- Removed:  `react-router-nav-prompt`

**Checklist**

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish is required)
- [ ] I have followed the suggested description format and styling

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
