### PR TITLE
Add data cy to select close icon

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -45,7 +45,10 @@ const DropdownIndicator = props => (
 );
 
 const ClearIndicator = props => (
-  <components.ClearIndicator {...props}>
+  <components.ClearIndicator
+    {...props}
+    innerProps={{ ...props.innerProps, ["data-cy"]: "clear-select-indicator" }}
+  >
     <Close size={16} />
   </components.ClearIndicator>
 );

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -47,7 +47,7 @@ const DropdownIndicator = props => (
 const ClearIndicator = props => (
   <components.ClearIndicator
     {...props}
-    innerProps={{ ...props.innerProps, ["data-cy"]: "clear-select-indicator" }}
+    innerProps={{ ...props.innerProps, "data-cy": "clear-select-indicator" }}
   >
     <Close size={16} />
   </components.ClearIndicator>


### PR DESCRIPTION
- Fixes #1999 

**Description**
Added: data cy to close select/multiSelect icon 


**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@Amaljith-K _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
