### PR TITLE
Removed condition to disable formik button when the form is invalid

### DIFF
--- a/src/components/formik/Button.jsx
+++ b/src/components/formik/Button.jsx
@@ -10,7 +10,7 @@ const FormikButton = forwardRef(({ disabled, ...otherProps }, ref) => {
     useFormikContext();
 
   const isDisabled =
-    disabled ?? (isSubmitting || !isValid || equals(values, initialValues));
+    disabled ?? (isSubmitting || equals(values, initialValues));
 
   return (
     <Button

--- a/tests/formik/Button.test.jsx
+++ b/tests/formik/Button.test.jsx
@@ -71,11 +71,11 @@ describe("formik/Button", () => {
     await waitFor(() => expect(onSubmit).not.toBeCalled());
   });
 
-  it("Should be disabled if form contains errors", async () => {
+  it("Should not be disabled if form contains errors but should not submit form", async () => {
     const { input, button, onSubmit } = renderTestComponent();
     userEvent.type(input, "{selectall}{backspace}"); // clear everything
-    // error: name is required; button disabled
-    await waitFor(() => expect(button).toBeDisabled());
+    // error: name is required;
+    await waitFor(() => expect(button).not.toBeDisabled());
     userEvent.click(button);
     await waitFor(() => expect(onSubmit).not.toBeCalled());
   });

--- a/tests/formik/Form.test.jsx
+++ b/tests/formik/Form.test.jsx
@@ -90,7 +90,7 @@ describe("formik/Form", () => {
     const input = screen.getByLabelText("First Name");
     const button = screen.getByRole("button");
     userEvent.type(input, "{selectall}{backspace}");
-    await waitFor(() => expect(button).toBeDisabled());
+    await waitFor(() => expect(button).not.toBeDisabled());
     userEvent.click(button);
     await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
   });


### PR DESCRIPTION
Refer: <https://github.com/bigbinary/neeto-molecules/issues/316>.

**Description**
- Removed: condition to disable _FormikButton_ when the form is invalid.

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).
