### PR TITLE
Avoided redundant handleChange call

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -68,7 +68,10 @@ const Input = forwardRef(
 
     const handleOnBlur = e => {
       if (!disableTrimOnBlur && typeof value === "string") {
-        e.target.value = value.trim();
+        const trimmedValue = value.trim();
+        if (value === trimmedValue) return;
+
+        e.target.value = trimmedValue;
         handleChange(e);
       }
       onBlur?.(e);

--- a/tests/Input.test.jsx
+++ b/tests/Input.test.jsx
@@ -109,6 +109,21 @@ describe("Input", () => {
     expect(getByLabelText("label")).toHaveValue("Test");
   });
 
+  it("should not trigger onChange on onBlur if there are no leading and trailing white spaces", async () => {
+    const handleChange = jest.fn();
+    const { getByLabelText } = render(
+      <Input label="label" onChange={handleChange} />
+    );
+    await userEvent.type(getByLabelText("label"), "  Test  ");
+    await userEvent.tab(); // go out of focus
+    expect(handleChange).toBeCalled();
+
+    await userEvent.type(getByLabelText("label"), "Test");
+    handleChange.mockReset(); // reset previous invocations
+    await userEvent.tab(); // go out of focus
+    expect(handleChange).not.toBeCalled();
+  });
+
   it("should properly handle disableTrimOnBlur", async () => {
     const { getByLabelText } = render(
       <Input disableTrimOnBlur label="label" />


### PR DESCRIPTION
**Description**
Previously onBlur was causing a redundant onChange call. Now onChange will be called only if the value contains leading or trailing whitespaces.

**Checklist**

- [x] ~~I have made corresponding changes to the documentation.~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln _a
cc @navaneethsdk thanks for pointing out this bug in https://github.com/bigbinary/smile-cart-frontend/pull/57
<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
