### PR TITLE
Made the table pagination more compact

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -167,19 +167,23 @@ const Table = ({
 
   const itemRender = (_, type, originalElement) => {
     if (type === "prev") {
-      return <Button className="" icon={Left} style="text" />;
+      return <Button className="" icon={Left} size="small" style="text" />;
     }
 
     if (type === "next") {
-      return <Button className="" icon={Right} style="text" />;
+      return <Button className="" icon={Right} size="small" style="text" />;
     }
 
     if (type === "jump-prev") {
-      return <Button className="" icon={MenuHorizontal} style="text" />;
+      return (
+        <Button className="" icon={MenuHorizontal} size="small" style="text" />
+      );
     }
 
     if (type === "jump-next") {
-      return <Button className="" icon={MenuHorizontal} style="text" />;
+      return (
+        <Button className="" icon={MenuHorizontal} size="small" style="text" />
+      );
     }
 
     return originalElement;

--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -19,10 +19,10 @@
   }
 
   .neeto-ui-pagination__item {
-    width: 32px;
-    min-width: 32px;
-    height: 32px;
-    line-height: 30px;
+    width: 28px;
+    min-width: 28px;
+    height: 28px;
+    line-height: 26px;
     font-size: var(--neeto-ui-text-sm);
     font-weight: var(--neeto-ui-font-medium);
     transition: var(--neeto-ui-transition);

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -108,6 +108,19 @@
     }
   }
 
+  .ant-table-pagination.ant-pagination {
+    margin: 12px 0 0 0 !important;
+  }
+
+  .ant-table-pagination.ant-pagination .ant-pagination-prev,
+  .ant-table-pagination.ant-pagination .ant-pagination-next,
+  .ant-table-pagination.ant-pagination .ant-pagination-jump-prev,
+  .ant-table-pagination.ant-pagination .ant-pagination-jump-next {
+    min-width: 28px;
+    height: 28px;
+    line-height: 28px;
+  }
+
   ul.ant-pagination.ant-table-pagination.ant-table-pagination-right {
     .ant-pagination-prev .ant-pagination-item-link,
     .ant-pagination-next .ant-pagination-item-link {
@@ -126,6 +139,10 @@
       font-weight: var(--neeto-ui-font-medium);
       background-color: rgb(var(--neeto-ui-white));
       // transition: var(--neeto-ui-transition);
+
+      min-width: 28px;
+      height: 28px;
+      line-height: 26px;
 
       a {
         color: rgb(var(--neeto-ui-gray-700));
@@ -730,11 +747,11 @@ td.ant-table-column-sort {
 }
 
 .ant-table table,
-.ant-table-header{
+.ant-table-header {
   border-radius: 0 !important;
 }
 
 .ant-table-column-sorter-up,
-.ant-table-column-sorter-down{
+.ant-table-column-sorter-down {
   font-size: 11px !important;
 }


### PR DESCRIPTION
- Fixes #1965 

<img width="369" alt="Frame 1" src="https://github.com/bigbinary/neeto-ui/assets/48869249/820f4516-a780-4a46-b908-4b7d5b66067e">

**Description**

- Changed: pagination button size from `32px` to `28px`.
- Changed: reduced pagination margin top and margin bottom values to make it more compact.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
