### PR TITLE
Updated `BlockNavigation` component

### DIFF
--- a/formik.d.ts
+++ b/formik.d.ts
@@ -10,6 +10,7 @@ import {
   MultiEmailInput as PlainMultiEmailInput,
   Button as PlainButton,
   ButtonProps,
+  AlertProps,
 } from "./index";
 
 export interface ActionBlockProps {
@@ -30,7 +31,7 @@ export interface Form {
 }
 
 export const ActionBlock: React.FC<ActionBlockProps>;
-export const BlockNavigation: React.FC<BlockNavigationProps>;
+export const BlockNavigation: React.FC<BlockNavigationProps & Partial<AlertProps>>;
 
 export const Input: typeof PlainInput;
 export const Radio: typeof PlainRadio;

--- a/src/components/formik/BlockNavigation.jsx
+++ b/src/components/formik/BlockNavigation.jsx
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import Alert from "components/Alert";
 import { useNavPrompt } from "hooks";
 
-const BlockNavigation = ({ isDirty = false }) => {
+const BlockNavigation = ({ isDirty = false, ...otherProps }) => {
   const formikContext = useFormikContext();
   const shouldBlock =
     isDirty || (Boolean(formikContext) && Boolean(formikContext.dirty));
@@ -28,10 +28,16 @@ const BlockNavigation = ({ isDirty = false }) => {
       title="You have unsaved changes"
       onClose={hidePrompt}
       onSubmit={continueAction}
+      {...otherProps}
     />
   );
 };
 
-BlockNavigation.propTypes = { isDirty: PropTypes.bool };
+BlockNavigation.propTypes = {
+  isDirty: PropTypes.bool,
+  message: PropTypes.string,
+  title: PropTypes.string,
+  submitButtonLabel: PropTypes.string,
+};
 
 export default BlockNavigation;


### PR DESCRIPTION
- Fixes #1819 

**Description**
- Added: Support for overriding props to `Alert` in `BlockNavigation`

**Checklist**

- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
