### PR TITLE
Updated neetoUI peer dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ properly. Install the peer dependencies using the below command:
 yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 @bigbinary/neeto-icons antd@4.24.3 i18next@21.7.0
 ```
 
-Additionally, you can install `@emotion/is-prop-valid` if you want to detect whether a prop is valid or not for HTML and SVG elements:
-
-```
-yarn add @emotion/is-prop-valid
-```
-
 ### `react-toastify`
 
 neetoUI depends on `react-toastify` for Toasters, so the styles for toaster must

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ working, please import the neetoUI stylesheet to your main `scss` entry point.
 properly. Install the peer dependencies using the below command:
 
 ```
-yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0
+yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 @bigbinary/neeto-icons antd i18next @emotion/is-prop-valid
 ```
 
 ### `react-toastify`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ working, please import the neetoUI stylesheet to your main `scss` entry point.
 properly. Install the peer dependencies using the below command:
 
 ```
-yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 @bigbinary/neeto-icons antd i18next @emotion/is-prop-valid
+yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 @bigbinary/neeto-icons antd@4.24.3 i18next@21.7.0
+```
+
+Additionally, you can install `@emotion/is-prop-valid` if you want to detect whether a prop is valid or not for HTML and SVG elements:
+
+```
+yarn add @emotion/is-prop-valid
 ```
 
 ### `react-toastify`

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "yup": "0.32.11"
   },
   "peerDependencies": {
-    "@bigbinary/neeto-commons-frontend": "latest",
     "@bigbinary/neeto-icons": "latest",
     "antd": "4.24.3",
     "formik": "2.2.0",


### PR DESCRIPTION
- Fixes #1782 

**Description**
Added `@bigbinary/neeto-icons, antd, i18next, and @emotion/is-prop-valid` in peer dependencies list.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
