### PR TITLE
Fixed Button style issue when using children prop for label

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import { AnimatePresence, motion } from "framer-motion";
+
 import classnames from "classnames";
+import { AnimatePresence, motion } from "framer-motion";
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 
 import { Spinner } from "atoms";
 
@@ -64,11 +65,11 @@ const Button = React.forwardRef(
     };
 
     const Icon =
-      typeof icon == "string"
+      typeof icon === "string"
         ? () => (
             <i
-              data-testid="class-icon"
               className={classnames("neeto-ui-btn__icon", [icon])}
+              data-testid="class-icon"
             />
           )
         : icon || React.Fragment;
@@ -76,8 +77,8 @@ const Button = React.forwardRef(
     return (
       <Tooltip disabled={!tooltipProps} {...tooltipProps}>
         <Parent
+          disabled={disabled}
           ref={ref}
-          onClick={handleClick}
           className={classnames("neeto-ui-btn", [className], {
             "neeto-ui-btn--style-primary": style === BUTTON_STYLES.primary,
             "neeto-ui-btn--style-secondary": style === BUTTON_STYLES.secondary,
@@ -89,32 +90,31 @@ const Button = React.forwardRef(
             "neeto-ui-btn--size-medium": size === SIZES.medium,
             "neeto-ui-btn--size-large": size === SIZES.large,
             "neeto-ui-btn--width-full": fullWidth,
-            "neeto-ui-btn--icon-left": iconPosition == ICON_POSITIONS.left,
+            "neeto-ui-btn--icon-left": iconPosition === ICON_POSITIONS.left,
             "neeto-ui-btn--icon-only": !renderLabel,
-            disabled: disabled,
+            disabled,
           })}
-          disabled={disabled}
+          onClick={handleClick}
           {...elementSpecificProps}
           {...otherProps}
         >
           {renderLabel && <span>{renderLabel}</span>}
-
           <AnimatePresence exitBeforeEnter>
             {icon ? (
               /* When Icon is present, animate between the icon and the spinner*/
               loading ? (
                 <Spinner
                   aria-hidden="true"
+                  className="neeto-ui-btn__spinner"
                   key="1"
                   size={16}
-                  className="neeto-ui-btn__spinner"
                 />
               ) : (
                 <Icon
                   aria-hidden="true"
+                  className="neeto-ui-btn__icon"
                   key="2"
                   size={iconSize}
-                  className="neeto-ui-btn__icon"
                 />
               )
             ) : (
@@ -122,19 +122,19 @@ const Button = React.forwardRef(
               loading && (
                 <motion.div
                   className="neeto-ui-btn__spinner-wrapper"
+                  exit={{ width: 0, scale: 0 }}
                   initial={{ width: 0, scale: 0 }}
+                  transition={{ bounce: false }}
                   animate={{
                     width: "auto",
                     scale: 1,
                   }}
-                  exit={{ width: 0, scale: 0 }}
-                  transition={{ bounce: false }}
                 >
                   <Spinner
                     aria-hidden="true"
+                    className="neeto-ui-btn__spinner"
                     key="3"
                     size={16}
-                    className="neeto-ui-btn__spinner"
                   />
                 </motion.div>
               )
@@ -145,6 +145,8 @@ const Button = React.forwardRef(
     );
   }
 );
+
+Button.displayName = "Button";
 
 Button.propTypes = {
   /**


### PR DESCRIPTION
- Fixes #1676 

**Description**

- Fixed: _Button_ component style issue when using `children` prop for rendering label.

**Checklist**

- ~[ ] I have made corresponding changes to the documentation.~
- ~[ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
