### PR TITLE
Updates the propType of message in Alert component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ export interface AlertProps {
   onClose?: () => void;
   onSubmit?: () => void;
   title?: string;
-  message?: string;
+  message?: React.ReactNode;
   submitButtonLabel?: string;
   cancelButtonLabel?: string;
 }

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -86,7 +86,7 @@ Alert.propTypes = {
   /**
    * To provide description to the Alert.
    */
-  message: PropTypes.string,
+  message: PropTypes.node,
   /**
    * To add loading state to submit button
    */


### PR DESCRIPTION
- Fixes #1727 

**Description**
Updates the type of message in Alert component so that it can accept a string or React element to render as message. This will help us conform to the [new language rules](https://witty-tern-16b.notion.site/Confirmation-modal-best-practices-ef707f480cdd42e1bbcd3abea065a0d9) that we've finalized.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
