### PR TITLE
Fixed button type in color picker

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -70,6 +70,7 @@ const ColorPicker = ({
 
   const Target = ({ size }) => (
     <button
+     type="button"
       data-cy="color-picker-target"
       className={classnames("neeto-ui-colorpicker__target", {
         "neeto-ui-colorpicker__target-size--large": size === TARGET_SIZES.large,
@@ -115,6 +116,7 @@ const ColorPicker = ({
               onClick={pickColor}
               size="small"
               className="neeto-ui-colorpicker__eyedropper-btn"
+              type="button"
             />
           )}
           <div className="neeto-ui-input__wrapper">


### PR DESCRIPTION
- Fixes #1662 

**Description**

- Fixed: defaulted buttons inside color picker to type `button`

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
