### PR TITLE
Changed onChange function to output hex-alpha value if transparency option is turned on

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -53,7 +53,9 @@ const ColorPicker = ({
   const onColorChange = hex => {
     const color = tinycolor(hex);
     const rgb = color.toRgb();
-    const hexValue = color.toHexString();
+    const hexValue = showTransparencyControl
+      ? color.toHex8String()
+      : color.toHexString();
     onChangeInternal({ hex: hexValue, rgb });
   };
 


### PR DESCRIPTION
- Fixes #1808

**Description**

- Changed: onChange function of `ColorPicker` to output hex-alpha value if the transparency option is turned on

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
