### PR TITLE
Updated the multi select component to not show the `Add` button when no options are selected

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -25,6 +25,7 @@ const Control = ({ children, ...props }) => {
 
   return (
     <components.Control {...props}>
+      {/* hasValue is part of commonProps passed to custom components internally by react-select */}
       {hasValue && selectProps.isMulti && (
         <span className="neeto-ui-btn neeto-ui-btn--style-secondary neeto-ui-react-select__add-btn">
           {selectProps.addButtonLabel || "Add"}

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -21,12 +21,12 @@ const SIZES = { small: "small", medium: "medium", large: "large" };
 const STRATEGIES = { default: "default", fixed: "fixed" };
 
 const Control = ({ children, ...props }) => {
-  const { selectProps } = props;
+  const { selectProps, hasValue } = props;
 
   return (
     <components.Control {...props}>
-      {selectProps.isMulti && (
-        <span className="neeto-ui-btn neeto-ui-btn--style-primary neeto-ui-react-select__add-btn">
+      {hasValue && selectProps.isMulti && (
+        <span className="neeto-ui-btn neeto-ui-btn--style-secondary neeto-ui-react-select__add-btn">
           {selectProps.addButtonLabel || "Add"}
         </span>
       )}{" "}


### PR DESCRIPTION
- Fixes #2021

**Description**
- Updated the multi select component to not show the `Add` button when no options are selected.
- Changed the type of the `Add` button from `primary` to `secondary`.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
