### PR TITLE
Added name to select value container to fix scrollToErrorField

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -99,6 +99,7 @@ const ValueContainer = props => {
       {...props}
       innerProps={{
         ...props.innerProps,
+        name: selectProps.name,
         "data-cy": selectProps
           ? `${hyphenize(selectProps.label)}-select-value-container`
           : "select-value-container",


### PR DESCRIPTION
- Fixes #1785 

**Description**
Fixed: scrollToErrorField not working for Select component.

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
