### PR TITLE
Specified the first focusable item in Alert

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,6 +119,7 @@ export interface AlertProps {
   message?: React.ReactNode;
   submitButtonLabel?: string;
   cancelButtonLabel?: string;
+  initialFocusElement?: "cancel" | "submit";
 }
 
 export type AvatarProps = {
@@ -324,7 +325,7 @@ export type SelectProps = {
   id?: string;
   loadOptions?: boolean;
   labelProps?: LabelProps;
-  optionRemapping?: { label?: string, value?: string }
+  optionRemapping?: { label?: string; value?: string };
   [key: string]: any;
 };
 

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -34,11 +34,6 @@ const Alert = ({
   const submitButtonRef = useRef(null);
   const cancelButtonRef = useRef(null);
 
-  const FOCUSABLE_ELEMENTS = {
-    submitButton: submitButtonRef,
-    cancelButton: cancelButtonRef,
-  };
-
   const hasCustomFocusableElement = !!initialFocusRef || initialFocusElement;
   const initialFocusElementRef =
     initialFocusElement === FOCUSABLE_ELEMENTS.submit

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -8,6 +8,11 @@ import Typography from "./Typography";
 
 const SIZES = { small: "small", medium: "medium", large: "large" };
 
+const FOCUSABLE_ELEMENTS = {
+  submit: "submit",
+  cancel: "cancel",
+};
+
 const Alert = ({
   size = SIZES.medium,
   isOpen = false,
@@ -65,8 +70,21 @@ const Alert = ({
 );
 =======
   initialFocusRef,
+  initialFocusElement,
 }) => {
   const submitButtonRef = useRef(null);
+  const cancelButtonRef = useRef(null);
+
+  const FOCUSABLE_ELEMENTS = {
+    submitButton: submitButtonRef,
+    cancelButton: cancelButtonRef,
+  };
+
+  const hasCustomFocusableElement = !!initialFocusRef || initialFocusElement;
+  const initialFocusElementRef =
+    initialFocusElement === FOCUSABLE_ELEMENTS.submit
+      ? submitButtonRef
+      : cancelButtonRef;
 
   return (
     <Modal
@@ -75,10 +93,12 @@ const Alert = ({
       closeButton={closeButton}
       closeOnEsc={closeOnEsc}
       closeOnOutsideClick={closeOnOutsideClick}
-      initialFocusRef={initialFocusRef || submitButtonRef}
       isOpen={isOpen}
       size={size}
       onClose={onClose}
+      {...(hasCustomFocusableElement && {
+        initialFocusRef: initialFocusRef || initialFocusElementRef,
+      })}
     >
       <Modal.Header>
         <Typography data-cy="alert-title" style="h2">
@@ -102,6 +122,7 @@ const Alert = ({
         <Button
           data-cy="alert-cancel-button"
           label={cancelButtonLabel}
+          ref={cancelButtonRef}
           style="text"
           onClick={onClose}
         />
@@ -173,6 +194,10 @@ Alert.propTypes = {
    * If not specified, the focus will be set to the submit button inside the Alert.
    * */
   initialFocusRef: PropTypes.object,
+  /**
+   * To specify the element which will receive focus when the Alert is opened.
+   */
+  initialFocusElement: PropTypes.oneOf(Object.values(FOCUSABLE_ELEMENTS)),
 };
 
 export default Alert;

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -28,47 +28,6 @@ const Alert = ({
   message = "",
   submitButtonLabel = "Continue",
   cancelButtonLabel = "Cancel",
-<<<<<<< HEAD
-}) => (
-  <Modal
-    backdropClassName={backdropClassName}
-    className={className}
-    closeButton={closeButton}
-    closeOnEsc={closeOnEsc}
-    closeOnOutsideClick={closeOnOutsideClick}
-    isOpen={isOpen}
-    size={size}
-    onClose={onClose}
-  >
-    <Modal.Header>
-      <Typography data-cy="alert-title" style="h2">
-        {title}
-      </Typography>
-    </Modal.Header>
-    <Modal.Body>
-      <Typography data-cy="alert-message" lineHeight="normal" style="body2">
-        {message}
-      </Typography>
-    </Modal.Body>
-    <Modal.Footer className="neeto-ui-gap-2 neeto-ui-flex neeto-ui-items-center">
-      <Button
-        data-cy="alert-submit-button"
-        disabled={!isOpen}
-        label={submitButtonLabel}
-        loading={isSubmitting}
-        style="danger"
-        onClick={onSubmit}
-      />
-      <Button
-        data-cy="alert-cancel-button"
-        label={cancelButtonLabel}
-        style="text"
-        onClick={onClose}
-      />
-    </Modal.Footer>
-  </Modal>
-);
-=======
   initialFocusRef,
   initialFocusElement,
 }) => {
@@ -130,7 +89,6 @@ const Alert = ({
     </Modal>
   );
 };
->>>>>>> 5d4b8ff5 (Specified the first focusable item in Alert)
 
 Alert.propTypes = {
   /**

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 
 import PropTypes from "prop-types";
 
@@ -23,6 +23,7 @@ const Alert = ({
   message = "",
   submitButtonLabel = "Continue",
   cancelButtonLabel = "Cancel",
+<<<<<<< HEAD
 }) => (
   <Modal
     backdropClassName={backdropClassName}
@@ -62,6 +63,53 @@ const Alert = ({
     </Modal.Footer>
   </Modal>
 );
+=======
+  initialFocusRef,
+}) => {
+  const submitButtonRef = useRef(null);
+
+  return (
+    <Modal
+      backdropClassName={backdropClassName}
+      className={className}
+      closeButton={closeButton}
+      closeOnEsc={closeOnEsc}
+      closeOnOutsideClick={closeOnOutsideClick}
+      initialFocusRef={initialFocusRef || submitButtonRef}
+      isOpen={isOpen}
+      size={size}
+      onClose={onClose}
+    >
+      <Modal.Header>
+        <Typography data-cy="alert-title" style="h2">
+          {title}
+        </Typography>
+      </Modal.Header>
+      <Modal.Body>
+        <Typography data-cy="alert-message" lineHeight="normal" style="body2">
+          {message}
+        </Typography>
+      </Modal.Body>
+      <Modal.Footer className="neeto-ui-gap-2 neeto-ui-flex neeto-ui-items-center">
+        <Button
+          data-cy="alert-submit-button"
+          label={submitButtonLabel}
+          loading={isSubmitting}
+          ref={submitButtonRef}
+          style="danger"
+          onClick={onSubmit}
+        />
+        <Button
+          data-cy="alert-cancel-button"
+          label={cancelButtonLabel}
+          style="text"
+          onClick={onClose}
+        />
+      </Modal.Footer>
+    </Modal>
+  );
+};
+>>>>>>> 5d4b8ff5 (Specified the first focusable item in Alert)
 
 Alert.propTypes = {
   /**
@@ -120,6 +168,11 @@ Alert.propTypes = {
    * To close on clicking outside the Alert content.
    */
   closeOnOutsideClick: PropTypes.bool,
+  /**
+   * To specify the ref of the element which will receive focus when the Alert is opened.
+   * If not specified, the focus will be set to the submit button inside the Alert.
+   * */
+  initialFocusRef: PropTypes.object,
 };
 
 export default Alert;

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -72,6 +72,7 @@ const Alert = ({
       <Modal.Footer className="neeto-ui-gap-2 neeto-ui-flex neeto-ui-items-center">
         <Button
           data-cy="alert-submit-button"
+          disabled={!isOpen}
           label={submitButtonLabel}
           loading={isSubmitting}
           ref={submitButtonRef}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,7 +66,7 @@ export const renderFocusOnFocusableElements = (
   shouldFocusFirstFocusableElement = true
 ) => {
   const focusableElements =
-    '[href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    'button,[href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
   const firstFocusableElement =
     ref?.current?.querySelectorAll(focusableElements)[0];


### PR DESCRIPTION
- Fixes #1734 

**Description**

- Added: `initialFocusRef` prop to _Alert_

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln _A Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
