### PR TITLE
Implemented setting the pagination and sorting config in URL query parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -378,7 +378,7 @@ export interface TableProps {
   enableColumnReorder?: boolean;
   onColumnUpdate?: (columns: any[]) => void;
   [key: string]: any;
-  shouldSetTableConfig?: boolean;
+  preserveTableStateInQuery?: boolean;
 }
 
 export interface TagProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -378,6 +378,7 @@ export interface TableProps {
   enableColumnReorder?: boolean;
   onColumnUpdate?: (columns: any[]) => void;
   [key: string]: any;
+  shouldSetTableConfig?: boolean;
 }
 
 export interface TagProps {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "prettier": "2.6.2",
     "prettier-plugin-tailwindcss": "0.1.10",
     "prop-types": "15.8.1",
+    "qs": "^6.11.0",
     "ramda": "^0.29.0",
     "raw-loader": "4.0.2",
     "react": "17.0.2",

--- a/src/components/Table/constants.js
+++ b/src/components/Table/constants.js
@@ -1,0 +1,3 @@
+export const URL_SORT_ORDERS = { ascend: "asc", descend: "desc" };
+
+export const TABLE_SORT_ORDERS = { asc: "ascend", desc: "descend" };

--- a/src/components/Table/hooks/useReorderColumns.js
+++ b/src/components/Table/hooks/useReorderColumns.js
@@ -9,7 +9,7 @@ const useReorderColumns = ({
 }) => {
   if (!isEnabled) return { dragProps: {}, columns };
 
-  const isColumnFixed = (column) => !!column.fixed;
+  const isColumnFixed = column => !!column.fixed;
 
   const dragProps = {
     onDragEnd: (fromIndex, toIndex) => {
@@ -19,6 +19,7 @@ const useReorderColumns = ({
         from = fromIndex - 1;
         to = toIndex - 1;
       }
+
       if (isColumnFixed(columns[from]) || isColumnFixed(columns[to])) return;
       const newColumns = move(from, to, columns);
       setColumns(newColumns);

--- a/src/components/Table/hooks/useResizableColumns.js
+++ b/src/components/Table/hooks/useResizableColumns.js
@@ -6,27 +6,25 @@ const useResizableColumns = ({
   isEnabled,
   onColumnUpdate,
 }) => {
-  if (!isEnabled)
-    return {
-      components: {},
-      columns,
+  if (!isEnabled) {
+    return { components: {}, columns };
+  }
+
+  const handleResize =
+    index =>
+    (_, { size }) => {
+      const nextColumns = [...columns];
+      nextColumns[index] = { ...nextColumns[index], width: size.width };
+      setColumns(nextColumns);
     };
 
-  const handleResize = (index) => (_, { size }) => {
-    const nextColumns = [...columns];
-    nextColumns[index] = {
-      ...nextColumns[index],
-      width: size.width,
-    };
-    setColumns(nextColumns);
-  };
-
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const computedColumnsData = useMemo(
     () =>
       columns.map((col, index) => {
         const modifiedColumn = {
           ...col,
-          onHeaderCell: (column) => ({
+          onHeaderCell: column => ({
             width: column.width,
             onResize: handleResize(index),
             onResizeStop: () => onColumnUpdate(columns),
@@ -36,6 +34,7 @@ const useResizableColumns = ({
         if (!col.ellipsis) {
           modifiedColumn.ellipsis = true;
         }
+
         return modifiedColumn;
       }),
     [columns]

--- a/src/components/Table/hooks/useTableSort.js
+++ b/src/components/Table/hooks/useTableSort.js
@@ -1,0 +1,27 @@
+import { mergeLeft } from "ramda";
+import { useHistory } from "react-router-dom";
+
+import { URL_SORT_ORDERS } from "../constants";
+import { camelToSnakeCase, getQueryParams, buildUrl } from "../utils";
+
+const useTableSort = () => {
+  const queryParams = getQueryParams();
+
+  const history = useHistory();
+
+  const handleTableChange = (pagination, sorter) => {
+    const params = {
+      sort_by: sorter.order && camelToSnakeCase(sorter.field),
+      order_by: URL_SORT_ORDERS[sorter.order],
+      page: pagination.current,
+      page_size: pagination.pageSize,
+    };
+
+    const pathname = window.location.pathname;
+    history.push(buildUrl(pathname, mergeLeft(params, queryParams)));
+  };
+
+  return { handleTableChange };
+};
+
+export default useTableSort;

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -51,7 +51,7 @@ const Table = ({
   bordered = true,
   onColumnUpdate = noop,
   components = {},
-  shouldSetTableConfig = false,
+  preserveTableStateInQuery = false,
   ...otherProps
 }) => {
   const [containerHeight, setContainerHeight] = useState(null);
@@ -123,7 +123,7 @@ const Table = ({
       columnData
     );
 
-  const sortedColumns = shouldSetTableConfig
+  const sortedColumns = preserveTableStateInQuery
     ? setSortFromURL(curatedColumnsData)
     : curatedColumnsData;
 
@@ -241,7 +241,7 @@ const Table = ({
       }}
       onChange={(pagination, _, sorter) => {
         handleHeaderClasses();
-        shouldSetTableConfig && handleTableChange(pagination, sorter);
+        preserveTableStateInQuery && handleTableChange(pagination, sorter);
       }}
       onHeaderRow={() => ({
         ref: headerRef,
@@ -362,7 +362,7 @@ Table.propTypes = {
   /**
    * This prop decides whether the pagination and sorting parameters should be added to the URL query parameters.
    */
-  shouldSetTableConfig: PropTypes.bool,
+  preserveTableStateInQuery: PropTypes.bool,
 };
 
 export default Table;

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -51,6 +51,7 @@ const Table = ({
   bordered = true,
   onColumnUpdate = noop,
   components = {},
+  shouldSetTableConfig = false,
   ...otherProps
 }) => {
   const [containerHeight, setContainerHeight] = useState(null);
@@ -121,6 +122,10 @@ const Table = ({
       assoc("sortOrder", TABLE_SORT_ORDERS[queryParams.order_by]),
       columnData
     );
+
+  const sortedColumns = shouldSetTableConfig
+    ? setSortFromURL(curatedColumnsData)
+    : curatedColumnsData;
 
   const locale = {
     emptyText: <Typography style="body2">No Data</Typography>,
@@ -202,7 +207,7 @@ const Table = ({
   const renderTable = () => (
     <AntTable
       bordered={bordered}
-      columns={setSortFromURL(curatedColumnsData)}
+      columns={sortedColumns}
       components={componentOverrides}
       dataSource={rowData}
       loading={loading}
@@ -236,7 +241,7 @@ const Table = ({
       }}
       onChange={(pagination, _, sorter) => {
         handleHeaderClasses();
-        handleTableChange(pagination, sorter);
+        shouldSetTableConfig && handleTableChange(pagination, sorter);
       }}
       onHeaderRow={() => ({
         ref: headerRef,
@@ -354,6 +359,10 @@ Table.propTypes = {
    * Make sure to pass `id` in `rowData` for this to work.
    */
   rowSelection: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+  /**
+   * This prop decides whether the pagination and sorting parameters should be added to the URL query parameters.
+   */
+  shouldSetTableConfig: PropTypes.bool,
 };
 
 export default Table;

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -1,0 +1,86 @@
+import { parse, stringify } from "qs";
+import { curry, isEmpty, isNil, omit, pipe, toPairs } from "ramda";
+
+const matchesImpl = (pattern, object, __parent = object) => {
+  if (object === pattern) return true;
+
+  if (typeof pattern === "function" && pattern(object, __parent)) return true;
+
+  if (isNil(pattern) || isNil(object)) return false;
+
+  if (typeof pattern !== "object") return false;
+
+  return Object.entries(pattern).every(([key, value]) =>
+    matchesImpl(value, object[key], __parent)
+  );
+};
+
+const matches = /*#__PURE__*/ curry((pattern, object) =>
+  matchesImpl(pattern, object)
+);
+
+const transformObjectDeep = (
+  object,
+  keyValueTransformer,
+  /** @type {undefined | ((any) => any)} */
+  objectPreProcessor = undefined
+) => {
+  if (objectPreProcessor && typeof objectPreProcessor === "function") {
+    object = objectPreProcessor(object);
+  }
+
+  if (Array.isArray(object)) {
+    return object.map(obj =>
+      transformObjectDeep(obj, keyValueTransformer, objectPreProcessor)
+    );
+  } else if (object === null || typeof object !== "object") {
+    return object;
+  }
+
+  return Object.fromEntries(
+    Object.entries(object).map(([key, value]) =>
+      keyValueTransformer(
+        key,
+        transformObjectDeep(value, keyValueTransformer, objectPreProcessor)
+      )
+    )
+  );
+};
+
+const preprocessForSerialization = object =>
+  transformObjectDeep(
+    object,
+    (key, value) => [key, value],
+    object => (typeof object?.toJSON === "function" ? object.toJSON() : object)
+  );
+
+export const getQueryParams = (options = {}) =>
+  parse(location.search, { ignoreQueryPrefix: true, ...options });
+
+export const modifyBy = /*#__PURE__*/ curry((pattern, modifier, array) =>
+  array.map(item => (matches(pattern, item) ? modifier(item) : item))
+);
+
+export const snakeToCamelCase = string =>
+  string.replace(/(_\w)/g, letter => letter[1].toUpperCase());
+
+export const camelToSnakeCase = string =>
+  string.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+
+export const buildUrl = (route, params) => {
+  const placeHolders = [];
+  toPairs(params).forEach(([key, value]) => {
+    if (route.includes(`:${key}`)) {
+      placeHolders.push(key);
+      route = route.replace(`:${key}`, encodeURIComponent(value));
+    }
+  });
+
+  const queryParams = pipe(
+    omit(placeHolders),
+    preprocessForSerialization,
+    stringify
+  )(params);
+
+  return isEmpty(queryParams) ? route : `${route}?${queryParams}`;
+};

--- a/stories/Components/TableStoriesDocs/TableSortingDocs.mdx
+++ b/stories/Components/TableStoriesDocs/TableSortingDocs.mdx
@@ -32,3 +32,13 @@ const columns = [
   }
 />
 ```
+
+- By default, the `onChange` function is utilized to set the pagination and sorting configuration like
+  current page, page size, sort column and sort order in the URL query parameters with the following keys:
+  - `sort_by`: The `dataIndex` of the particular column in `snake_case`.
+  - `order_by`: The sort order, whether `ascend`, `descend` or `undefined`.
+  - `page`: The current page number.
+  - `page_size`: The page size specified by the product.
+
+  If this functionality is not required simply override the `onChange` prop with the required function or
+  noop if no functionality is needed.

--- a/stories/Components/TableStoriesDocs/TableSortingDocs.mdx
+++ b/stories/Components/TableStoriesDocs/TableSortingDocs.mdx
@@ -33,12 +33,11 @@ const columns = [
 />
 ```
 
-- By default, the `onChange` function is utilized to set the pagination and sorting configuration like
+- The `onChange` function is utilized to set the pagination and sorting configuration like
   current page, page size, sort column and sort order in the URL query parameters with the following keys:
   - `sort_by`: The `dataIndex` of the particular column in `snake_case`.
   - `order_by`: The sort order, whether `ascend`, `descend` or `undefined`.
   - `page`: The current page number.
   - `page_size`: The page size specified by the product.
 
-  If this functionality is not required simply override the `onChange` prop with the required function or
-  noop if no functionality is needed.
+  This functionality is turned off by default. To toggle it, set the prop `preserveTableStateInQuery` to `true`.

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -179,6 +179,7 @@ describe("Table", () => {
     render(
       <BrowserRouter>
         <Table
+          shouldSetTableConfig
           columnData={columnData}
           defaultPageSize={2}
           handlePageChange={handlePageChange}
@@ -199,6 +200,7 @@ describe("Table", () => {
     render(
       <BrowserRouter>
         <Table
+          shouldSetTableConfig
           columnData={columnData}
           defaultPageSize={2}
           rowData={rowData}

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -179,7 +179,7 @@ describe("Table", () => {
     render(
       <BrowserRouter>
         <Table
-          shouldSetTableConfig
+          preserveTableStateInQuery
           columnData={columnData}
           defaultPageSize={2}
           handlePageChange={handlePageChange}
@@ -200,7 +200,7 @@ describe("Table", () => {
     render(
       <BrowserRouter>
         <Table
-          shouldSetTableConfig
+          preserveTableStateInQuery
           columnData={columnData}
           defaultPageSize={2}
           rowData={rowData}

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -2,8 +2,10 @@ import React from "react";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { BrowserRouter } from "react-router-dom";
 
 import { Table } from "components";
+import { getQueryParams } from "components/Table/utils";
 
 const columnData = [
   {
@@ -22,6 +24,7 @@ const columnData = [
     title: "Last Name",
     dataIndex: "last_name",
     key: "last_name",
+    sorter: true,
     width: 150,
   },
 ];
@@ -156,16 +159,62 @@ describe("Table", () => {
   it("should call handlePageChange when page is changed ", () => {
     const handlePageChange = jest.fn();
     render(
-      <Table
-        columnData={columnData}
-        defaultPageSize={2}
-        handlePageChange={handlePageChange}
-        rowData={rowData}
-        shouldDynamicallyRenderRowSize={false}
-      />
+      <BrowserRouter>
+        <Table
+          columnData={columnData}
+          defaultPageSize={2}
+          handlePageChange={handlePageChange}
+          rowData={rowData}
+          shouldDynamicallyRenderRowSize={false}
+        />
+      </BrowserRouter>
     );
     const pages = screen.getAllByRole("listitem");
     userEvent.click(pages[2]);
     expect(handlePageChange).toBeCalledTimes(1);
+  });
+
+  it("should set pagination URL query parameters when page is changed", () => {
+    const handlePageChange = jest.fn();
+    render(
+      <BrowserRouter>
+        <Table
+          columnData={columnData}
+          defaultPageSize={2}
+          handlePageChange={handlePageChange}
+          rowData={rowData}
+          shouldDynamicallyRenderRowSize={false}
+        />
+      </BrowserRouter>
+    );
+    const pages = screen.getAllByRole("listitem");
+    userEvent.click(pages[2]);
+    const queryParams = getQueryParams();
+
+    expect(queryParams).toEqual({ page: "2", page_size: "2" });
+    expect(handlePageChange).toBeCalledTimes(1);
+  });
+
+  it("should set sorting URL query parameters when column title is clicked", () => {
+    render(
+      <BrowserRouter>
+        <Table
+          columnData={columnData}
+          defaultPageSize={2}
+          rowData={rowData}
+          shouldDynamicallyRenderRowSize={false}
+        />
+      </BrowserRouter>
+    );
+    const column = screen.getByText("Last Name");
+    userEvent.click(column);
+    const queryParams = getQueryParams();
+
+    expect(queryParams).toEqual({
+      page: "1",
+      page_size: "2",
+      sort: "last_name",
+      order: "asc",
+    });
   });
 });

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -213,8 +213,8 @@ describe("Table", () => {
     expect(queryParams).toEqual({
       page: "1",
       page_size: "2",
-      sort: "last_name",
-      order: "asc",
+      sort_by: "last_name",
+      order_by: "asc",
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12834,6 +12834,13 @@ qs@6.11.0, qs@^6.10.0:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.11.0:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
+  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
+  dependencies:
+    side-channel "^1.0.4"
+
 query-string@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"


### PR DESCRIPTION
- Fixes #1767 

**Description**

- Added: Mechanism to set the pagination and sorting config in URL query parameters for `Table`.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- ~~[ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).