### PR TITLE
Fixes issues with table height calculation logic

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -133,7 +133,8 @@ const Table = ({
     },
   }));
 
-  const isPaginationVisible = rowData.length > defaultPageSize;
+  const isPaginationVisible =
+    otherProps.pagination !== false && rowData.length > defaultPageSize;
 
   let rowSelectionProps = false;
   if (rowSelection) {


### PR DESCRIPTION
- Fixes #2017

**Description**
 - Updates the logic to calculate table height without considering the pagination height when pagination is set to false

**Checklist**

- ~[ ] I have made corresponding changes to the documentation.~
- ~[ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@AbhayVAshokan _a Please review

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
