### PR TITLE
Updated the default row size to 30 and hidden the page size changer

### DIFF
--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -19,7 +19,7 @@ const Table = ({
   className = "",
   columnData = [],
   currentPageNumber = 1,
-  defaultPageSize = 15,
+  defaultPageSize = 30,
   handlePageChange = noop,
   loading = false,
   onRowClick,
@@ -47,7 +47,9 @@ const Table = ({
   );
 
   useTimeout(() => {
-    const headerHeight = headerRef.current ? headerRef.current.offsetHeight : TABLE_DEFAULT_HEADER_HEIGHT;
+    const headerHeight = headerRef.current
+      ? headerRef.current.offsetHeight
+      : TABLE_DEFAULT_HEADER_HEIGHT;
     setHeaderHeight(headerHeight);
   }, 0);
 
@@ -85,7 +87,7 @@ const Table = ({
     containerHeight -
     headerHeight -
     (isPaginationVisible ? TABLE_PAGINATION_HEIGHT : 0);
-  
+
   const itemRender = (_, type, originalElement) => {
     if (type === "prev") {
       return <Button style="text" className="" icon={Left} />;
@@ -148,6 +150,7 @@ const Table = ({
       pagination={{
         hideOnSinglePage: true,
         ...paginationProps,
+        showSizeChanger: false,
         total: totalCount ?? 0,
         current: currentPageNumber,
         defaultPageSize: shouldDynamicallyRenderRowSize
@@ -163,11 +166,11 @@ const Table = ({
             allowRowClick && onRowClick && onRowClick(event, record, rowIndex),
         };
       }}
-      onHeaderRow={()=>{
+      onHeaderRow={() => {
         return {
           ref: headerRef,
           className: "neeto-ui-table__header",
-          id: "neeto-ui-table__header"
+          id: "neeto-ui-table__header",
         };
       }}
       locale={locale}


### PR DESCRIPTION
Fixes #1650 

**Description**

- Changed: -the default row size to 30 and hidden the page size changer in the _Table_ component.

**Checklist**

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish is required)
- [x] I have followed the suggested description format and styling

**Reviewers**

@ajmaln _a Please review.

@ajmaln _a Please review

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
