### PR TITLE
Add onBlur handler to trim leading and trailing spaces

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -31,6 +31,8 @@ const Input = forwardRef(
       unlimitedChars = false,
       labelProps,
       rejectCharsRegex,
+      onBlur,
+      disableTrimOnBlur = false,
       ...otherProps
     },
     ref
@@ -59,6 +61,14 @@ const Input = forwardRef(
     };
 
     const handleChange = rejectCharsRegex ? handleRegexChange : onChange;
+
+    const handleOnBlur = e => {
+      if (!disableTrimOnBlur) {
+        e.target.value = value.trim();
+        handleChange(e);
+      }
+      onBlur?.(e);
+    };
 
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>
@@ -111,6 +121,7 @@ const Input = forwardRef(
             {...(isMaxLengthPresent && !unlimitedChars && { maxLength })}
             {...otherProps}
             value={value}
+            onBlur={handleOnBlur}
             onChange={handleChange}
           />
           {suffix && <div className="neeto-ui-input__suffix">{suffix}</div>}
@@ -212,6 +223,10 @@ Input.propTypes = {
    * cannot be input by the user. It will also prevent such characters from being pasted into the input.
    */
   rejectCharsRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * To disable leading and trailing white spaces onBlur.
+   */
+  disableTrimOnBlur: PropTypes.bool,
 };
 
 export default Input;

--- a/stories/Components/Input.stories.jsx
+++ b/stories/Components/Input.stories.jsx
@@ -33,6 +33,13 @@ Default.args = {
   placeholder: "Input placeholder",
 };
 
+const Email = Template.bind({});
+Email.args = {
+  label: "Email",
+  placeholder: "oliver@example.com",
+  type: 'email'
+};
+
 const Sizes = args => (
   <div className="flex w-full flex-col gap-3">
     <Input
@@ -194,6 +201,7 @@ RejectCharsInputStory.parameters = {
 
 export {
   Default,
+  Email,
   Sizes,
   Controlled,
   Required,

--- a/tests/Input.test.jsx
+++ b/tests/Input.test.jsx
@@ -101,4 +101,19 @@ describe("Input", () => {
     userEvent.type(getByLabelText("Input label"), "m");
     expect(getByText(/9(.*)\/(.*)10/)).toBeInTheDocument();
   });
+
+  it("should trim leading and trailing white spaces onBlur", () => {
+    const { getByLabelText } = render(<Input  label="label" />);
+    userEvent.type(getByLabelText("label"), "   Test   ");
+    userEvent.tab(); // go out of focus
+    expect(getByLabelText("label")).toHaveValue("Test");
+  });
+
+  it("should properly handle disableTrimOnBlur", () => {
+    const { getByLabelText } = render(<Input  label="label" disableTrimOnBlur/>);
+    userEvent.type(getByLabelText("label"), "   Test   ");
+    userEvent.tab();
+    expect(getByLabelText("label")).toHaveValue("   Test   ");
+  });
+
 });


### PR DESCRIPTION
- Fixes  #1899

**Description**
Add onBlur handler to `Input` component to trim leading and trailing spaces


**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
