### PR TITLE
Updated instances of `@reach/autoid` with React `useId`

### DIFF
--- a/src/components/Checkbox.jsx
+++ b/src/components/Checkbox.jsx
@@ -1,9 +1,9 @@
 import React, { forwardRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
+import { useId } from "hooks";
 import { hyphenize } from "utils";
 
 import Label from "./Label";

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -1,12 +1,11 @@
 import React, { forwardRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import { DatePicker as AntDatePicker } from "antd";
 import classnames from "classnames";
 import { Left, Right, Calendar, Close } from "neetoicons";
 import PropTypes from "prop-types";
 
-import { useSyncedRef } from "hooks";
+import { useSyncedRef, useId } from "hooks";
 import { convertToDayjsObjects, noop, hyphenize } from "utils";
 
 import Label from "./Label";

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -1,10 +1,10 @@
 import React, { useState, forwardRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 import { replace } from "ramda";
 
+import { useId } from "hooks";
 import { hyphenize } from "utils";
 
 import Label from "./Label";

--- a/src/components/Radio/Item.jsx
+++ b/src/components/Radio/Item.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
 import Label from "components/Label";
+import { useId } from "hooks";
 import { hyphenize } from "utils";
 
 const Item = ({

--- a/src/components/Radio/index.jsx
+++ b/src/components/Radio/index.jsx
@@ -1,10 +1,10 @@
 import React, { useState, Children, cloneElement } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
 import Label from "components/Label";
+import { useId } from "hooks";
 import { hyphenize } from "utils";
 
 import Item from "./Item";

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import { Down, Close } from "neetoicons";
 import PropTypes from "prop-types";
@@ -10,6 +9,7 @@ import Async from "react-select/async";
 import AsyncCreatable from "react-select/async-creatable";
 import Creatable from "react-select/creatable";
 
+import { useId } from "hooks";
 import { hyphenize } from "utils";
 
 import Label from "./Label";

--- a/src/components/Slider/index.jsx
+++ b/src/components/Slider/index.jsx
@@ -1,10 +1,11 @@
-import React, { useId } from "react";
+import React from "react";
 
 import { Slider as AntdSlider, ConfigProvider } from "antd";
 import PropTypes from "prop-types";
 
 import Label from "components/Label";
 import Typography from "components/Typography";
+import { useId } from "hooks";
 import { ANT_DESIGN_GLOBAL_TOKEN_OVERRIDES, hyphenize, noop } from "utils";
 
 import { NEETO_UI_PRIMARY_500 } from "./constants";
@@ -22,8 +23,7 @@ const Slider = ({
   helpText,
   ...otherProps
 }) => {
-  const _id = useId();
-  const id = otherProps.id || _id;
+  const id = useId(otherProps.id);
   const errorId = `error_${id}`;
   const helpTextId = `helpText_${id}`;
 

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -1,10 +1,10 @@
 import React, { forwardRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import { Check, Close } from "neetoicons";
 import PropTypes from "prop-types";
 
+import { useId } from "hooks";
 import { hyphenize, noop } from "utils";
 
 import Label from "./Label";

--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, forwardRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import PropTypes from "prop-types";
 
-import { useSyncedRef } from "hooks";
+import { useSyncedRef, useId } from "hooks";
 import { hyphenize } from "utils";
 
 import Label from "./Label";

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -1,12 +1,11 @@
 import React, { forwardRef } from "react";
 
-import { useId } from "@reach/auto-id";
 import classnames from "classnames";
 import { Clock } from "neetoicons";
 import PropTypes from "prop-types";
 
 import Label from "components/Label";
-import { useSyncedRef } from "hooks";
+import { useSyncedRef, useId } from "hooks";
 import { convertToDayjsObjects, noop, hyphenize } from "utils";
 
 import { TIME_PICKER_TYPES } from "./constants";

--- a/src/components/TimePickerInput/index.jsx
+++ b/src/components/TimePickerInput/index.jsx
@@ -1,4 +1,4 @@
-import React, { useId } from "react";
+import React from "react";
 
 import classnames from "classnames";
 import dayjs from "dayjs";
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import TimePicker from "react-time-picker";
 
 import Label from "components/Label";
+import { useId } from "hooks";
 import { convertToDayjsObjects, hyphenize } from "utils";
 
 dayjs.extend(customParseFormat);
@@ -25,8 +26,7 @@ const TimePickerInput = ({
   error = "",
   ...otherProps
 }) => {
-  const _id = useId();
-  const id = otherProps.id || _id;
+  const id = useId(otherProps.id);
   const errorId = `error_${id}`;
 
   const handleChange = value => {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+import useId from "./useId";
 import useNavPrompt from "./useNavPrompt";
 import useOnClickOutside from "./useOnClickOutside";
 import useOverlay from "./useOverlay";
@@ -6,6 +7,7 @@ import useSyncedRef from "./useSyncedRef";
 import useTimeout from "./useTimeout";
 
 export {
+  useId,
   useOnClickOutside,
   useOverlay,
   useOverlayManager,

--- a/src/hooks/useId.js
+++ b/src/hooks/useId.js
@@ -1,0 +1,9 @@
+import { useId as useReactId } from "react";
+
+const useId = defaultId => {
+  const id = useReactId();
+
+  return defaultId || id;
+};
+
+export default useId;

--- a/stories/Components/DateInput.stories.jsx
+++ b/stories/Components/DateInput.stories.jsx
@@ -49,14 +49,14 @@ DateInput.args = {
 };
 
 const RequiredDatePicker = args => <DatePicker {...args} />;
-DateInput.args = {
+RequiredDatePicker.args = {
   label: "Required Date",
   type: "date",
   picker: "date",
   showTime: false,
   required: true,
 };
-DateInput.storyName = "Required Date";
+RequiredDatePicker.storyName = "Required Date";
 
 const DatePickerWithRef = args => {
   const ref = React.useRef();
@@ -204,6 +204,7 @@ ShowTime.storyName = "Show time";
 
 export {
   DateInput,
+  RequiredDatePicker,
   DatePickerWithRef,
   DatePickerInModal,
   DatePickerInPane,
@@ -211,7 +212,6 @@ export {
   DateRangePicker,
   DateRangePickerWithPresetRanges,
   ShowTime,
-  RequiredDatePicker,
 };
 
 export default metadata;


### PR DESCRIPTION
- Fixes #1952 

**Description**
Changed: Updated instances of `@reach/autoid` with React `useId`

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
