### PR TITLE
Allowed tooltip component to accept children array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -463,7 +463,6 @@ export interface TooltipProps {
   interactive?: boolean;
   hideAfter?: number;
   hideOnTargetExit?: boolean;
-  children: JSX.Element | string;
   [key: string]: any;
 }
 

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -20,7 +20,6 @@ const Tooltip = ({
   const [instance, setInstance] = useState(null);
 
   const localProps = {};
-  const childToBeRendered = Array.isArray(children) ? children[0] : children;
 
   if (hideAfter > 0) {
     localProps["onShow"] = instance =>
@@ -57,11 +56,7 @@ const Tooltip = ({
       {...localProps}
       {...otherProps}
     >
-      {React.isValidElement(childToBeRendered) ? (
-        childToBeRendered
-      ) : (
-        <span>{childToBeRendered}</span>
-      )}
+      {React.isValidElement(children) ? children : <span>{children}</span>}
     </Tippy>
   );
 };

--- a/tests/Tooltip.test.js
+++ b/tests/Tooltip.test.js
@@ -1,7 +1,9 @@
 import React from "react";
-import { Tooltip, Typography } from "components";
+
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+import { Tooltip, Typography } from "components";
 
 describe("Tooltip", () => {
   it("should render on hover", () => {
@@ -22,6 +24,21 @@ describe("Tooltip", () => {
     userEvent.hover(text);
     const tooltip = screen.getByText("Tooltip");
     expect(tooltip).toBeInTheDocument();
+  });
+
+  it("should render properly when array of nodes is passed as children", () => {
+    render(
+      <Tooltip content="Tooltip">
+        <span>Hello</span>
+        <span>World</span>
+      </Tooltip>
+    );
+    const text1 = screen.getByText("Hello");
+    const text2 = screen.getByText("World");
+    userEvent.hover(text1);
+    expect(screen.getByText("Tooltip")).toBeInTheDocument();
+    userEvent.hover(text2);
+    expect(screen.getByText("Tooltip")).toBeInTheDocument();
   });
 
   it("should not render when user stops hovering", async () => {


### PR DESCRIPTION
- Fixes #1667 

**Description**
Added: Support for children array in _Tooltip_ component. 

**Checklist**

- ~[ ] I have made corresponding changes to the documentation.~
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
