### PR TITLE
Fixed `ColorPicker` short code issue

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -50,7 +50,14 @@ const ColorPicker = ({
 
   const onChangeInternal = onChange || setColorInternal;
 
-  const onColorChange = hex => {
+  const onColorInputChange = hex => {
+    const color = tinycolor(hex);
+    const rgb = color.toRgb();
+
+    onChangeInternal({ hex, rgb });
+  };
+
+  const onPickerChange = hex => {
     const color = tinycolor(hex);
     const rgb = color.toRgb();
     const hexValue = showTransparencyControl
@@ -59,11 +66,20 @@ const ColorPicker = ({
     onChangeInternal({ hex: hexValue, rgb });
   };
 
+  const onBlur = () => {
+    const color = tinycolor(colorValue);
+    const rgb = color.toRgb();
+    onChangeInternal({
+      rgb,
+      hex: showTransparencyControl ? color.toHex8String() : color.toHexString(),
+    });
+  };
+
   const pickColor = async () => {
     try {
       const colorResponse = await open();
       const colorHex = tinycolor(colorResponse.sRGBHex).toHexString();
-      onColorChange(colorHex);
+      onPickerChange(colorHex);
     } catch {
       // Ensures component is still mounted
       // before calling setState
@@ -108,7 +124,7 @@ const ColorPicker = ({
     >
       <div className="neeto-ui-colorpicker__popover">
         <div className="neeto-ui-colorpicker__pointer">
-          <PickerComponent color={colorValue} onChange={onColorChange} />
+          <PickerComponent color={colorValue} onChange={onPickerChange} />
         </div>
         <div className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-center neeto-ui-mt-2 neeto-ui-gap-2">
           {showEyeDropper && isSupported() && (
@@ -129,7 +145,8 @@ const ColorPicker = ({
               <HexColorInput
                 alpha={!!showTransparencyControl}
                 color={colorValue}
-                onChange={onColorChange}
+                onBlur={onBlur}
+                onChange={onColorInputChange}
               />
             </div>
           </div>

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
 import classnames from "classnames";
 import { Down, Focus } from "neetoicons";
@@ -33,6 +33,7 @@ const ColorPicker = ({
   showTransparencyControl = false,
 }) => {
   const [colorInternal, setColorInternal] = useState(color);
+  const isInputChanged = useRef(false);
   const { open, isSupported } = useEyeDropper({
     pickRadius: 3,
     // cursorActive: CSS Cursors,
@@ -53,6 +54,7 @@ const ColorPicker = ({
   const onColorInputChange = hex => {
     const color = tinycolor(hex);
     const rgb = color.toRgb();
+    isInputChanged.current = true;
 
     onChangeInternal({ hex, rgb });
   };
@@ -67,6 +69,9 @@ const ColorPicker = ({
   };
 
   const onBlur = () => {
+    // If input is not changed, don't call onChange on blur
+    if (!isInputChanged.current) return;
+    isInputChanged.current = false;
     const color = tinycolor(colorValue);
     const rgb = color.toRgb();
     onChangeInternal({

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -51,6 +51,15 @@ const ColorPicker = ({
 
   const onChangeInternal = onChange || setColorInternal;
 
+  const getColor = colorValue => {
+    const color = tinycolor(colorValue);
+
+    return {
+      hex: showTransparencyControl ? color.toHex8String() : color.toHexString(),
+      rgb: color.toRgb(),
+    };
+  };
+
   const onColorInputChange = hex => {
     const color = tinycolor(hex);
     const rgb = color.toRgb();
@@ -59,25 +68,13 @@ const ColorPicker = ({
     onChangeInternal({ hex, rgb });
   };
 
-  const onPickerChange = hex => {
-    const color = tinycolor(hex);
-    const rgb = color.toRgb();
-    const hexValue = showTransparencyControl
-      ? color.toHex8String()
-      : color.toHexString();
-    onChangeInternal({ hex: hexValue, rgb });
-  };
+  const onPickerChange = hex => onChangeInternal(getColor(hex));
 
   const onBlur = () => {
     // If input is not changed, don't call onChange on blur
     if (!isInputChanged.current) return;
     isInputChanged.current = false;
-    const color = tinycolor(colorValue);
-    const rgb = color.toRgb();
-    onChangeInternal({
-      rgb,
-      hex: showTransparencyControl ? color.toHex8String() : color.toHexString(),
-    });
+    onChangeInternal(getColor(colorValue));
   };
 
   const pickColor = async () => {

--- a/stories/Components/ColorPicker.stories.jsx
+++ b/stories/Components/ColorPicker.stories.jsx
@@ -51,9 +51,7 @@ const Default = ({ color, ...args }) => {
   );
 };
 
-Default.args = {
-  color: "#4558F9",
-};
+Default.args = { color: "#4558F9" };
 
 const Sizes = args => {
   const [color, setColor] = useState("#4558F9");
@@ -86,9 +84,7 @@ const Sizes = args => {
 };
 
 Sizes.storyName = "Sizes";
-Sizes.args = {
-  color: "#4558F9",
-};
+Sizes.args = { color: "#4558F9" };
 
 const WithColorPalette = args => {
   const [color, setColor] = useState("#4558F9");
@@ -138,9 +134,7 @@ const WithColorPalette = args => {
   );
 };
 WithColorPalette.storyName = "With color palette";
-WithColorPalette.args = {
-  color: "#4558F9",
-};
+WithColorPalette.args = { color: "#4558F9" };
 
 const WithEyeDropper = args => {
   const [color, setColor] = useState("#4558F9");
@@ -161,9 +155,7 @@ const WithEyeDropper = args => {
   );
 };
 WithEyeDropper.storyName = "With eye dropper";
-WithEyeDropper.args = {
-  color: "#4558F9",
-};
+WithEyeDropper.args = { color: "#4558F9" };
 
 const ShowHexValue = args => {
   const [color, setColor] = useState("#4558F9");
@@ -184,9 +176,7 @@ const ShowHexValue = args => {
   );
 };
 ShowHexValue.storyName = "Show hex value";
-ShowHexValue.args = {
-  color: "#4558F9",
-};
+ShowHexValue.args = { color: "#4558F9" };
 
 const ShowTransparencyControl = args => {
   const [color, setColor] = useState("#4558F9");
@@ -207,9 +197,7 @@ const ShowTransparencyControl = args => {
   );
 };
 ShowTransparencyControl.storyName = "Show transparency control";
-ShowTransparencyControl.args = {
-  color: "#4558F9c9",
-};
+ShowTransparencyControl.args = { color: "#4558F9c9" };
 
 export {
   Default,


### PR DESCRIPTION
- Fixes #1812 

**Description**
- Fixed: Short hex code filling up the input in `ColorPicker`

**Checklist**

- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
