### PR TITLE
Added `optionRemapping` prop in Select component.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -324,6 +324,7 @@ export type SelectProps = {
   id?: string;
   loadOptions?: boolean;
   labelProps?: LabelProps;
+  optionRemapping?: { label?: string, value?: string }
   [key: string]: any;
 };
 

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -69,11 +69,11 @@ const Select = ({
   }
 
   if (optionRemapping.value) {
-    otherProps.getOptionValue = prop(optionRemapping?.value);
+    otherProps.getOptionValue = prop(optionRemapping.value);
   }
 
   if (optionRemapping.label) {
-    otherProps.getOptionLabel = prop(optionRemapping?.label);
+    otherProps.getOptionLabel = prop(optionRemapping.label);
   }
 
   const portalProps = strategy === STRATEGIES.fixed && {

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -4,7 +4,7 @@ import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import { Down, Close } from "neetoicons";
 import PropTypes from "prop-types";
-import { assoc } from "ramda";
+import { prop, assoc } from "ramda";
 import SelectInput, { components } from "react-select";
 import Async from "react-select/async";
 import AsyncCreatable from "react-select/async-creatable";
@@ -53,6 +53,7 @@ const Select = ({
   value,
   defaultValue,
   components: componentOverrides,
+  optionRemapping = {},
   ...otherProps
 }) => {
   const inputId = useId(id);
@@ -65,6 +66,14 @@ const Select = ({
 
   if (otherProps.loadOptions) {
     Parent = isCreateable ? AsyncCreatable : Async;
+  }
+
+  if (optionRemapping.value) {
+    otherProps.getOptionValue = prop(optionRemapping?.value);
+  }
+
+  if (optionRemapping.label) {
+    otherProps.getOptionLabel = prop(optionRemapping?.label);
   }
 
   const portalProps = strategy === STRATEGIES.fixed && {
@@ -200,6 +209,17 @@ Select.propTypes = {
    * To specify the name for the Select input.
    */
   name: PropTypes.string,
+  /**
+   * The `options` prop expects an array of objects of the format `{ label: "", value: "" }`.
+   *
+   * If your array has different keys, you can specify them using this prop.
+   *
+   * Eg: `{ label: "name", value: "id" }` if `options` is an array of  `{ name: "", id: "" }` objects.
+   */
+  optionRemapping: PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string,
+  }),
   /**
    * To provide the options for the Select input.
    */

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -39,6 +39,7 @@ Default.args = {
   isClearable: true,
   isSearchable: true,
   name: "ValueList",
+  optionRemapping: {},
   options: [
     { value: "value1", label: "Value one" },
     { value: "value2", label: "Value two" },

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -148,7 +148,7 @@ it("should show option list on clicking when remapped label is provided with opt
 });
 
 it("should not show option list on clicking when remapped label is provided without optionRemapping", () => {
-  const { getByRole, getByText, queryByText } = render(
+  const { getByRole, queryByText } = render(
     <Select label="Select" options={remappedLabelOptions} />
   );
   const select = getByRole("combobox");

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -16,6 +16,28 @@ const options = [
   },
 ];
 
+const remappedLabelAndValueOptions = [
+  {
+    lab: "Option 1",
+    val: "option-1",
+  },
+  {
+    lab: "Option 2",
+    val: "option-2",
+  },
+];
+
+const remappedLabelOptions = [
+  {
+    lab: "Option 1",
+    value: "option-1",
+  },
+  {
+    lab: "Option 2",
+    value: "option-2",
+  },
+];
+
 describe("Select", () => {
   it("should render without error", () => {
     const { getByText } = render(<Select label="Select" options={options} />);
@@ -95,4 +117,42 @@ describe("Select", () => {
     expect(screen.getByText("Option 2")).toBeInTheDocument();
     expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
   });
+});
+
+it("should show option list on clicking when remapped label and value is provided with optionRemapping", () => {
+  const { getByRole, getByText } = render(
+    <Select
+      label="Select"
+      optionRemapping={{ label: "lab", value: "val" }}
+      options={remappedLabelAndValueOptions}
+    />
+  );
+  const select = getByRole("combobox");
+  userEvent.click(select);
+  expect(getByText("Option 1")).toBeInTheDocument();
+  expect(getByText("Option 2")).toBeInTheDocument();
+});
+
+it("should show option list on clicking when remapped label is provided with optionRemapping", () => {
+  const { getByRole, getByText } = render(
+    <Select
+      label="Select"
+      optionRemapping={{ label: "lab" }}
+      options={remappedLabelOptions}
+    />
+  );
+  const select = getByRole("combobox");
+  userEvent.click(select);
+  expect(getByText("Option 1")).toBeInTheDocument();
+  expect(getByText("Option 2")).toBeInTheDocument();
+});
+
+it("should not show option list on clicking when remapped label is provided without optionRemapping", () => {
+  const { getByRole, getByText, queryByText } = render(
+    <Select label="Select" options={remappedLabelOptions} />
+  );
+  const select = getByRole("combobox");
+  userEvent.click(select);
+  expect(queryByText("Option 1")).toBeNull();
+  expect(queryByText("Option 2")).toBeNull();
 });


### PR DESCRIPTION


- Fixes #1704 

**Description**
Added: `optionRemapping` prop to map the label and value properties of `options` prop in _Select_ component.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
