### PR TITLE
Removed the `sticky` prop from the table

### DIFF
--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useRef, useState } from "react";
+
 import { Table as AntTable } from "antd";
 import classnames from "classnames";
+import { Left, Right, MenuHorizontal } from "neetoicons";
 import PropTypes from "prop-types";
-import { Left, Right, MenuHorizontal } from "@bigbinary/neeto-icons";
 
+import { useTimeout } from "hooks";
 import { noop } from "utils";
 
-import Typography from "./Typography";
 import Button from "./Button";
-import { useTimeout } from "hooks";
+import Typography from "./Typography";
 
 const TABLE_PAGINATION_HEIGHT = 64;
 const TABLE_DEFAULT_HEADER_HEIGHT = 40;
@@ -41,8 +42,12 @@ const Table = ({
   const headerRef = useRef();
 
   const resizeObserver = useRef(
-    new ResizeObserver(([{ contentRect: { height } }]) =>
-      setContainerHeight(height)
+    new ResizeObserver(
+      ([
+        {
+          contentRect: { height },
+        },
+      ]) => setContainerHeight(height)
     )
   );
 
@@ -54,7 +59,7 @@ const Table = ({
   }, 0);
 
   const tableRef = useCallback(
-    (table) => {
+    table => {
       if (fixedHeight) {
         if (table !== null) {
           resizeObserver.current.observe(table?.parentNode);
@@ -90,19 +95,19 @@ const Table = ({
 
   const itemRender = (_, type, originalElement) => {
     if (type === "prev") {
-      return <Button style="text" className="" icon={Left} />;
+      return <Button className="" icon={Left} style="text" />;
     }
 
     if (type === "next") {
-      return <Button style="text" className="" icon={Right} />;
+      return <Button className="" icon={Right} style="text" />;
     }
 
     if (type === "jump-prev") {
-      return <Button style="text" className="" icon={MenuHorizontal} />;
+      return <Button className="" icon={MenuHorizontal} style="text" />;
     }
 
     if (type === "jump-next") {
-      return <Button style="text" className="" icon={MenuHorizontal} />;
+      return <Button className="" icon={MenuHorizontal} style="text" />;
     }
 
     return originalElement;
@@ -113,6 +118,7 @@ const Table = ({
     const rowsPerPage = Math.floor(
       ((viewportHeight - TABLE_PAGINATION_HEIGHT) / TABLE_ROW_HEIGHT) * 3
     );
+
     return Math.ceil(rowsPerPage / 10) * 10;
   };
 
@@ -122,7 +128,7 @@ const Table = ({
       : defaultPageSize;
 
     const pageSizeOptions = [...Array(5).keys()].map(
-      (i) => (i + 1) * rowsPerPage
+      i => (i + 1) * rowsPerPage
     );
 
     return pageSizeOptions;
@@ -130,23 +136,14 @@ const Table = ({
 
   return (
     <AntTable
-      sticky
       bordered={bordered}
-      ref={tableRef}
       columns={columnData}
       dataSource={rowData}
       loading={loading}
-      rowClassName={classnames(
-        "neeto-ui-table--row",
-        { "neeto-ui-table--row_hover": allowRowClick },
-        [className]
-      )}
+      locale={locale}
+      ref={tableRef}
+      rowKey="id"
       rowSelection={rowSelectionProps}
-      scroll={{
-        x:"max-content",
-        y: calculateTableContainerHeight(),
-        ...scroll,
-      }}
       showSorterTooltip={false}
       pagination={{
         hideOnSinglePage: true,
@@ -159,23 +156,27 @@ const Table = ({
           : defaultPageSize,
         pageSizeOptions: calculatePageSizeOptions(),
         onChange: handlePageChange,
-        itemRender: itemRender,
+        itemRender,
       }}
-      onRow={(record, rowIndex) => {
-        return {
-          onClick: (event) =>
-            allowRowClick && onRowClick && onRowClick(event, record, rowIndex),
-        };
+      rowClassName={classnames(
+        "neeto-ui-table--row",
+        { "neeto-ui-table--row_hover": allowRowClick },
+        [className]
+      )}
+      scroll={{
+        x: "max-content",
+        y: calculateTableContainerHeight(),
+        ...scroll,
       }}
-      onHeaderRow={() => {
-        return {
-          ref: headerRef,
-          className: "neeto-ui-table__header",
-          id: "neeto-ui-table__header",
-        };
-      }}
-      locale={locale}
-      rowKey={"id"}
+      onHeaderRow={() => ({
+        ref: headerRef,
+        className: "neeto-ui-table__header",
+        id: "neeto-ui-table__header",
+      })}
+      onRow={(record, rowIndex) => ({
+        onClick: event =>
+          allowRowClick && onRowClick && onRowClick(event, record, rowIndex),
+      })}
       {...otherProps}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -15897,8 +15897,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
- Fixes #1694

**Description**
- Fixed: Multiple scroll bars in the _Table_ caused due to wrong usage of the `sticky` prop internally.

**Checklist**

- [ ] ~~I have made corresponding changes to the documentation.~~
- [ ] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
