### PR TITLE
Added `required` prop to input fields in stories

### DIFF
--- a/stories/Components/Input.stories.jsx
+++ b/stories/Components/Input.stories.jsx
@@ -168,7 +168,7 @@ const FormikInputStory = args => (
   >
     {() => (
       <div className="space-y-2">
-        <FormikInput {...args} label="Name" name="name" />
+        <FormikInput {...args} required label="Name" name="name" />
         <FormikInput {...args} label="Email" name="email" type="email" />
         <Button label="Submit" type="submit" />
       </div>

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -477,12 +477,14 @@ const FormikSelectWithValidation = () => (
     <Form className="flex space-x-2">
       <FormikSelect
         isClearable
+        required
         label="Select 1"
         name="select1"
         options={options}
       />
       <FormikSelect
         isClearable
+        required
         label="Select 2"
         name="select2"
         options={options}

--- a/stories/Components/TreeSelect.stories.jsx
+++ b/stories/Components/TreeSelect.stories.jsx
@@ -105,6 +105,7 @@ WithCustomSuffixAndSwitcherIcon.args = {
 
 const FormikTreeSelectStory = _ => (
   <Form
+    className="space-y-2"
     formikProps={{
       initialValues: { category: "" },
       validationSchema: yup.object({
@@ -112,9 +113,8 @@ const FormikTreeSelectStory = _ => (
       }),
       onSubmit: values => window.alert(JSON.stringify(values)),
     }}
-    className="space-y-2"
   >
-    <FormikTreeSelect {...commonProps} name="category" />
+    <FormikTreeSelect required {...commonProps} name="category" />
     <Button label="Submit" type="submit" />
   </Form>
 );

--- a/stories/Formik/BlockNavigation.stories.jsx
+++ b/stories/Formik/BlockNavigation.stories.jsx
@@ -47,8 +47,8 @@ const FormikStory = args => (
           >
             <BlockNavigation />
             <div className="space-y-4">
-              <Input label="First name" name="firstName" />
-              <Input label="Last name" name="lastName" />
+              <Input required label="First name" name="firstName" />
+              <Input required label="Last name" name="lastName" />
               <div className="flex justify-center">
                 <Button label="Submit" type="submit" />
               </div>

--- a/stories/Formik/Form.stories.jsx
+++ b/stories/Formik/Form.stories.jsx
@@ -34,9 +34,9 @@ const FormikStory = args => (
     {...args}
   >
     <div className="flex h-40 w-full flex-col items-center space-y-4 p-10">
-      <Input className="w-40" label="First name" name="firstName" />
-      <Input className="w-40" label="Last name" name="lastName" />
-      <Input className="w-40" label="Email" name="email" />
+      <Input required className="w-40" label="First name" name="firstName" />
+      <Input required className="w-40" label="Last name" name="lastName" />
+      <Input required className="w-40" label="Email" name="email" />
       <Button className="w-20" disabled={false} label="Submit" type="submit" />
     </div>
   </Form>


### PR DESCRIPTION
- Fixes #1926 

**Description**
Added: `required` props in formik input stories

**Checklist**

- [x] I have made corresponding changes to the documentation.

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
