### PR TITLE
Disabled scroll to error field in formik/Form component by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The `Form` component accepts the following props:
 - `formProps`: Form props object. You can pass `className`, `style` etc. as
   props to the `Form` component.
 - `scrollToErrorField`: To specify whether scroll to error field on clicking
-  submit button is enabled or not. Default value is true.
+  submit button is enabled or not. Default value is false.
 
 ---
 

--- a/src/components/formik/Form/index.jsx
+++ b/src/components/formik/Form/index.jsx
@@ -7,7 +7,7 @@ import FormWrapper from "./FormWrapper";
 
 const Form = forwardRef(
   (
-    { className, children, formikProps, formProps, scrollToErrorField = true },
+    { className, children, formikProps, formProps, scrollToErrorField = false },
     ref
   ) => (
     <Formik {...formikProps}>

--- a/tests/formik/Form.test.jsx
+++ b/tests/formik/Form.test.jsx
@@ -101,26 +101,26 @@ describe("formik/Form", () => {
     await waitFor(() => expect(button).not.toBeDisabled());
     userEvent.click(button);
     await waitFor(() => {
-      expect(scrollIntoView).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "center",
-      });
+      expect(scrollIntoView).not.toHaveBeenCalled();
       expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 
-  it("should not call scrollIntoView function if form is invalid but hasScrollToErrorField prop is false", async () => {
+  it("should call scrollIntoView function if form is invalid but hasScrollToErrorField prop is true", async () => {
     const onSubmit = jest.fn();
     const scrollIntoView = jest.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
-    render(<FormikForm scrollToErrorField={false} onSubmit={onSubmit} />);
+    render(<FormikForm scrollToErrorField onSubmit={onSubmit} />);
     const input = screen.getByLabelText("First Name");
     const button = screen.getByRole("button");
     userEvent.type(input, "{selectall}{backspace}");
     await waitFor(() => expect(button).not.toBeDisabled());
     userEvent.click(button);
     await waitFor(() => {
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center",
+      });
       expect(onSubmit).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
- Fixes #1739 

**Description**
- Changed: Default value of`scrollToErrorField` prop of formik _Form_ to false.

**Checklist**

- [x] I have made corresponding changes to the documentation.
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

