### PR TITLE
Add data-cy to Single select value

### DIFF
--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from "react";
 import { useId } from "@reach/auto-id";
 import { DatePicker as AntDatePicker } from "antd";
 import classnames from "classnames";
-import { Left, Right, Calendar } from "neetoicons";
+import { Left, Right, Calendar, Close } from "neetoicons";
 import PropTypes from "prop-types";
 
 import { useSyncedRef } from "hooks";
@@ -97,6 +97,9 @@ const DatePicker = forwardRef(
           suffixIcon={<Calendar size={16} />}
           superNextIcon={<IconOverride icon={Right} />}
           superPrevIcon={<IconOverride icon={Left} />}
+          allowClear={{
+            clearIcon: <Close data-cy="date-time-clear-icon" size={16} />,
+          }}
         />
         {!!error && (
           <p

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -20,7 +20,10 @@ const SIZES = { small: "small", medium: "medium", large: "large" };
 const STRATEGIES = { default: "default", fixed: "fixed" };
 
 const DropdownIndicator = props => (
-  <components.DropdownIndicator {...props}>
+  <components.DropdownIndicator
+    {...props}
+    innerProps={{ ...props.innerProps, ["data-cy"]: "action-select-indicator" }}
+  >
     <Down size={16} />
   </components.DropdownIndicator>
 );
@@ -91,6 +94,13 @@ const Menu = props => {
     />
   );
 };
+
+const SingleValue = props => (
+  <components.SingleValue
+    {...props}
+    innerProps={{ ...props.innerProps, "data-cy": "select-single-value" }}
+  />
+);
 
 const ValueContainer = props => {
   const { selectProps } = props;
@@ -263,6 +273,7 @@ const Select = ({
           Menu,
           ValueContainer,
           MenuList,
+          SingleValue,
           ...componentOverrides,
         }}
         {...portalProps}

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -84,6 +84,7 @@ const Tag = forwardRef(
         {onClose && (
           <span
             className="neeto-ui-tag__close"
+            data-cy="tag-close-icon"
             data-testid="tag-close-button"
             onClick={!disabled ? onClose : null}
           >


### PR DESCRIPTION
- Fixes #1946 

**Description**
Added: data-cy attributes to Select, DatePicker and Tags

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
