### PR TITLE
Fixed grouped select default value

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { existsBy } from "neetocist";
 import { Down, Close } from "neetoicons";
 import PropTypes from "prop-types";
-import { prop, assoc } from "ramda";
+import { prop, assoc, flatten, pluck } from "ramda";
 import SelectInput, { components } from "react-select";
 import Async from "react-select/async";
 import AsyncCreatable from "react-select/async-creatable";
@@ -238,12 +238,15 @@ const Select = ({
     if (!value || otherProps.isMulti) {
       return value;
     }
-    const currentOptions = options || defaultOptions;
+
+    let currentOptions = options || defaultOptions;
     if (Array.isArray(value)) value = value[0];
 
     const isGrouped = existsBy({ options: Array.isArray }, currentOptions);
 
-    if (isGrouped) return value;
+    if (isGrouped) {
+      currentOptions = flatten(pluck("options", currentOptions));
+    }
 
     return currentOptions?.filter(
       opt => getRealOptionValue(opt) === getRealOptionValue(value)

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 
 import classnames from "classnames";
+import { existsBy } from "neetocist";
 import { Down, Close } from "neetoicons";
 import PropTypes from "prop-types";
 import { prop, assoc } from "ramda";
@@ -155,9 +156,8 @@ const MenuList = props => {
     }
 
     return () => {
-      if (loaderRef.current && isAsyncLoadOptionEnabled) {
-        observer?.unobserve(loaderRef.current);
-      }
+      if (!(loaderRef.current && isAsyncLoadOptionEnabled)) return;
+      observer?.unobserve(loaderRef.current);
     };
   }, [hasMore]);
 
@@ -241,6 +241,10 @@ const Select = ({
     const currentOptions = options || defaultOptions;
     if (Array.isArray(value)) value = value[0];
 
+    const isGrouped = existsBy({ options: Array.isArray }, currentOptions);
+
+    if (isGrouped) return value;
+
     return currentOptions?.filter(
       opt => getRealOptionValue(opt) === getRealOptionValue(value)
     );
@@ -254,10 +258,10 @@ const Select = ({
     >
       {label && (
         <Label
+          {...{ required }}
           data-cy={`${hyphenize(label)}-input-label`}
           data-testid="select-label"
           htmlFor={inputId}
-          required={required}
           {...labelProps}
         >
           {label}
@@ -269,8 +273,6 @@ const Select = ({
         closeMenuOnSelect={!otherProps.isMulti}
         data-cy={`${hyphenize(label)}-select-container`}
         defaultValue={findInOptions(defaultValue)}
-        inputId={inputId}
-        label={label}
         ref={innerRef}
         value={findInOptions(value)}
         className={classnames(["neeto-ui-react-select__container"], {
@@ -293,8 +295,7 @@ const Select = ({
           Control,
           ...componentOverrides,
         }}
-        {...portalProps}
-        {...otherProps}
+        {...{ inputId, label, ...portalProps, ...otherProps }}
       />
       {!!error && (
         <p

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -326,7 +326,7 @@ Select.propTypes = {
   /**
    * To specify the default selected option.
    */
-  defaultValue: PropTypes.object,
+  defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   /**
    * To specify the placeholder text.
    */

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -173,7 +173,7 @@ const Creatable = args => {
         isCreateable
         isSearchable
         defaultValue={[{ value: "value3", label: "Value three" }]}
-        label="Grouped Select"
+        label="Creatable Select"
         name="ValueList"
         options={options}
         placeholder="Select an option"

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Select } from "components";
+import { append, evolve } from "ramda";
 
 const options = [
   { label: "Option 1", value: "option-1" },
@@ -201,4 +202,33 @@ describe("Select", () => {
     );
     expect(screen.getByText("Add more")).toBeInTheDocument();
   });
+
+  it("should set the default value for grouped Select", () => {
+    render(
+      <Select
+        options={[
+          {
+            label: "Group 1",
+            options: options
+          },
+          {
+            label: "Group 2",
+            options: options.map(evolve({
+              label: val => `Group 2 - ${val}`,
+              value: val => `Group 2 - ${val}`
+            }))
+          }
+        ]}
+        defaultValue={[
+          {
+            label: 'Group 2 - Option 1',
+            value: 'Group 2 - options-1'
+          }
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Group 2 - Option 1')).toBeInTheDocument()
+    expect(screen.queryByText('Group 2 - Option 2')).not.toBeInTheDocument()
+  })
 });

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Select } from "components";
-import { append, evolve } from "ramda";
+import { evolve } from "ramda";
 
 const options = [
   { label: "Option 1", value: "option-1" },

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -222,7 +222,7 @@ describe("Select", () => {
         defaultValue={[
           {
             label: 'Group 2 - Option 1',
-            value: 'Group 2 - options-1'
+            value: 'Group 2 - option-1'
           }
         ]}
       />


### PR DESCRIPTION
- Fixes #1988 

**Description**
- Fixed: Grouped select `defaultValue` not being set issue

**Checklist**

- [ ] ~~I have made corresponding changes to the documentation.~~
- [ ] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
