### PR TITLE
Overrided onchange function to output empty array if value is null

### DIFF
--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -60,6 +60,12 @@ const DatePicker = forwardRef(
 
     const errorId = `error_${id}`;
 
+    const handleOnChange = (date, dateString) => {
+      type === "range" && !date
+        ? onChange([], dateString)
+        : onChange(value, dateString);
+    };
+
     return (
       <div className="neeto-ui-input__wrapper">
         {label && <Label {...labelProps}>{label}</Label>}
@@ -82,7 +88,7 @@ const DatePicker = forwardRef(
             dropdownClassName, // Will be removed in the next major version
             popupClassName,
           ])}
-          onChange={onChange}
+          onChange={handleOnChange}
           onOk={onOk}
           {...otherProps}
           nextIcon={<IconOverride icon={Right} />}

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -63,7 +63,7 @@ const DatePicker = forwardRef(
     const handleOnChange = (date, dateString) => {
       type === "range" && !date
         ? onChange([], dateString)
-        : onChange(value, dateString);
+        : onChange(date, dateString);
     };
 
     return (

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -61,6 +61,12 @@ const TimePicker = forwardRef(
       showTimeLabels.hour = true;
     }
 
+    const handleOnChange = (time, timeString) => {
+      type === "range" && !time
+        ? onChange([], timeString)
+        : onChange(value, timeString);
+    };
+
     const panelRender = originalPanel => (
       <div className="neeto-ui-date-input-custom-panel">
         <div className="neeto-ui-date-input-custom-panel__header">
@@ -110,7 +116,7 @@ const TimePicker = forwardRef(
             dropdownClassName, // Will be removed in the next major version
             popupClassName,
           ])}
-          onChange={onChange}
+          onChange={handleOnChange}
           {...otherProps}
           defaultValue={convertToDayjsObjects(defaultValue)}
           mode={undefined}

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -64,7 +64,7 @@ const TimePicker = forwardRef(
     const handleOnChange = (time, timeString) => {
       type === "range" && !time
         ? onChange([], timeString)
-        : onChange(value, timeString);
+        : onChange(time, timeString);
     };
 
     const panelRender = originalPanel => (


### PR DESCRIPTION
- Fixes #1669 

**Description**

- Fixed: Overrided `onChange` function to output empty array if value is null in _DatePicker_

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln _A Please review

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
