### PR TITLE
Fixed bug with cancel button not executing the onClick event properly

### DIFF
--- a/src/components/formik/ActionBlock.jsx
+++ b/src/components/formik/ActionBlock.jsx
@@ -30,6 +30,7 @@ const ActionBlock = ({ className, submitButtonProps, cancelButtonProps }) => {
         label="Cancel"
         style="text"
         onClick={handleReset}
+        onMouseDown={e => e.preventDefault()}
         {...cancelButtonProps}
       />
     </div>


### PR DESCRIPTION
- Fixes #1810 

**Description**
- The bug was due to a layout shift that happens when the formik error message is rendered. Details in https://github.com/bigbinary/neeto-ui/issues/1810#issuecomment-1745953703. 
- The issue is fixed when we prevent the default behavior on mouseDown events for the cancel button, as suggesed by Sreerag in https://github.com/bigbinary/neeto-ui/issues/1810#issuecomment-1746360449

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
