### PR TITLE
Added unlmitedChars prop to input and textarea and updated the behaviour of maxlength prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -283,6 +283,8 @@ export interface InputProps
   contentSize?: number;
   required?: boolean;
   labelProps?: LabelProps;
+  maxLength?: number;
+  unlimitedChars: boolean;
 }
 
 export type LabelProps = {
@@ -412,6 +414,7 @@ export type TextareaProps = {
   className?: string;
   maxLength?: number;
   labelProps?: LabelProps;
+  unlimitedChars: boolean;
 } & React.DetailedHTMLProps<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
   HTMLTextAreaElement

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -1,7 +1,9 @@
+/* eslint-disable react/display-name */
 import React, { useState, forwardRef } from "react";
+
+import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
-import { useId } from "@reach/auto-id";
 
 import { hyphenize } from "utils";
 
@@ -26,6 +28,7 @@ const Input = forwardRef(
       contentSize = null,
       required = false,
       maxLength,
+      unlimitedChars = false,
       labelProps,
       ...otherProps
     },
@@ -40,11 +43,10 @@ const Input = forwardRef(
     const value = otherProps.value ?? valueInternal ?? "";
 
     const valueLength = value?.toString().length || 0;
-    const isCharacterLimitVisible = valueLength >= maxLength * 0.9;
-    const maxLengthError = !!maxLength && valueLength > maxLength;
+    const isCharacterLimitVisible = valueLength >= maxLength * 0.85;
+    const maxLengthError = unlimitedChars && valueLength > maxLength;
 
-
-    const onChangeInternal = (e) => setValueInternal(e.target.value);
+    const onChangeInternal = e => setValueInternal(e.target.value);
 
     const onChange = otherProps.onChange || onChangeInternal;
 
@@ -53,9 +55,9 @@ const Input = forwardRef(
         <div className="neeto-ui-input__label-wrapper">
           {label && (
             <Label
-              required={required}
               data-cy={`${hyphenize(label)}-input-label`}
               htmlFor={id}
+              required={required}
               {...labelProps}
             >
               {label}
@@ -63,10 +65,10 @@ const Input = forwardRef(
           )}
           {isCharacterLimitVisible && (
             <Typography
+              style="body2"
               className={classnames("neeto-ui-input__max-length", {
                 "neeto-ui-input__max-length--error": maxLengthError,
               })}
-              style="body2"
             >
               {valueLength}/{maxLength}
             </Typography>
@@ -84,18 +86,19 @@ const Input = forwardRef(
         >
           {prefix && <div className="neeto-ui-input__prefix">{prefix}</div>}
           <input
-            ref={ref}
-            id={id}
-            type={type}
-            disabled={disabled}
-            size={contentSize}
-            required={required}
             aria-invalid={!!error}
+            data-cy="input-field"
+            disabled={disabled}
+            id={id}
+            ref={ref}
+            required={required}
+            size={contentSize}
+            type={type}
             aria-describedby={classnames({
               [errorId]: !!error,
               [helpTextId]: helpText,
             })}
-            data-cy="input-field"
+            {...(maxLength && !unlimitedChars && { maxLength })}
             {...otherProps}
             value={value}
             onChange={onChange}
@@ -104,20 +107,20 @@ const Input = forwardRef(
         </div>
         {!!error && (
           <Typography
-            style="body3"
-            data-cy={`${hyphenize(label)}-input-error`}
             className="neeto-ui-input__error"
+            data-cy={`${hyphenize(label)}-input-error`}
             id={errorId}
+            style="body3"
           >
             {error}
           </Typography>
         )}
         {helpText && (
           <Typography
-            style="body3"
             className="neeto-ui-input__help-text"
-            id={helpTextId}
             data-cy={`${hyphenize(label)}-input-help`}
+            id={helpTextId}
+            style="body3"
           >
             {helpText}
           </Typography>
@@ -145,9 +148,13 @@ Input.propTypes = {
    */
   labelProps: PropTypes.object,
   /**
-   * To specify a maximum character limit to the Input. Charater limit is visible only if the Input value is greater than or equal to 90% of the maximum character limit.
+   * To specify a maximum character limit to the Input. Charater limit is visible only if the Input value is greater than or equal to 85% of the maximum character limit.
    */
-  maxLength: PropTypes.number,
+  maxLength: PropTypes.bool,
+  /**
+   * To be used along with maxLength prop. When set to true the character limit will not be enforced and character count will be shown in error state if the character limit is exceeded.
+   */
+  unlimitedChars: PropTypes.number,
   /**
    * To specify the text to be displayed above the Input.
    */

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -49,6 +49,7 @@ const Input = forwardRef(
     const onChangeInternal = e => setValueInternal(e.target.value);
 
     const onChange = otherProps.onChange || onChangeInternal;
+    const isMaxLengthPresent = !!maxLength || maxLength === 0;
 
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>
@@ -98,7 +99,7 @@ const Input = forwardRef(
               [errorId]: !!error,
               [helpTextId]: helpText,
             })}
-            {...(maxLength && !unlimitedChars && { maxLength })}
+            {...(isMaxLengthPresent && !unlimitedChars && { maxLength })}
             {...otherProps}
             value={value}
             onChange={onChange}
@@ -150,11 +151,11 @@ Input.propTypes = {
   /**
    * To specify a maximum character limit to the Input. Charater limit is visible only if the Input value is greater than or equal to 85% of the maximum character limit.
    */
-  maxLength: PropTypes.bool,
+  maxLength: PropTypes.number,
   /**
    * To be used along with maxLength prop. When set to true the character limit will not be enforced and character count will be shown in error state if the character limit is exceeded.
    */
-  unlimitedChars: PropTypes.number,
+  unlimitedChars: PropTypes.bool,
   /**
    * To specify the text to be displayed above the Input.
    */

--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -1,12 +1,14 @@
+/* eslint-disable react/display-name */
 import React, { useState, useEffect, forwardRef } from "react";
+
+import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
-import Label from "./Label";
-import { useId } from "@reach/auto-id";
 
 import { useSyncedRef } from "hooks";
 import { hyphenize } from "utils";
 
+import Label from "./Label";
 import Typography from "./Typography";
 
 const SIZES = { small: "small", medium: "medium", large: "large" };
@@ -24,6 +26,7 @@ const Textarea = forwardRef(
       label = "",
       className = "",
       maxLength,
+      unlimitedChars = false,
       labelProps,
       ...otherProps
     },
@@ -39,17 +42,17 @@ const Textarea = forwardRef(
     const textareaRef = useSyncedRef(ref);
 
     const valueLength = value?.toString().length || 0;
-    const isCharacterLimitVisible = valueLength >= maxLength * 0.9;
-    const maxLengthError = !!maxLength && valueLength > maxLength;
+    const isCharacterLimitVisible = valueLength >= maxLength * 0.85;
+    const maxLengthError = unlimitedChars && valueLength > maxLength;
 
-    const onChangeInternal = (e) => setValueInternal(e.target.value);
+    const onChangeInternal = e => setValueInternal(e.target.value);
     const onChange = otherProps.onChange ?? onChangeInternal;
 
     useEffect(() => {
       textareaRef.current.style.minHeight = "22px";
       textareaRef.current.style.height = "auto";
       const scrollHeight = textareaRef.current.scrollHeight;
-      textareaRef.current.style.height = scrollHeight + "px";
+      textareaRef.current.style.height = `${scrollHeight}px`;
     }, [value]);
 
     return (
@@ -57,9 +60,9 @@ const Textarea = forwardRef(
         <div className="neeto-ui-input__label-wrapper">
           {label && (
             <Label
-              required={required}
               data-cy={`${hyphenize(label)}-label`}
               htmlFor={id}
+              required={required}
               {...labelProps}
             >
               {label}
@@ -67,10 +70,10 @@ const Textarea = forwardRef(
           )}
           {isCharacterLimitVisible && (
             <Typography
+              style="body2"
               className={classnames("neeto-ui-input__max-length", {
                 "neeto-ui-input__max-length--error": maxLengthError,
               })}
-              style="body2"
             >
               {valueLength}/{maxLength}
             </Typography>
@@ -87,9 +90,10 @@ const Textarea = forwardRef(
           })}
         >
           <textarea
-            rows={rows}
-            ref={textareaRef}
             disabled={disabled}
+            ref={textareaRef}
+            rows={rows}
+            {...(maxLength && !unlimitedChars && { maxLength })}
             {...otherProps}
             value={value}
             onChange={onChange}
@@ -97,19 +101,19 @@ const Textarea = forwardRef(
         </div>
         {!!error && (
           <Typography
-            style="body3"
-            data-cy={`${hyphenize(label)}-input-error`}
             className="neeto-ui-input__error"
+            data-cy={`${hyphenize(label)}-input-error`}
             id={errorId}
+            style="body3"
           >
             {error}
           </Typography>
         )}
         {helpText && (
           <Typography
-            style="body3"
             className="neeto-ui-input__help-text"
             id={helpTextId}
+            style="body3"
           >
             {helpText}
           </Typography>
@@ -169,9 +173,13 @@ Textarea.propTypes = {
    */
   nakedTextarea: PropTypes.bool,
   /**
-   * To specify a maximum character limit to the Textarea.
+   * To specify a maximum character limit to the Textarea. Charater limit is visible only if the Textarea value is greater than or equal to 85% of the maximum character limit.
    */
-  maxLength: PropTypes.number,
+  maxLength: PropTypes.bool,
+  /**
+   * To be used along with maxLength prop. When set to true the character limit will not be enforced and character count will be shown in error state if the character limit is exceeded.
+   */
+  unlimitedChars: PropTypes.number,
 };
 
 export default Textarea;

--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -47,6 +47,7 @@ const Textarea = forwardRef(
 
     const onChangeInternal = e => setValueInternal(e.target.value);
     const onChange = otherProps.onChange ?? onChangeInternal;
+    const isMaxLengthPresent = !!maxLength || maxLength === 0;
 
     useEffect(() => {
       textareaRef.current.style.minHeight = "22px";
@@ -93,7 +94,7 @@ const Textarea = forwardRef(
             disabled={disabled}
             ref={textareaRef}
             rows={rows}
-            {...(maxLength && !unlimitedChars && { maxLength })}
+            {...(isMaxLengthPresent && !unlimitedChars && { maxLength })}
             {...otherProps}
             value={value}
             onChange={onChange}
@@ -175,11 +176,11 @@ Textarea.propTypes = {
   /**
    * To specify a maximum character limit to the Textarea. Charater limit is visible only if the Textarea value is greater than or equal to 85% of the maximum character limit.
    */
-  maxLength: PropTypes.bool,
+  maxLength: PropTypes.number,
   /**
    * To be used along with maxLength prop. When set to true the character limit will not be enforced and character count will be shown in error state if the character limit is exceeded.
    */
-  unlimitedChars: PropTypes.number,
+  unlimitedChars: PropTypes.bool,
 };
 
 export default Textarea;

--- a/stories/Components/Input.stories.jsx
+++ b/stories/Components/Input.stories.jsx
@@ -18,13 +18,12 @@ export default {
     },
     design: {
       type: "figma",
-      url:
-        "https://www.figma.com/file/zhdsnPzXzr264x1WUeVdmA/02-Components?node-id=104%3A11",
+      url: "https://www.figma.com/file/zhdsnPzXzr264x1WUeVdmA/02-Components?node-id=104%3A11",
     },
   },
 };
 
-const Template = (args) => <Input {...args} />;
+const Template = args => <Input {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
@@ -35,7 +34,7 @@ Default.args = {
 // eslint-disable-next-line no-empty-pattern
 export const Sizes = ({}) => {
   return (
-    <div className="flex flex-col w-full gap-3">
+    <div className="flex w-full flex-col gap-3">
       <Input label="Small" placeholder="Input placeholder" size="small" />
       <Input label="Medium" placeholder="Input placeholder" />
       <Input label="Large" placeholder="Input placeholder" size="large" />
@@ -50,7 +49,7 @@ export const Controlled = () => {
       prefix={<Search />}
       label="Controlled Input"
       value={value}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={e => setValue(e.target.value)}
     />
   );
 };
@@ -125,8 +124,9 @@ export const InputWithMaxLength = () => {
         placeholder="Input placeholder"
       />
       <Input
-        label="Input with max length"
+        label="Input with max length and unlimited characters"
         maxLength={10}
+        unlimitedChars={true}
         value="Sample Input"
         placeholder="Input placeholder"
       />
@@ -144,10 +144,10 @@ export const FormikInputStory = ({}) => {
           validationSchema: yup.object({
             name: yup.string().required("Name is required"),
           }),
-          onSubmit: (values) => window.alert(JSON.stringify(values)),
+          onSubmit: values => window.alert(JSON.stringify(values)),
         }}
       >
-        {(props) => (
+        {props => (
           <div className="space-y-2">
             <FormikInput name="name" label="Name" />
             <FormikInput name="email" type="email" label="Email" />

--- a/stories/Components/Textarea.stories.jsx
+++ b/stories/Components/Textarea.stories.jsx
@@ -14,13 +14,12 @@ export default {
     },
     design: {
       type: "figma",
-      url:
-        "https://www.figma.com/file/zhdsnPzXzr264x1WUeVdmA/02-Components?node-id=104%3A13",
+      url: "https://www.figma.com/file/zhdsnPzXzr264x1WUeVdmA/02-Components?node-id=104%3A13",
     },
   },
 };
 
-const Template = (args) => <Textarea {...args} />;
+const Template = args => <Textarea {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
@@ -30,11 +29,12 @@ Default.args = {
 
 export const Controlled = () => {
   const [value, setValue] = useState("BigBinary");
+
   return (
     <Textarea
       label="Controlled input"
       value={value}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={e => setValue(e.target.value)}
     />
   );
 };
@@ -75,10 +75,32 @@ NakedInput.args = {
   nakedTextarea: true,
 };
 
-export const TextareaWithMaxLength = Template.bind({});
+export const TextareaWithMaxLength = () => (
+  <div className="flex flex-col space-y-6">
+    <Textarea
+      label="Textarea with max length"
+      maxLength={10}
+      placeholder="Enter text"
+    />
+    <Textarea
+      label="Textarea with max length"
+      maxLength={10}
+      placeholder="Enter text"
+      value="Sample i"
+    />
+    <Textarea
+      label="Textarea with max length"
+      maxLength={10}
+      placeholder="Enter text"
+      value="Sample in"
+    />
+    <Textarea
+      unlimitedChars
+      label="Textarea with max length and unlimited characters"
+      maxLength={10}
+      placeholder="Enter text"
+      value="Sample Input"
+    />
+  </div>
+);
 TextareaWithMaxLength.storyName = "Textarea with max length";
-TextareaWithMaxLength.args = {
-  label: "Textarea with max length",
-  placeholder: "Enter text",
-  maxLength: 10,
-};

--- a/tests/Input.test.js
+++ b/tests/Input.test.js
@@ -65,6 +65,15 @@ describe("Input", () => {
       <Input id="input" label="Input label" maxLength={5} />
     );
     userEvent.type(getByLabelText("Input label"), "Testing maxLength");
+    expect(getByText(/5(.*)\/(.*)5/)).toBeInTheDocument();
+    expect(getByLabelText("Input label")).toHaveValue("Testi");
+  });
+
+  it("should properly handle maxLength with unlimitedChars", () => {
+    const { getByLabelText, getByText } = render(
+      <Input id="input" label="Input label" maxLength={5} unlimitedChars />
+    );
+    userEvent.type(getByLabelText("Input label"), "Testing maxLength");
     expect(getByText(/17(.*)\/(.*)5/)).toBeInTheDocument();
     expect(getByLabelText("Input label")).toHaveValue("Testing maxLength");
   });

--- a/tests/Textarea.test.js
+++ b/tests/Textarea.test.js
@@ -1,7 +1,9 @@
 import React from "react";
+
 import { render } from "@testing-library/react";
-import { Textarea } from "components";
 import userEvent from "@testing-library/user-event";
+
+import { Textarea } from "components";
 
 describe("Textarea", () => {
   it("should render without error", () => {
@@ -27,14 +29,14 @@ describe("Textarea", () => {
 
   it("should display helpText", () => {
     const { getByText } = render(
-      <Textarea id="text" label="Textarea" helpText="Help text" />
+      <Textarea helpText="Help text" id="text" label="Textarea" />
     );
     expect(getByText("Help text")).toBeInTheDocument();
   });
 
   it("should display error message", () => {
     const { getByText } = render(
-      <Textarea id="text" label="Textarea" error="Error message" />
+      <Textarea error="Error message" id="text" label="Textarea" />
     );
     expect(getByText("Error message")).toBeInTheDocument();
   });
@@ -42,6 +44,15 @@ describe("Textarea", () => {
   it("should properly handle maxLength", () => {
     const { getByLabelText, getByText } = render(
       <Textarea id="text" label="Textarea" maxLength={5} />
+    );
+    userEvent.type(getByLabelText("Textarea"), "Testing maxLength");
+    expect(getByText(/5(.*)\/(.*)5/)).toBeInTheDocument();
+    expect(getByLabelText("Textarea")).toHaveValue("Testi");
+  });
+
+  it("should properly handle maxLength", () => {
+    const { getByLabelText, getByText } = render(
+      <Textarea unlimitedChars id="text" label="Textarea" maxLength={5} />
     );
     userEvent.type(getByLabelText("Textarea"), "Testing maxLength");
     expect(getByText(/17(.*)\/(.*)5/)).toBeInTheDocument();


### PR DESCRIPTION
- Fixes #1675 

**Description**

- Added: `unlmitedChars` prop to _Input_ and _Textarea_ and reverted the behaviour of maxlength prop to the native one.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@ajmaln _a Please review

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
