### PR TITLE
Add prop to hide cancel button in alert component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,7 @@ export interface AlertProps {
   submitButtonLabel?: string;
   cancelButtonLabel?: string;
   initialFocusElement?: "cancel" | "submit";
+  hideCancelButton?: boolean;
 }
 
 export type AvatarProps = {

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -27,6 +27,7 @@ const Alert = ({
   cancelButtonLabel = "Cancel",
   initialFocusRef,
   initialFocusElement,
+  hideCancelButton = false,
 }) => {
   const submitButtonRef = useRef(null);
   const cancelButtonRef = useRef(null);
@@ -39,15 +40,17 @@ const Alert = ({
 
   return (
     <Modal
-      backdropClassName={backdropClassName}
-      className={className}
-      closeButton={closeButton}
-      closeOnEsc={closeOnEsc}
-      closeOnOutsideClick={closeOnOutsideClick}
+      {...{
+        backdropClassName,
+        className,
+        closeButton,
+        closeOnEsc,
+        closeOnOutsideClick,
+        isOpen,
+        onClose,
+        size,
+      }}
       data-cy="alert-box"
-      isOpen={isOpen}
-      size={size}
-      onClose={onClose}
       {...(hasCustomFocusableElement && {
         initialFocusRef: initialFocusRef || initialFocusElementRef,
       })}
@@ -72,13 +75,15 @@ const Alert = ({
           style="danger"
           onClick={onSubmit}
         />
-        <Button
-          data-cy="alert-cancel-button"
-          label={cancelButtonLabel}
-          ref={cancelButtonRef}
-          style="text"
-          onClick={onClose}
-        />
+        {!hideCancelButton && (
+          <Button
+            data-cy="alert-cancel-button"
+            label={cancelButtonLabel}
+            ref={cancelButtonRef}
+            style="text"
+            onClick={onClose}
+          />
+        )}
       </Modal.Footer>
     </Modal>
   );
@@ -150,6 +155,10 @@ Alert.propTypes = {
    * To specify the element which will receive focus when the Alert is opened.
    */
   initialFocusElement: PropTypes.oneOf(Object.values(FOCUSABLE_ELEMENTS)),
+  /**
+   * To hide the cancel button
+   */
+  hideCancelButton: PropTypes.bool,
 };
 
 export default Alert;

--- a/tests/Alert.test.jsx
+++ b/tests/Alert.test.jsx
@@ -143,4 +143,16 @@ describe("Alert", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
+
+  it("should not show cancel button when hideCancelButton is true", () => {
+    const { queryByText } = render(
+      <Alert
+        hideCancelButton
+        isOpen
+        message="Alert message"
+        title="Alert title"
+      />
+    );
+    expect(queryByText("Cancel")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Fixes #1996 

**Description**
Added:  `hideCancelButton` prop to __Alert__ component.
**Checklist**

~- [] I have made corresponding changes to the documentation.~
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@Amaljith-K _a
<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
