### PR TITLE
Disabled click in selected option close button if select is disabled

### DIFF
--- a/src/styles/components/_select.scss
+++ b/src/styles/components/_select.scss
@@ -7,7 +7,7 @@
   }
 }
 
-.neeto-ui-react-select__container{
+.neeto-ui-react-select__container {
   width: 100%;
 }
 
@@ -77,7 +77,7 @@
       min-height: 26px;
       padding: 0 8px;
     }
-    .neeto-ui-react-select__indicators{
+    .neeto-ui-react-select__indicators {
       padding-right: 8px;
     }
   }
@@ -87,7 +87,7 @@
       min-height: 30px;
       padding: 0 8px;
     }
-    .neeto-ui-react-select__indicators{
+    .neeto-ui-react-select__indicators {
       padding-right: 8px;
     }
   }
@@ -97,7 +97,7 @@
       padding: 0 12px;
       min-height: 38px;
     }
-    .neeto-ui-react-select__indicators{
+    .neeto-ui-react-select__indicators {
       padding-right: 12px;
     }
   }
@@ -110,11 +110,11 @@
     text-overflow: ellipsis;
   }
 
-  .neeto-ui-react-select__input-container{
+  .neeto-ui-react-select__input-container {
     color: rgb(var(--neeto-ui-gray-800));
   }
 
-  .neeto-ui-react-select__single-value{
+  .neeto-ui-react-select__single-value {
     color: rgb(var(--neeto-ui-gray-800));
   }
 
@@ -127,7 +127,7 @@
     display: none;
   }
 
-  .neeto-ui-react-select__indicators{
+  .neeto-ui-react-select__indicators {
     padding-right: 12px;
     gap: 8px;
   }
@@ -138,7 +138,7 @@
     color: rgb(var(--neeto-ui-gray-800));
     transition: var(--neeto-ui-transition);
 
-    &:hover{
+    &:hover {
       color: rgb(var(--neeto-ui-gray-700));
     }
   }
@@ -237,9 +237,9 @@
       display: flex;
       align-items: center;
     }
-    .neeto-ui-react-select__multi-value__remove{
+    .neeto-ui-react-select__multi-value__remove {
       color: inherit !important;
-      &:hover{
+      &:hover {
         opacity: 0.7;
       }
     }
@@ -258,6 +258,11 @@
       color: rgb(var(--neeto-ui-gray-700));
     }
   }
+}
+
+.neeto-ui-react-select__container
+  .neeto-ui-react-select__control.neeto-ui-react-select__control--is-disabled {
+  pointer-events: none;
 }
 
 .neeto-ui-react-select__menu-portal {


### PR DESCRIPTION
- Fixes #1748 

**Description**

- Fixed: Disabled click in selected option close button if select is disabled.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@praveen-murali-ind _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
