### PR TITLE
Added regex prop to reject specified characters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -287,6 +287,7 @@ export interface InputProps
   labelProps?: LabelProps;
   maxLength?: number;
   unlimitedChars: boolean;
+  rejectedCharacters?: RegExp; 
 }
 
 export type LabelProps = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -287,7 +287,7 @@ export interface InputProps
   labelProps?: LabelProps;
   maxLength?: number;
   unlimitedChars: boolean;
-  rejectedCharacters?: RegExp; 
+  rejectCharsRegex?: RegExp;
 }
 
 export type LabelProps = {

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -3,7 +3,7 @@ import React, { useState, forwardRef } from "react";
 import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
-import { assocPath, replace } from "ramda";
+import { replace } from "ramda";
 
 import { hyphenize } from "utils";
 
@@ -54,12 +54,8 @@ const Input = forwardRef(
 
     const handleRegexChange = e => {
       const globalRegex = new RegExp(rejectCharsRegex, "g");
-      const newEvent = assocPath(
-        ["target", "value"],
-        replace(globalRegex, "", e.target.value),
-        e
-      );
-      onChange(newEvent);
+      e.target.value = replace(globalRegex, "", e.target.value);
+      onChange(e);
     };
 
     const handleChange = rejectCharsRegex ? handleRegexChange : onChange;

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -30,7 +30,7 @@ const Input = forwardRef(
       maxLength,
       unlimitedChars = false,
       labelProps,
-      rejectedCharacters = /^\s+$/,
+      rejectCharsRegex = /^\s+$/,
       ...otherProps
     },
     ref
@@ -53,7 +53,7 @@ const Input = forwardRef(
     const isMaxLengthPresent = !!maxLength || maxLength === 0;
 
     const handleChange = e =>
-      !test(rejectedCharacters, e.target.value) && onChange(e);
+      !test(rejectCharsRegex, e.target.value) && onChange(e);
 
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>
@@ -206,7 +206,7 @@ Input.propTypes = {
    * To specify a regex to be matched against the user input. If it matches, the `onChange` prop will not be triggered.
    * By default, it will reject strings containing only whitespace characters.
    */
-  rejectedCharacters: PropTypes.instanceOf(RegExp),
+  rejectCharsRegex: PropTypes.instanceOf(RegExp),
 };
 
 export default Input;

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -3,6 +3,7 @@ import React, { useState, forwardRef } from "react";
 import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
+import { test } from "ramda";
 
 import { hyphenize } from "utils";
 
@@ -29,6 +30,7 @@ const Input = forwardRef(
       maxLength,
       unlimitedChars = false,
       labelProps,
+      rejectedCharacters = /^\s+$/,
       ...otherProps
     },
     ref
@@ -49,6 +51,9 @@ const Input = forwardRef(
 
     const onChange = otherProps.onChange || onChangeInternal;
     const isMaxLengthPresent = !!maxLength || maxLength === 0;
+
+    const handleChange = e =>
+      !test(rejectedCharacters, e.target.value) && onChange(e);
 
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>
@@ -101,7 +106,7 @@ const Input = forwardRef(
             {...(isMaxLengthPresent && !unlimitedChars && { maxLength })}
             {...otherProps}
             value={value}
-            onChange={onChange}
+            onChange={handleChange}
           />
           {suffix && <div className="neeto-ui-input__suffix">{suffix}</div>}
         </div>
@@ -197,6 +202,11 @@ Input.propTypes = {
    * To specify whether the Input field is required or not.
    */
   required: PropTypes.bool,
+  /**
+   * To specify a regex to be matched against the user input. If it matches, the `onChange` prop will not be triggered.
+   * By default, it will reject strings containing only whitespace characters.
+   */
+  rejectedCharacters: PropTypes.instanceOf(RegExp),
 };
 
 export default Input;

--- a/stories/Components/Input.stories.jsx
+++ b/stories/Components/Input.stories.jsx
@@ -22,7 +22,7 @@ const metadata = {
       url: "https://www.figma.com/file/zhdsnPzXzr264x1WUeVdmA/02-Components?node-id=104%3A11",
     },
   },
-  argTypes: { rejectedCharacters: { control: "text" } },
+  argTypes: { rejectCharsRegex: { control: "text" } },
 };
 
 const Template = args => <Input {...args} />;

--- a/stories/Components/Input.stories.jsx
+++ b/stories/Components/Input.stories.jsx
@@ -178,6 +178,20 @@ FormikInputStory.parameters = {
   },
 };
 
+const RejectCharsInputStory = args => (
+  <Input {...args} label="No numbers" rejectCharsRegex={/[0-9]+/} />
+);
+
+RejectCharsInputStory.storyName = "Reject specific characters";
+RejectCharsInputStory.parameters = {
+  docs: {
+    description: {
+      story: `The prop \`rejectCharsRegex\` will accept a regex and any character that matches it
+      cannot be input by the user. It will also prevent such characters from being pasted into the input.`,
+    },
+  },
+};
+
 export {
   Default,
   Sizes,
@@ -190,6 +204,7 @@ export {
   SearchInput,
   InputWithMaxLength,
   FormikInputStory,
+  RejectCharsInputStory,
 };
 
 export default metadata;

--- a/stories/Components/Input.stories.jsx
+++ b/stories/Components/Input.stories.jsx
@@ -22,6 +22,7 @@ const metadata = {
       url: "https://www.figma.com/file/zhdsnPzXzr264x1WUeVdmA/02-Components?node-id=104%3A11",
     },
   },
+  argTypes: { rejectedCharacters: { control: "text" } },
 };
 
 const Template = args => <Input {...args} />;

--- a/tests/Input.test.jsx
+++ b/tests/Input.test.jsx
@@ -27,22 +27,17 @@ describe("Input", () => {
     expect(onChange).toHaveBeenCalledTimes(4);
   });
 
-  it("should not call onChange when input value is only whitespace", () => {
-    const onChange = jest.fn();
+  it("should not show matched regex value", () => {
     const { getByLabelText } = render(
-      <Input id="input" label="Input Label" onChange={onChange} />
+      <Input id="input" label="Input Label" rejectCharsRegex={/[0-9]+/} />
     );
-    userEvent.type(getByLabelText("Input Label"), "    ");
-    expect(onChange).not.toHaveBeenCalled();
-  });
+    const inputField = getByLabelText("Input Label");
+    userEvent.type(inputField, "12345");
+    expect(inputField).not.toHaveValue("12345");
 
-  it("should call onChange when input value contains whitespace and other characters", () => {
-    const onChange = jest.fn();
-    const { getByLabelText } = render(
-      <Input id="input" label="Input Label" onChange={onChange} />
-    );
-    userEvent.type(getByLabelText("Input Label"), "1 2");
-    expect(onChange).toHaveBeenCalled();
+    userEvent.type(inputField, "abc123");
+    expect(inputField).toHaveValue("abc");
+    expect(inputField).not.toHaveValue("123");
   });
 
   it("should display error message", () => {

--- a/tests/Input.test.jsx
+++ b/tests/Input.test.jsx
@@ -27,6 +27,24 @@ describe("Input", () => {
     expect(onChange).toHaveBeenCalledTimes(4);
   });
 
+  it("should not call onChange when input value is only whitespace", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <Input id="input" label="Input Label" onChange={onChange} />
+    );
+    userEvent.type(getByLabelText("Input Label"), "    ");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("should call onChange when input value contains whitespace and other characters", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <Input id="input" label="Input Label" onChange={onChange} />
+    );
+    userEvent.type(getByLabelText("Input Label"), "1 2");
+    expect(onChange).toHaveBeenCalled();
+  });
+
   it("should display error message", () => {
     const { getByText } = render(<Input error="Error message" label="input" />);
     expect(getByText("Error message")).toBeInTheDocument();

--- a/tests/formik/Input.test.jsx
+++ b/tests/formik/Input.test.jsx
@@ -81,4 +81,14 @@ describe("formik/Input", () => {
       expect(screen.getByText("Invalid email address")).toBeInTheDocument()
     );
   });
+
+  it("should display validation error when string containing only whitespace is provided", async () => {
+    const onSubmit = jest.fn();
+    render(<TestForm onSubmit={onSubmit} />);
+    userEvent.type(screen.getByLabelText("First Name"), "    ");
+    userEvent.click(screen.getByText("Submit"));
+    await waitFor(() =>
+      expect(screen.getByText("First name is required")).toBeInTheDocument()
+    );
+  });
 });

--- a/tests/formik/Input.test.jsx
+++ b/tests/formik/Input.test.jsx
@@ -16,11 +16,7 @@ const TestForm = ({ onSubmit }) => {
       <h1>Sign Up</h1>
       <Form
         formikProps={{
-          initialValues: {
-            firstName: "",
-            lastName: "",
-            email: "",
-          },
+          initialValues: { firstName: "", lastName: "", email: "" },
           validationSchema: yup.object().shape({
             firstName: yup.string().required("First name is required"),
             lastName: yup.string().required("Last name is required"),
@@ -48,12 +44,7 @@ const TestForm = ({ onSubmit }) => {
 describe("formik/Input", () => {
   it("should render without error", () => {
     render(
-      <Form
-        formikProps={{
-          initialValues: {},
-          onSubmit: () => {},
-        }}
-      >
+      <Form formikProps={{ initialValues: {}, onSubmit: () => {} }}>
         <Input label="Input label" name="test" />
       </Form>
     );
@@ -81,9 +72,9 @@ describe("formik/Input", () => {
     render(<TestForm onSubmit={onSubmit} />);
     userEvent.type(screen.getByLabelText("Email"), "john.doemail.com");
     userEvent.click(screen.getByText("Submit"));
-    await waitFor(() =>
-      expect(screen.getByText("Invalid email address")).toBeInTheDocument()
-    );
+    expect(
+      await screen.findByText("First name is required")
+    ).toBeInTheDocument();
   });
 
   it("should display validation error when string having only rejected characters is provided", async () => {
@@ -91,8 +82,9 @@ describe("formik/Input", () => {
     render(<TestForm onSubmit={onSubmit} />);
     userEvent.type(screen.getByLabelText("First Name"), "123");
     userEvent.click(screen.getByText("Submit"));
-    await waitFor(() =>
-      expect(screen.getByText("First name is required")).toBeInTheDocument()
-    );
+
+    expect(
+      await screen.findByText("First name is required")
+    ).toBeInTheDocument();
   });
 });

--- a/tests/formik/Input.test.jsx
+++ b/tests/formik/Input.test.jsx
@@ -32,7 +32,11 @@ const TestForm = ({ onSubmit }) => {
           onSubmit: handleSubmit,
         }}
       >
-        <Input label="First Name" name="firstName" />
+        <Input
+          label="First Name"
+          name="firstName"
+          rejectCharsRegex={/[0-9]+/}
+        />
         <Input label="Last Name" name="lastName" />
         <Input label="Email" name="email" type="email" />
         <button type="submit">Submit</button>
@@ -82,10 +86,10 @@ describe("formik/Input", () => {
     );
   });
 
-  it("should display validation error when string containing only whitespace is provided", async () => {
+  it("should display validation error when string having only rejected characters is provided", async () => {
     const onSubmit = jest.fn();
     render(<TestForm onSubmit={onSubmit} />);
-    userEvent.type(screen.getByLabelText("First Name"), "    ");
+    userEvent.type(screen.getByLabelText("First Name"), "123");
     userEvent.click(screen.getByText("Submit"));
     await waitFor(() =>
       expect(screen.getByText("First name is required")).toBeInTheDocument()


### PR DESCRIPTION
- Fixes #1760 

**Description**
Added: `rejectCharsRegex` prop to _Input_ component.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
