### PR TITLE
Removed reduntant ToastContainer from storybook

### DIFF
--- a/stories/Overlays/Toastr.stories.jsx
+++ b/stories/Overlays/Toastr.stories.jsx
@@ -129,54 +129,48 @@ const ErrorToastr = ({}) => {
   };
 
   return (
-    <>
-      <ToastContainer />
-      <div className="space-x-6">
-        <Button label="String error" onClick={onStringError} />
-        <Button label="Throw an axios error" onClick={onAxiosStringError} />
-        <Button
-          label="Throw an axios error with array of error messages"
-          onClick={onAxiosArrayError}
-        />
-      </div>
-    </>
+    <div className="space-x-6">
+      <Button label="String error" onClick={onStringError} />
+      <Button label="Throw an axios error" onClick={onAxiosStringError} />
+      <Button
+        label="Throw an axios error with array of error messages"
+        onClick={onAxiosArrayError}
+      />
+    </div>
   );
 };
 
 // eslint-disable-next-line no-empty-pattern
 const CustomConfigToastr = ({}) => (
-  <>
-    <ToastContainer />
-    <div className="space-x-6">
-      <Button
-        label="Custom config 1"
-        onClick={() =>
-          Toastr.info(
-            "This toastr has a custom configuration along with buttonLabel and onClick callback as separate arguments",
-            "Okay",
-            () => {},
-            {
-              hideProgressBar: false,
-              autoClose: 5000,
-            }
-          )
-        }
-      />
-      <Button
-        label="Custom config 2"
-        onClick={() =>
-          Toastr.show(
-            "This toastr has a custom configuration passed which includes buttonLabel and onClick in the same config object",
-            {
-              buttonLabel: "Okay",
-              onClick: () => {},
-              autoClose: 3000,
-            }
-          )
-        }
-      />
-    </div>
-  </>
+  <div className="space-x-6">
+    <Button
+      label="Custom config 1"
+      onClick={() =>
+        Toastr.info(
+          "This toastr has a custom configuration along with buttonLabel and onClick callback as separate arguments",
+          "Okay",
+          () => {},
+          {
+            hideProgressBar: false,
+            autoClose: 5000,
+          }
+        )
+      }
+    />
+    <Button
+      label="Custom config 2"
+      onClick={() =>
+        Toastr.show(
+          "This toastr has a custom configuration passed which includes buttonLabel and onClick in the same config object",
+          {
+            buttonLabel: "Okay",
+            onClick: () => {},
+            autoClose: 3000,
+          }
+        )
+      }
+    />
+  </div>
 );
 
 CustomConfigToastr.storyName = "Custom config toastr";


### PR DESCRIPTION
- Fixes #1713 

**Description**

- Fixed - issue with multiple instances of toaster being shown in storybook.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
