### PR TITLE
Fixed janky animation in panes with forms containing `autoFocus`

### DIFF
--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -51,7 +51,7 @@ const Pane = ({
   });
 
   useEffect(() => {
-    if (isOpen) {
+    if (hasTransitionCompleted) {
       const headerHeight = getHeaderHeight(paneWrapper);
       if (headerHeight > DEFAULT_PANE_HEADER_HEIGHT) {
         paneWrapper.current.style.setProperty(
@@ -60,7 +60,7 @@ const Pane = ({
         );
       }
     }
-  }, [isOpen]);
+  }, [hasTransitionCompleted]);
 
   return (
     <Portal rootId="neeto-ui-portal">

--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -69,7 +69,7 @@ const Pane = ({
         appear={isOpen}
         classNames="neeto-ui-pane"
         in={isOpen}
-        timeout={250}
+        timeout={230}
         onEntered={() => setHasTransitionCompleted(true)}
         onExited={() => setHasTransitionCompleted(false)}
       >

--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -69,7 +69,7 @@ const Pane = ({
         appear={isOpen}
         classNames="neeto-ui-pane"
         in={isOpen}
-        timeout={210}
+        timeout={250}
         onEntered={() => setHasTransitionCompleted(true)}
         onExited={() => setHasTransitionCompleted(false)}
       >
@@ -104,10 +104,13 @@ const Pane = ({
                 onClick={handleOverlayClose}
               />
             )}
-            {hasTransitionCompleted &&
-              (typeof children === "function"
-                ? children({ setFocusField })
-                : children)}
+            {hasTransitionCompleted && (
+              <>
+                {typeof children === "function"
+                  ? children({ setFocusField })
+                  : children}
+              </>
+            )}
           </div>
         </Backdrop>
       </CSSTransition>

--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -69,7 +69,7 @@ const Pane = ({
         appear={isOpen}
         classNames="neeto-ui-pane"
         in={isOpen}
-        timeout={300}
+        timeout={210}
         onEntered={() => setHasTransitionCompleted(true)}
         onExited={() => setHasTransitionCompleted(false)}
       >
@@ -104,9 +104,10 @@ const Pane = ({
                 onClick={handleOverlayClose}
               />
             )}
-            {typeof children === "function"
-              ? children({ setFocusField })
-              : children}
+            {hasTransitionCompleted &&
+              (typeof children === "function"
+                ? children({ setFocusField })
+                : children)}
           </div>
         </Backdrop>
       </CSSTransition>

--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -46,6 +46,7 @@ const useOverlay = ({
     if (hasTransitionCompleted) {
       if (initialFocusRef?.current) {
         initialFocusRef?.current?.focus();
+        renderFocusOnFocusableElements(overlayWrapper, false);
       } else {
         renderFocusOnFocusableElements(overlayWrapper);
       }

--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -44,11 +44,10 @@ const useOverlay = ({
 
   const focusRequiredElementInOverlay = () => {
     if (hasTransitionCompleted) {
-      if (!initialFocusRef?.current) {
-        renderFocusOnFocusableElements(overlayWrapper);
-      } else {
+      if (initialFocusRef?.current) {
         initialFocusRef?.current?.focus();
-        renderFocusOnFocusableElements(overlayWrapper, false);
+      } else {
+        renderFocusOnFocusableElements(overlayWrapper);
       }
     }
   };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,7 +66,7 @@ export const renderFocusOnFocusableElements = (
   shouldFocusFirstFocusableElement = true
 ) => {
   const focusableElements =
-    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    '[href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
   const firstFocusableElement =
     ref?.current?.querySelectorAll(focusableElements)[0];

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,7 +66,7 @@ export const renderFocusOnFocusableElements = (
   shouldFocusFirstFocusableElement = true
 ) => {
   const focusableElements =
-    '[href], input:not([type="checkbox"]), select, textarea, [tabindex]:not([tabindex="-1"])';
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
   const firstFocusableElement =
     ref?.current?.querySelectorAll(focusableElements)[0];

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,7 +66,7 @@ export const renderFocusOnFocusableElements = (
   shouldFocusFirstFocusableElement = true
 ) => {
   const focusableElements =
-    '[href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    '[href], input:not([type="checkbox"]), select, textarea, [tabindex]:not([tabindex="-1"])';
 
   const firstFocusableElement =
     ref?.current?.querySelectorAll(focusableElements)[0];

--- a/tests/Pane.test.jsx
+++ b/tests/Pane.test.jsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { Pane, Typography, Button } from "components";
 
 describe("Pane", () => {
-  it("should render without error", () => {
+  it("should render without error", async () => {
     const { getByText } = render(
       <Pane isOpen>
         <Pane.Header>
@@ -14,6 +14,7 @@ describe("Pane", () => {
         </Pane.Header>
       </Pane>
     );
+    await new Promise(r => setTimeout(r, 300));
     expect(getByText("Pane header")).toBeInTheDocument();
   });
 
@@ -28,7 +29,7 @@ describe("Pane", () => {
     expect(queryByText("Pane header")).not.toBeInTheDocument();
   });
 
-  it("should render body", () => {
+  it("should render body", async () => {
     const { getByText } = render(
       <Pane isOpen>
         <Pane.Body>
@@ -38,10 +39,12 @@ describe("Pane", () => {
         </Pane.Body>
       </Pane>
     );
+
+    await new Promise(r => setTimeout(r, 300));
     expect(getByText("Pane body")).toBeInTheDocument();
   });
 
-  it("should render footer", () => {
+  it("should render footer", async () => {
     const { getByText } = render(
       <Pane isOpen>
         <Pane.Footer>
@@ -49,6 +52,7 @@ describe("Pane", () => {
         </Pane.Footer>
       </Pane>
     );
+    await new Promise(r => setTimeout(r, 300));
     expect(getByText("Submit")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Fixes #1396 

**Description**
- Fixes janky animation in _Pane_ when form fields have the `autoFocus` prop.

**Checklist**

- [ ] ~~I have made corresponding changes to the documentation.~~
- [ ] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
