### PR TITLE
Fixed multi-dropdown position in Safari

### DIFF
--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -86,6 +86,7 @@
   }
   .neeto-ui-dropdown__popup-menu-item {
     all: unset;
+    display: block;
   }
   .neeto-ui-dropdown__popup-menu-item-btn {
     width: 100%;


### PR DESCRIPTION
- Fixes #1680 

**Description**

- Fixed: multi dropdown position in Safari.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

Before

<img width="195" alt="Screenshot 2023-04-13 at 4 52 48 PM" src="https://user-images.githubusercontent.com/48869249/231744142-c79825b1-843f-4c7a-b4b4-2c899a7d59dc.png">

After

<img width="362" alt="Screenshot 2023-04-13 at 4 53 02 PM" src="https://user-images.githubusercontent.com/48869249/231744201-3655d190-80c4-4a24-afd5-5a98b3705442.png">

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
