### PR TITLE
Fixed empty ref issue in `Table` component

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -127,7 +127,7 @@ const Table = ({
   const sortedColumnsWithAlignment = sortedColumns.map(sortedColumn => ({
     ...sortedColumn,
     onHeaderCell: column => {
-      const col = column.onHeaderCell?.(sortedColumn);
+      const col = sortedColumn.onHeaderCell?.(column);
 
       return { ...col, "data-text-align": column.align };
     },

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -83,20 +83,11 @@ const Table = ({
     [resizeObserver.current, fixedHeight]
   );
 
-  const handleHeaderClasses = () => {
-    if (headerRef?.current?.children) {
-      Object.values(headerRef.current.children).forEach(child => {
-        child.setAttribute("data-text-align", child.style["text-align"]);
-      });
-    }
-  };
-
   useTimeout(() => {
     const headerHeight = headerRef.current
       ? headerRef.current.offsetHeight
       : TABLE_DEFAULT_HEADER_HEIGHT;
     setHeaderHeight(headerHeight);
-    handleHeaderClasses();
   }, 10);
 
   const { dragProps, columns: columnsWithReorderProps } = useReorderColumns({
@@ -132,6 +123,15 @@ const Table = ({
   const locale = {
     emptyText: <Typography style="body2">No Data</Typography>,
   };
+
+  const sortedColumnsWithAlignment = sortedColumns.map(sortedColumn => ({
+    ...sortedColumn,
+    onHeaderCell: column => {
+      const col = column.onHeaderCell?.(sortedColumn);
+
+      return { ...col, "data-text-align": column.align };
+    },
+  }));
 
   const isPaginationVisible = rowData.length > defaultPageSize;
 
@@ -209,7 +209,7 @@ const Table = ({
   const renderTable = () => (
     <AntTable
       bordered={bordered}
-      columns={sortedColumns}
+      columns={sortedColumnsWithAlignment}
       components={componentOverrides}
       dataSource={rowData}
       loading={loading}
@@ -242,7 +242,6 @@ const Table = ({
         ...scroll,
       }}
       onChange={(pagination, _, sorter) => {
-        handleHeaderClasses();
         preserveTableStateInQuery && handleTableChange(pagination, sorter);
       }}
       onHeaderRow={() => ({

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -84,9 +84,11 @@ const Table = ({
   );
 
   const handleHeaderClasses = () => {
-    Object.values(headerRef.current?.children).forEach(child => {
-      child.setAttribute("data-text-align", child.style["text-align"]);
-    });
+    if (headerRef?.current?.children) {
+      Object.values(headerRef.current.children).forEach(child => {
+        child.setAttribute("data-text-align", child.style["text-align"]);
+      });
+    }
   };
 
   useTimeout(() => {


### PR DESCRIPTION
- Fixes #1795 

**Description**
- Fixed: bug with sortable columns trying to access a `null` `headerRef ` in the `handleHeaderClasses` function. 
-  Achieved the same behavior of center aligning table header content for sortable columns, without depending on `headerRef` to do so.

**Checklist**
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@ajmaln _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->