### PR TITLE
Added support for showing only the palette in `ColorPicker`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export interface ColorPickerProps {
   showEyeDropper?: boolean;
   showHexValue?: boolean;
   showTransparencyControl?: boolean;
+  showPicker?: boolean;
 }
 
 interface PopupProps {

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -128,7 +128,10 @@ const ColorPicker = ({
       <div className="neeto-ui-colorpicker__popover">
         {showPicker && (
           <>
-            <div className="neeto-ui-colorpicker__pointer">
+            <div
+              className="neeto-ui-colorpicker__pointer"
+              data-testid="neeto-color-picker-section"
+            >
               <PickerComponent color={colorValue} onChange={onPickerChange} />
             </div>
             <div className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-center neeto-ui-mt-2 neeto-ui-gap-2">

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -27,7 +27,7 @@ const ColorPicker = ({
   color = "",
   size = TARGET_SIZES.large,
   onChange = noop,
-  colorPaletteProps = null,
+  colorPaletteProps,
   showEyeDropper = false,
   showHexValue = false,
   showTransparencyControl = false,

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -31,6 +31,7 @@ const ColorPicker = ({
   showEyeDropper = false,
   showHexValue = false,
   showTransparencyControl = false,
+  showPicker = false,
 }) => {
   const [colorInternal, setColorInternal] = useState(color);
   const isInputChanged = useRef(false);
@@ -125,38 +126,45 @@ const ColorPicker = ({
       position="bottom-start"
     >
       <div className="neeto-ui-colorpicker__popover">
-        <div className="neeto-ui-colorpicker__pointer">
-          <PickerComponent color={colorValue} onChange={onPickerChange} />
-        </div>
-        <div className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-center neeto-ui-mt-2 neeto-ui-gap-2">
-          {showEyeDropper && isSupported() && (
-            <Button
-              className="neeto-ui-colorpicker__eyedropper-btn"
-              icon={Focus}
-              size="small"
-              style="text"
-              type="button"
-              onClick={pickColor}
-            />
-          )}
-          <div className="neeto-ui-input__wrapper">
-            <div
-              className="neeto-ui-colorpicker__input neeto-ui-input neeto-ui-input--small"
-              data-cy="colorpicker-editable-input"
-            >
-              <HexColorInput
-                alpha={!!showTransparencyControl}
-                color={colorValue}
-                onBlur={onBlur}
-                onChange={onColorInputChange}
-              />
+        {showPicker && (
+          <>
+            <div className="neeto-ui-colorpicker__pointer">
+              <PickerComponent color={colorValue} onChange={onPickerChange} />
             </div>
-          </div>
-        </div>
+            <div className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-center neeto-ui-mt-2 neeto-ui-gap-2">
+              {showEyeDropper && isSupported() && (
+                <Button
+                  className="neeto-ui-colorpicker__eyedropper-btn"
+                  icon={Focus}
+                  size="small"
+                  style="text"
+                  type="button"
+                  onClick={pickColor}
+                />
+              )}
+              <div className="neeto-ui-input__wrapper">
+                <div
+                  className="neeto-ui-colorpicker__input neeto-ui-input neeto-ui-input--small"
+                  data-cy="colorpicker-editable-input"
+                >
+                  <HexColorInput
+                    alpha={!!showTransparencyControl}
+                    color={colorValue}
+                    onBlur={onBlur}
+                    onChange={onColorInputChange}
+                  />
+                </div>
+              </div>
+            </div>
+          </>
+        )}
         {colorPaletteProps && (
           <div
-            className="neeto-ui-colorpicker__palette-wrapper"
             data-testid="color-palette"
+            className={classnames("neeto-ui-colorpicker__palette-wrapper", {
+              "neeto-ui-colorpicker__palette-wrapper--hidden-picker":
+                !showPicker,
+            })}
           >
             <Palette {...colorPaletteProps} />
           </div>

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -220,7 +220,7 @@ ColorPicker.propTypes = {
    */
   showTransparencyControl: PropTypes.bool,
   /**
-   * To show the picker. By default it will be hidden.
+   * To show the color picker. Used to hide the picker in cases where only palette is required. By default it will be true.
    */
   showPicker: PropTypes.bool,
 };

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -31,7 +31,7 @@ const ColorPicker = ({
   showEyeDropper = false,
   showHexValue = false,
   showTransparencyControl = false,
-  showPicker = false,
+  showPicker = true,
 }) => {
   const [colorInternal, setColorInternal] = useState(color);
   const isInputChanged = useRef(false);
@@ -219,6 +219,10 @@ ColorPicker.propTypes = {
    * To show transparency control. By default it will be hidden.
    */
   showTransparencyControl: PropTypes.bool,
+  /**
+   * To show the picker. By default it will be hidden.
+   */
+  showPicker: PropTypes.bool,
 };
 
 export default ColorPicker;

--- a/src/styles/components/_color-picker.scss
+++ b/src/styles/components/_color-picker.scss
@@ -14,6 +14,10 @@
 
   .neeto-ui-colorpicker__palette-wrapper {
     margin-top: 12px;
+
+    &--hidden-picker {
+      margin-top: 0;
+    }
   }
 
   .neeto-ui-colorpicker__saturation {
@@ -61,7 +65,7 @@
   transition: all 0.3s;
   padding: 2px;
   border-radius: var(--neeto-ui-rounded-md);
-  margin: 0 4px 4px 0;
+  // margin: 0 4px 4px 0;
 
   &.active {
     border-color: rgb(var(--neeto-ui-gray-500));

--- a/src/styles/components/_color-picker.scss
+++ b/src/styles/components/_color-picker.scss
@@ -65,7 +65,7 @@
   transition: all 0.3s;
   padding: 2px;
   border-radius: var(--neeto-ui-rounded-md);
-  // margin: 0 4px 4px 0;
+  margin: 0 0 0 1.25px;
 
   &.active {
     border-color: rgb(var(--neeto-ui-gray-500));

--- a/stories/Components/ColorPicker.stories.jsx
+++ b/stories/Components/ColorPicker.stories.jsx
@@ -9,6 +9,14 @@ const DEFAULT_COLORS = {
   "yellow-500": "#f57c00",
   "green-500": "#00ba88",
   "blue-500": "#276ef1",
+  "indigo-500": "#4c6ef5",
+  "purple-500": "#7c3aed",
+  "pink-500": "#f22d9e",
+  "gray-500": "#6b7280",
+  "gray-600": "#4b5563",
+  "gray-700": "#374151",
+  "gray-800": "#1f2937",
+  "gray-900": "#111827",
 };
 
 const metadata = {
@@ -211,6 +219,16 @@ const OnlyPalettePicker = args => {
     to: key,
   }));
 
+  const findColorByHex = hex => {
+    const colorClass = Object.keys(DEFAULT_COLORS).find(
+      key => hex === DEFAULT_COLORS[key]
+    );
+
+    return { from: colorClass, to: colorClass };
+  };
+
+  const selectedColor = findColorByHex(color);
+
   const handleColorChange = (fromValue, toValue) => {
     action("colorPaletteProps.onChange")(fromValue, toValue);
     const fromColor = DEFAULT_COLORS[fromValue];
@@ -222,8 +240,12 @@ const OnlyPalettePicker = args => {
       <ColorPicker
         showTransparencyControl
         color={color}
-        colorPaletteProps={{ color, colorList, onChange: handleColorChange }}
         showPicker={false}
+        colorPaletteProps={{
+          color: selectedColor,
+          colorList,
+          onChange: handleColorChange,
+        }}
       />
     </div>
   );

--- a/stories/Components/ColorPicker.stories.jsx
+++ b/stories/Components/ColorPicker.stories.jsx
@@ -199,6 +199,39 @@ const ShowTransparencyControl = args => {
 ShowTransparencyControl.storyName = "Show transparency control";
 ShowTransparencyControl.args = { color: "#4558F9c9" };
 
+const OnlyPalettePicker = args => {
+  const [color, setColor] = useState("#4558F9");
+
+  useEffect(() => {
+    setColor(args.color || "#4558F9c9");
+  }, [args.color]);
+
+  const colorList = Object.keys(DEFAULT_COLORS).map(key => ({
+    from: key,
+    to: key,
+  }));
+
+  const handleColorChange = (fromValue, toValue) => {
+    action("colorPaletteProps.onChange")(fromValue, toValue);
+    const fromColor = DEFAULT_COLORS[fromValue];
+    setColor(fromColor);
+  };
+
+  return (
+    <div className="h-60 w-40">
+      <ColorPicker
+        showTransparencyControl
+        color={color}
+        colorPaletteProps={{ color, colorList, onChange: handleColorChange }}
+        showPicker={false}
+      />
+    </div>
+  );
+};
+
+OnlyPalettePicker.storyName = "Show only palette picker";
+OnlyPalettePicker.args = { color: "#4558F9c9" };
+
 export {
   Default,
   Sizes,
@@ -206,6 +239,7 @@ export {
   WithEyeDropper,
   ShowHexValue,
   ShowTransparencyControl,
+  OnlyPalettePicker,
 };
 
 export default metadata;

--- a/stories/Components/ColorPicker.stories.jsx
+++ b/stories/Components/ColorPicker.stories.jsx
@@ -238,7 +238,6 @@ const OnlyPalettePicker = args => {
   return (
     <div className="h-60 w-40">
       <ColorPicker
-        showTransparencyControl
         color={color}
         showPicker={false}
         colorPaletteProps={{

--- a/stories/Components/ColorPicker.stories.jsx
+++ b/stories/Components/ColorPicker.stories.jsx
@@ -4,6 +4,8 @@ import { action } from "@storybook/addon-actions";
 
 import ColorPicker from "components/ColorPicker";
 
+import { PALETTE_PICKER_CODE } from "./constants";
+
 const DEFAULT_COLORS = {
   "red-500": "#f22d2d",
   "yellow-500": "#f57c00",
@@ -252,6 +254,9 @@ const OnlyPalettePicker = args => {
 
 OnlyPalettePicker.storyName = "Show only palette picker";
 OnlyPalettePicker.args = { color: "#4558F9c9" };
+OnlyPalettePicker.parameters = {
+  docs: { source: { code: PALETTE_PICKER_CODE } },
+};
 
 export {
   Default,

--- a/stories/Components/constants.js
+++ b/stories/Components/constants.js
@@ -1,0 +1,38 @@
+export const PALETTE_PICKER_CODE = `const OnlyPalettePicker = () => {
+  const [color, setColor] = useState("#4558F9");
+
+  const colorList = Object.keys(DEFAULT_COLORS).map(key => ({
+    from: key,
+    to: key,
+  }));
+
+  const findColorByHex = hex => {
+    const colorClass = Object.keys(DEFAULT_COLORS).find(
+      key => hex === DEFAULT_COLORS[key]
+    );
+
+    return { from: colorClass, to: colorClass };
+  };
+
+  const selectedColor = findColorByHex(color);
+
+  const handleColorChange = (fromValue, toValue) => {
+    action("colorPaletteProps.onChange")(fromValue, toValue);
+    const fromColor = DEFAULT_COLORS[fromValue];
+    setColor(fromColor);
+  };
+
+  return (
+    <div className="h-60 w-40">
+      <ColorPicker
+        color={color}
+        showPicker={false}
+        colorPaletteProps={{
+          color: selectedColor,
+          colorList,
+          onChange: handleColorChange,
+        }}
+      />
+    </div>
+  );
+};`;

--- a/tests/ColorPicker.test.jsx
+++ b/tests/ColorPicker.test.jsx
@@ -51,10 +51,7 @@ describe("ColorPicker", () => {
       <ColorPicker
         color={selectedColor}
         colorPaletteProps={{
-          color: {
-            from: "red-500",
-            to: "red-500",
-          },
+          color: { from: "red-500", to: "red-500" },
           colorList: Object.keys(DEFAULT_COLORS).map(key => ({
             from: key,
             to: key,
@@ -102,5 +99,12 @@ describe("ColorPicker", () => {
     });
 
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("should hide picker when showPicker is false", () => {
+    render(<ColorPicker showPicker={false} />);
+    expect(
+      screen.queryByTestId("neeto-color-picker-section")
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Fixes #1816 

**Description**
- Added: Support for showing only the palette in `ColorPicker`

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
