### PR TITLE
Removed the logic to trigger validation only after the user submits from the Form component

### DIFF
--- a/src/components/formik/Form/FormWrapper.jsx
+++ b/src/components/formik/Form/FormWrapper.jsx
@@ -34,7 +34,13 @@ const FormWrapper = forwardRef(
           } else {
             onSubmit(values, formikBag);
           }
-        } catch {}
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(
+            "An unhandled error was caught from validateForm()",
+            error
+          );
+        }
       },
       [
         values,

--- a/src/components/formik/Form/FormWrapper.jsx
+++ b/src/components/formik/Form/FormWrapper.jsx
@@ -1,32 +1,17 @@
-import React, { useEffect, useCallback, forwardRef } from "react";
+import React, { useCallback, forwardRef } from "react";
 
 import { Form as FormikForm, useFormikContext } from "formik";
 import PropTypes from "prop-types";
 
 const FormWrapper = forwardRef(
-  (
-    {
-      className,
-      formProps,
-      children,
-      onSubmit,
-      setEnableChangeAndBlurValidation,
-    },
-    formRef
-  ) => {
-    const {
-      submitCount,
-      values,
-      validateForm,
-      setErrors,
-      setTouched,
-      ...formikBag
-    } = useFormikContext();
+  ({ className, formProps, children, onSubmit }, formRef) => {
+    const { values, validateForm, setErrors, setTouched, ...formikBag } =
+      useFormikContext();
 
     const { dirty: isFormDirty, isSubmitting } = formikBag;
 
     const handleKeyDown = useCallback(
-      event => {
+      async event => {
         const isEventFromEditorOrTextarea =
           event.target.tagName === "TEXTAREA" || event.target.editor;
 
@@ -36,23 +21,20 @@ const FormWrapper = forwardRef(
 
         event.preventDefault();
 
-        if (event.shiftKey) {
-          return;
-        }
+        if (event.shiftKey) return;
 
         if (!isFormDirty || isSubmitting) return;
 
-        validateForm()
-          .then(errors => {
-            setEnableChangeAndBlurValidation(true);
-            if (Object.keys(errors).length > 0) {
-              setErrors(errors);
-              setTouched(errors);
-            } else {
-              onSubmit(values, formikBag);
-            }
-          })
-          .catch(() => {});
+        try {
+          const errors = await validateForm();
+
+          if (Object.keys(errors).length > 0) {
+            setErrors(errors);
+            setTouched(errors);
+          } else {
+            onSubmit(values, formikBag);
+          }
+        } catch {}
       },
       [
         values,
@@ -64,12 +46,6 @@ const FormWrapper = forwardRef(
         isSubmitting,
       ]
     );
-
-    useEffect(() => {
-      if (submitCount === 1) {
-        setEnableChangeAndBlurValidation(true);
-      }
-    }, [submitCount]);
 
     return (
       <FormikForm
@@ -85,6 +61,8 @@ const FormWrapper = forwardRef(
     );
   }
 );
+
+FormWrapper.displayName = "FormWrapper";
 
 FormWrapper.propTypes = {
   children: PropTypes.node,

--- a/src/components/formik/Form/index.jsx
+++ b/src/components/formik/Form/index.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef } from "react";
 
 import { Formik } from "formik";
 import PropTypes from "prop-types";
@@ -6,34 +6,20 @@ import PropTypes from "prop-types";
 import FormWrapper from "./FormWrapper";
 
 const Form = forwardRef(
-  ({ className, children, formikProps, formProps }, ref) => {
-    const [enabledChangeAndBlurValidation, setEnabledChangeAndBlurValidation] =
-      useState(false);
-
-    return (
-      <Formik
-        {...formikProps}
-        validateOnBlur={
-          formikProps?.validateOnBlur && enabledChangeAndBlurValidation
-        }
-        validateOnChange={
-          formikProps?.validateOnChange && enabledChangeAndBlurValidation
-        }
-      >
-        {props => (
-          <FormWrapper
-            className={className}
-            formProps={formProps}
-            ref={ref}
-            setEnableChangeAndBlurValidation={setEnabledChangeAndBlurValidation}
-            onSubmit={formikProps?.onSubmit}
-          >
-            {typeof children === "function" ? children(props) : children}
-          </FormWrapper>
-        )}
-      </Formik>
-    );
-  }
+  ({ className, children, formikProps, formProps }, ref) => (
+    <Formik {...formikProps}>
+      {props => (
+        <FormWrapper
+          className={className}
+          formProps={formProps}
+          ref={ref}
+          onSubmit={formikProps?.onSubmit}
+        >
+          {typeof children === "function" ? children(props) : children}
+        </FormWrapper>
+      )}
+    </Formik>
+  )
 );
 
 Form.displayName = "Form";

--- a/tests/formik/Form.test.jsx
+++ b/tests/formik/Form.test.jsx
@@ -95,40 +95,6 @@ describe("formik/Form", () => {
     await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
   });
 
-  it("should not validate form on value change or field blur until form is submitted once", async () => {
-    const onSubmit = jest.fn();
-    render(<FormikForm validateOnBlur validateOnChange onSubmit={onSubmit} />);
-
-    const formWrapper = screen.getByTestId("neeto-ui-form-wrapper");
-    const input = screen.getByLabelText("First Name");
-    const button = screen.getByRole("button");
-
-    // clear initial values and blur field.
-    userEvent.type(input, "{selectall}{backspace}");
-    userEvent.click(formWrapper);
-    expect(screen.queryByText("Name is required")).not.toBeInTheDocument();
-
-    userEvent.click(button); // Try submitting form with empty value.
-    await waitFor(() =>
-      expect(screen.getByText("Name is required")).toBeInTheDocument()
-    );
-    // Check error is removed when user types in value.
-    userEvent.type(input, "Oliver Smith");
-    await waitFor(() =>
-      expect(screen.queryByText("Name is required")).not.toBeInTheDocument()
-    );
-    // Clear values and make sure error is shown for the onChange event.
-    userEvent.type(input, "{selectall}{backspace}");
-    await waitFor(() =>
-      expect(screen.getByText("Name is required")).toBeInTheDocument()
-    );
-
-    userEvent.type(input, "Oliver");
-    await waitFor(() => expect(button).not.toBeDisabled());
-    userEvent.click(button);
-    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
-  });
-
   it("should not validate the form until form is dirty", async () => {
     const onSubmit = jest.fn();
     render(<EmptyMultiLineForm onSubmit={onSubmit} />);


### PR DESCRIPTION
- Fixes #1710 

**Description**

**Checklist**

- ~[ ] I have made corresponding changes to the documentation.~
- ~[ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
