### PR TITLE
Add prop scrolltoerrorfield in formik form

### DIFF
--- a/formik.d.ts
+++ b/formik.d.ts
@@ -24,8 +24,9 @@ export interface BlockNavigationProps {
 export interface Form {
   className?: string;
   children: React.ReactNode | ((props: FormikProps<any>) => React.ReactNode);
-  formikProps: {[key: string]: any};
-  formProps?: {[key: string]: any};
+  formikProps: { [key: string]: any };
+  formProps?: { [key: string]: any };
+  scrollToErrorField?: boolean;
 }
 
 export const ActionBlock: React.FC<ActionBlockProps>;

--- a/src/components/formik/Form/FormWrapper.jsx
+++ b/src/components/formik/Form/FormWrapper.jsx
@@ -1,14 +1,21 @@
-import React, { useCallback, forwardRef } from "react";
+import React, { useCallback, forwardRef, useRef } from "react";
 
 import { Form as FormikForm, useFormikContext } from "formik";
 import PropTypes from "prop-types";
 
+import ScrollToErrorField from "./ScrollToErrorField";
+
 const FormWrapper = forwardRef(
-  ({ className, formProps, children, onSubmit }, formRef) => {
+  (
+    { className, formProps, children, onSubmit, scrollToErrorField },
+    formRef
+  ) => {
     const { values, validateForm, setErrors, setTouched, ...formikBag } =
       useFormikContext();
 
     const { dirty: isFormDirty, isSubmitting } = formikBag;
+
+    const formRefForScrollToErrorFiled = useRef();
 
     const handleKeyDown = useCallback(
       async event => {
@@ -58,10 +65,15 @@ const FormWrapper = forwardRef(
         noValidate
         className={className}
         data-testid="neeto-ui-form-wrapper"
-        ref={formRef}
+        ref={formRef || formRefForScrollToErrorFiled}
         onKeyDown={handleKeyDown}
         {...formProps}
       >
+        {scrollToErrorField && (
+          <ScrollToErrorField
+            formRef={formRef || formRefForScrollToErrorFiled}
+          />
+        )}
         {children}
       </FormikForm>
     );
@@ -74,6 +86,7 @@ FormWrapper.propTypes = {
   children: PropTypes.node,
   formProps: PropTypes.object,
   onSubmit: PropTypes.func,
+  scrollToErrorField: PropTypes.bool,
 };
 
 export default FormWrapper;

--- a/src/components/formik/Form/ScrollToErrorField/index.js
+++ b/src/components/formik/Form/ScrollToErrorField/index.js
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+import { useFormikContext } from "formik";
+
+import { getErrorFieldName } from "./utils";
+
+const ScrollToErrorField = ({ formRef }) => {
+  const { submitCount, isValid, errors } = useFormikContext();
+  const isValidatedReference = useRef(false);
+
+  useEffect(() => {
+    isValidatedReference.current = false;
+  }, [submitCount]);
+
+  useEffect(() => {
+    if (!formRef.current || isValidatedReference.current || isValid) return;
+
+    isValidatedReference.current = true;
+    const fieldErrorNames = getErrorFieldName(errors);
+    if (!fieldErrorNames) return;
+
+    const errorFormElement = formRef.current.elements[fieldErrorNames];
+
+    errorFormElement?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  }, [submitCount, errors]);
+
+  return null;
+};
+
+export default ScrollToErrorField;

--- a/src/components/formik/Form/ScrollToErrorField/utils.js
+++ b/src/components/formik/Form/ScrollToErrorField/utils.js
@@ -1,0 +1,21 @@
+import { is } from "ramda";
+
+const transformObjectToDotNotation = (object, prefix = "") => {
+  const result = [];
+
+  Object.keys(object).forEach(key => {
+    const value = object[key];
+    if (value && is(Object, value)) {
+      const nextPrefix = prefix ? `${prefix}.${key}` : key;
+      result.push(...transformObjectToDotNotation(value, nextPrefix));
+    } else if (value) {
+      const nextKey = prefix ? `${prefix}.${key}` : key;
+      result.push(nextKey);
+    }
+  });
+
+  return result;
+};
+
+export const getErrorFieldName = formikErrors =>
+  transformObjectToDotNotation(formikErrors)?.[0];

--- a/src/components/formik/Form/index.jsx
+++ b/src/components/formik/Form/index.jsx
@@ -6,13 +6,17 @@ import PropTypes from "prop-types";
 import FormWrapper from "./FormWrapper";
 
 const Form = forwardRef(
-  ({ className, children, formikProps, formProps }, ref) => (
+  (
+    { className, children, formikProps, formProps, scrollToErrorField = true },
+    ref
+  ) => (
     <Formik {...formikProps}>
       {props => (
         <FormWrapper
           className={className}
           formProps={formProps}
           ref={ref}
+          scrollToErrorField={scrollToErrorField}
           onSubmit={formikProps?.onSubmit}
         >
           {typeof children === "function" ? children(props) : children}
@@ -45,6 +49,10 @@ Form.propTypes = {
    * https://formik.org/docs/api/form
    **/
   formProps: PropTypes.object,
+  /**
+   * Props to be passed for scrolling to error filed on submit button click.
+   **/
+  scrollToErrorField: PropTypes.bool,
 };
 
 export default Form;


### PR DESCRIPTION
- Refer: <https://github.com/bigbinary/neeto-molecules/issues/316>

**Description**
- Added: `scrollToErrorField` prop to formik _Form_ component.
- 
**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
