### PR TITLE
Fixed error value output in color picker when initial value is undefined

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -53,7 +53,8 @@ const ColorPicker = ({
   const onColorChange = hex => {
     const color = tinycolor(hex);
     const rgb = color.toRgb();
-    onChangeInternal({ hex, rgb });
+    const hexValue = color.toHexString();
+    onChangeInternal({ hex: hexValue, rgb });
   };
 
   const pickColor = async () => {


### PR DESCRIPTION
- Fixes #1749 

**Description**

- Fixed: error value output in color picker when the initial value is undefined

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
