### PR TITLE
Updated the delay for calculating the table header height

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -95,7 +95,7 @@ const Table = ({
       : TABLE_DEFAULT_HEADER_HEIGHT;
     setHeaderHeight(headerHeight);
     handleHeaderClasses();
-  }, 0);
+  }, 10);
 
   const { dragProps, columns: columnsWithReorderProps } = useReorderColumns({
     isEnabled: enableColumnReorder,


### PR DESCRIPTION
- Fixes #1796 

**Description**

- Updated the delay for calculating the height of the table header. This is to ensure that the height of the table is not affected by the flaky animation within the header during render process.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@AbhayVAshokan _a
patch _T

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
