### PR TITLE
Update NoData.stories.jsx

### DIFF
--- a/stories/Components/NoData.stories.jsx
+++ b/stories/Components/NoData.stories.jsx
@@ -36,7 +36,7 @@ const WithDescription = args => (
   <div className="flex w-full items-center justify-center">
     <NoData
       {...args}
-      description="You can try adding a new ticket"
+      description="You can try adding a new ticket."
       title="There are no tickets to show"
       primaryButtonProps={{
         label: "Add new ticket",
@@ -52,7 +52,7 @@ const WithSecondaryButton = args => (
     <NoData
       {...args}
       buttonSeparatorText="or"
-      description="You can try adding a new suite or importing test cases"
+      description="You can try adding a new suite or importing test cases."
       title="There are no suites to show"
       primaryButtonProps={{
         label: "Add new suite",
@@ -74,7 +74,7 @@ const WithHelpText = args => (
       helpText={
         <>
           For more information, please visit our{" "}
-          <Button label="Knowledge Base" style="link" />
+          <Button label="Knowledge Base" style="link" />.
         </>
       }
       primaryButtonProps={{


### PR DESCRIPTION
Screenshots

<img width="342" alt="Screenshot 2023-11-21 at 9 06 43 AM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/b8d1b3c6-c07b-459e-bcc7-948d0372eda5">
<img width="401" alt="Screenshot 2023-11-21 at 9 06 48 AM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/eab40532-8e88-44fd-9c00-69aa499104f5">
<img width="409" alt="Screenshot 2023-11-21 at 9 06 54 AM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/ff6e10dc-bd3b-4e2f-9a4a-6015171aa8f2">



- Fixes #1997 

**Description**

- Added: period after the description.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
