### PR TITLE
Fixed scroll to error on enter key press

### DIFF
--- a/src/components/formik/Form/FormWrapper.jsx
+++ b/src/components/formik/Form/FormWrapper.jsx
@@ -4,18 +4,18 @@ import { Form as FormikForm, useFormikContext } from "formik";
 import PropTypes from "prop-types";
 
 import ScrollToErrorField from "./ScrollToErrorField";
+import { scrollToError } from "./ScrollToErrorField/utils";
 
 const FormWrapper = forwardRef(
-  (
-    { className, formProps, children, onSubmit, scrollToErrorField },
-    formRef
-  ) => {
+  ({ className, formProps, children, onSubmit, scrollToErrorField }, ref) => {
     const { values, validateForm, setErrors, setTouched, ...formikBag } =
       useFormikContext();
 
     const { dirty: isFormDirty, isSubmitting } = formikBag;
 
-    const formRefForScrollToErrorFiled = useRef();
+    const formRefForScrollToErrorField = useRef();
+
+    const formRef = ref || formRefForScrollToErrorField;
 
     const handleKeyDown = useCallback(
       async event => {
@@ -38,6 +38,7 @@ const FormWrapper = forwardRef(
           if (Object.keys(errors).length > 0) {
             setErrors(errors);
             setTouched(errors);
+            scrollToErrorField && scrollToError(formRef, errors);
           } else {
             onSubmit(values, formikBag);
           }
@@ -65,15 +66,11 @@ const FormWrapper = forwardRef(
         noValidate
         className={className}
         data-testid="neeto-ui-form-wrapper"
-        ref={formRef || formRefForScrollToErrorFiled}
+        ref={formRef}
         onKeyDown={handleKeyDown}
         {...formProps}
       >
-        {scrollToErrorField && (
-          <ScrollToErrorField
-            formRef={formRef || formRefForScrollToErrorFiled}
-          />
-        )}
+        {scrollToErrorField && <ScrollToErrorField formRef={formRef} />}
         {children}
       </FormikForm>
     );

--- a/src/components/formik/Form/ScrollToErrorField/index.js
+++ b/src/components/formik/Form/ScrollToErrorField/index.js
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 
 import { useFormikContext } from "formik";
 
-import { getErrorFieldName } from "./utils";
+import { scrollToError } from "./utils";
 
 const ScrollToErrorField = ({ formRef }) => {
   const { submitCount, isValid, errors } = useFormikContext();
@@ -16,18 +16,8 @@ const ScrollToErrorField = ({ formRef }) => {
     if (!formRef.current || isValidatedReference.current || isValid) return;
     isValidatedReference.current = true;
 
-    const fieldErrorName = getErrorFieldName(errors);
-    if (!fieldErrorName) return;
-
-    const errorFormElement = formRef.current.querySelector(
-      `[name="${fieldErrorName}"]`
-    );
-
-    errorFormElement?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
-  }, [submitCount, errors]);
+    scrollToError(formRef, errors);
+  }, [submitCount]);
 
   return null;
 };

--- a/src/components/formik/Form/ScrollToErrorField/index.js
+++ b/src/components/formik/Form/ScrollToErrorField/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { useFormikContext } from "formik";
 
@@ -6,15 +6,9 @@ import { scrollToError } from "./utils";
 
 const ScrollToErrorField = ({ formRef }) => {
   const { submitCount, isValid, errors } = useFormikContext();
-  const isValidatedReference = useRef(false);
 
   useEffect(() => {
-    isValidatedReference.current = false;
-  }, [submitCount]);
-
-  useEffect(() => {
-    if (!formRef.current || isValidatedReference.current || isValid) return;
-    isValidatedReference.current = true;
+    if (!formRef.current || isValid) return;
 
     scrollToError(formRef, errors);
   }, [submitCount]);

--- a/src/components/formik/Form/ScrollToErrorField/utils.js
+++ b/src/components/formik/Form/ScrollToErrorField/utils.js
@@ -17,5 +17,19 @@ const transformObjectToDotNotation = (object, prefix = "") => {
   return result;
 };
 
-export const getErrorFieldName = formikErrors =>
+const getErrorFieldName = formikErrors =>
   transformObjectToDotNotation(formikErrors)?.[0];
+
+export const scrollToError = (formRef, errors) => {
+  const fieldErrorName = getErrorFieldName(errors);
+  if (!fieldErrorName) return;
+
+  const errorFormElement = formRef.current.querySelector(
+    `[name="${fieldErrorName}"]`
+  );
+
+  errorFormElement?.scrollIntoView({
+    behavior: "smooth",
+    block: "center",
+  });
+};


### PR DESCRIPTION
- Fixes #1780 

**Description**
Fixed: scroll to error is not triggered on submitting form with enter key.

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
