### PR TITLE
Add required prop to date picker

### DIFF
--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -43,6 +43,7 @@ const DatePicker = forwardRef(
       defaultValue,
       value,
       labelProps,
+      required = false,
       ...otherProps
     },
     ref
@@ -63,7 +64,11 @@ const DatePicker = forwardRef(
 
     return (
       <div className="neeto-ui-input__wrapper">
-        {label && <Label {...labelProps}>{label}</Label>}
+        {label && (
+          <Label required={required} {...labelProps}>
+            {label}
+          </Label>
+        )}
         <Component
           data-cy={label ? `${hyphenize(label)}-input` : "picker-input"}
           defaultValue={convertToDayjsObjects(defaultValue)}
@@ -179,6 +184,10 @@ DatePicker.propTypes = {
    * To specify the default values to be displayed inside the DatePicker.
    */
   defaultValue: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  /**
+   * To specify whether the Date picker is required or not.
+   */
+  required: PropTypes.bool,
 };
 
 export default DatePicker;

--- a/stories/Components/DateInput.stories.jsx
+++ b/stories/Components/DateInput.stories.jsx
@@ -46,6 +46,16 @@ DateInput.args = {
   showTime: false,
 };
 
+const RequiredDatePicker = args => <DatePicker {...args} />;
+DateInput.args = {
+  label: "Required Date",
+  type: "date",
+  picker: "date",
+  showTime: false,
+  required: true
+};
+DateInput.storyName = "Required Date";
+
 const DatePickerWithRef = args => {
   const ref = React.useRef();
   const [open, setOpen] = React.useState(false);
@@ -209,6 +219,7 @@ export {
   DateRangePicker,
   DateRangePickerWithPresetRanges,
   ShowTime,
+  RequiredDatePicker
 };
 
 export default metadata;

--- a/tests/DatePicker.test.jsx
+++ b/tests/DatePicker.test.jsx
@@ -109,4 +109,10 @@ describe("DatePicker", () => {
     expect(dateInputBox[0]).toHaveValue("11/04/2022");
     expect(dateInputBox[1]).toHaveValue("16/05/2022");
   });
+
+  it("should render asterisk when required is set to true", () => {
+    const { getByText } = render(<DatePicker required label="Input" />);
+    const asterisk = getByText("*");
+    expect(asterisk).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Fixes #1907

**Description**

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
