### PR TITLE
Fixed prefix and input misalignment and line break in prefix

### DIFF
--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -65,6 +65,10 @@
       }
     }
 
+    input {
+      line-height: 1.2;
+    }
+
     textarea {
       padding: 0;
       max-height: 224px;

--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -65,10 +65,6 @@
       }
     }
 
-    input {
-      line-height: 1.2;
-    }
-
     textarea {
       padding: 0;
       max-height: 224px;
@@ -196,6 +192,7 @@
   .neeto-ui-input__prefix,
   .neeto-ui-input__suffix {
     display: flex;
+    white-space: nowrap !important;
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;


### PR DESCRIPTION
- Fixes #1724 

**Description**

- Fixed: Misalignment between input and prefix for large screens. Line break in prefix when hyphens are added.

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).