### PR TITLE
Trigger onclose which clicked on the trigger to close

### DIFF
--- a/src/components/Dropdown/index.jsx
+++ b/src/components/Dropdown/index.jsx
@@ -53,12 +53,9 @@ const TRIGGERS = { click: "click", hover: "mouseenter focus" };
 const hideOnEsc = {
   name: "hideOnEsc",
   defaultValue: true,
-  fn({ hide, props: { hideOnEsc, onClose } }) {
+  fn({ hide, props: { hideOnEsc } }) {
     function onKeyDown(event) {
-      if (event.key?.toLowerCase() === "escape" && hideOnEsc) {
-        onClose();
-        hide();
-      }
+      if (event.key?.toLowerCase() === "escape" && hideOnEsc) hide();
     }
 
     return {
@@ -72,7 +69,7 @@ const hideOnEsc = {
   },
 };
 
-const plugins = [hideOnEsc, { name: "onClose", fn: () => ({}) }];
+const plugins = [hideOnEsc];
 
 const Dropdown = ({
   icon,
@@ -103,22 +100,15 @@ const Dropdown = ({
   const isControlled = !isNil(isOpen);
 
   const controlledProps = isControlled
-    ? { visible: isOpen, onClickOutside: onClose }
+    ? { visible: isOpen }
     : {
-        onClickOutside: () => {
-          onClose();
-
-          return closeOnOutsideClick;
-        },
+        onClickOutside: () => closeOnOutsideClick,
       };
 
   const { classNames: dropdownClassname, ...otherDropdownProps } =
     dropdownProps;
 
-  const close = () => {
-    instance.hide();
-    onClose();
-  };
+  const close = () => instance.hide();
 
   return (
     <Tippy
@@ -155,10 +145,12 @@ const Dropdown = ({
           </div>
         ) : null
       }
-      onClose={onClose}
       onCreate={instance => instance && setInstance(instance)}
-      onHidden={() => setMounted(false)}
       onMount={() => setMounted(true)}
+      onHidden={() => {
+        onClose();
+        setMounted(false);
+      }}
       {...otherProps}
       {...controlledProps}
     >


### PR DESCRIPTION
- Fixes #1745 

**Description**

- Fixed: issue with onClose in _Dropdown_ not getting called on trigger click.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
