### PR TITLE
Allowed passing `onChange` prop without `value` prop to the Input component

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -50,7 +50,9 @@ const Input = forwardRef(
     const maxLengthError = unlimitedChars && valueLength > maxLength;
 
     const onChange = e => {
-      setValueInternal(e.target.value);
+      if (!otherProps.onChange || !otherProps.value) {
+        setValueInternal(e.target.value);
+      }
       otherProps.onChange?.(e);
     };
 

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -49,9 +49,11 @@ const Input = forwardRef(
     const isCharacterLimitVisible = valueLength >= maxLength * 0.85;
     const maxLengthError = unlimitedChars && valueLength > maxLength;
 
-    const onChangeInternal = e => setValueInternal(e.target.value);
+    const onChange = e => {
+      setValueInternal(e.target.value);
+      otherProps.onChange?.(e);
+    };
 
-    const onChange = otherProps.onChange || onChangeInternal;
     const isMaxLengthPresent = !!maxLength || maxLength === 0;
 
     const handleRegexChange = e => {
@@ -75,9 +77,9 @@ const Input = forwardRef(
         <div className="neeto-ui-input__label-wrapper">
           {label && (
             <Label
+              {...{ required }}
               data-cy={`${hyphenize(label)}-input-label`}
               htmlFor={id}
-              required={required}
               {...labelProps}
             >
               {label}
@@ -108,19 +110,21 @@ const Input = forwardRef(
           <input
             aria-invalid={!!error}
             data-cy={`${hyphenize(label)}-input-field`}
-            disabled={disabled}
-            id={id}
-            ref={ref}
-            required={required}
             size={contentSize}
-            type={type}
             aria-describedby={classnames({
               [errorId]: !!error,
               [helpTextId]: helpText,
             })}
-            {...(isMaxLengthPresent && !unlimitedChars && { maxLength })}
-            {...otherProps}
-            value={value}
+            {...{
+              disabled,
+              id,
+              ref,
+              required,
+              type,
+              ...(isMaxLengthPresent && !unlimitedChars && { maxLength }),
+              ...otherProps,
+              value,
+            }}
             onBlur={handleOnBlur}
             onChange={handleChange}
           />

--- a/tests/Input.test.jsx
+++ b/tests/Input.test.jsx
@@ -21,7 +21,7 @@ describe("Input", () => {
   it("should call onChange when input value changes", () => {
     const onChange = jest.fn();
     const { getByLabelText } = render(
-      <Input id="input" label="Input Label" onChange={onChange} />
+      <Input {...{ onChange }} id="input" label="Input Label" />
     );
     userEvent.type(getByLabelText("Input Label"), "Test");
     expect(onChange).toHaveBeenCalledTimes(4);
@@ -103,17 +103,27 @@ describe("Input", () => {
   });
 
   it("should trim leading and trailing white spaces onBlur", () => {
-    const { getByLabelText } = render(<Input  label="label" />);
+    const { getByLabelText } = render(<Input label="label" />);
     userEvent.type(getByLabelText("label"), "   Test   ");
     userEvent.tab(); // go out of focus
     expect(getByLabelText("label")).toHaveValue("Test");
   });
 
   it("should properly handle disableTrimOnBlur", () => {
-    const { getByLabelText } = render(<Input  label="label" disableTrimOnBlur/>);
+    const { getByLabelText } = render(
+      <Input disableTrimOnBlur label="label" />
+    );
     userEvent.type(getByLabelText("label"), "   Test   ");
     userEvent.tab();
     expect(getByLabelText("label")).toHaveValue("   Test   ");
   });
 
+  it("should display value when onChange handler is passed but value prop is not passed", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <Input {...{ onChange }} label="label" />
+    );
+    userEvent.type(getByLabelText("label"), "Test");
+    expect(getByLabelText("label")).toHaveValue("Test");
+  });
 });


### PR DESCRIPTION
- Fixes #1958 

**Description**
- Allowed the component to use its internal state even when the `onChange` prop is passed.

**Checklist**

- [ ] ~~I have made corresponding changes to the documentation.~~
- [ ] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
