### PR TITLE
Enhanced UI responsiveness

### DIFF
--- a/src/components/NoData/index.jsx
+++ b/src/components/NoData/index.jsx
@@ -67,7 +67,7 @@ const NoData = ({
         </Typography>
       )}
       {(hasPrimaryButtonProps || hasSecondaryButtonProps) && (
-        <div className="neeto-ui-no-data__action-block neeto-ui-flex neeto-ui-items-center neeto-ui-justify-center">
+        <div className="neeto-ui-no-data__action-block">
           {hasPrimaryButtonProps && (
             <Button data-cy="no-data-primary-button" {...primaryButtonProps} />
           )}

--- a/src/styles/components/_date-time-picker.scss
+++ b/src/styles/components/_date-time-picker.scss
@@ -362,6 +362,12 @@
     }
 
     .ant-picker-body {
+
+      @include viewport(xs-mob) {
+        padding-left: 8px;
+        padding-right: 8px;
+      }
+
       .ant-picker-content {
         .ant-picker-cell.ant-picker-cell-in-view.ant-picker-cell-today {
           .ant-picker-cell-inner {
@@ -482,6 +488,11 @@
     white-space: nowrap;
     align-items: center;
     border-bottom: var(--neeto-ui-date-panel-header-border-bottom-width);
+
+    @include viewport(xs-mob) {
+      padding-left: 8px;
+      padding-right: 8px;
+    }
   }
 
   .ant-picker-header-view {
@@ -514,6 +525,10 @@
 
   .ant-picker-date-panel {
     width: var(--neeto-ui-date-panel-width);
+
+    @include viewport(xs-mob) {
+      width: 296px;
+    }
   }
 
   .ant-picker-date-panel .ant-picker-content {

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -70,6 +70,12 @@
     backdrop-filter: var(--neeto-ui-modal-wrapper-backdrop-filter);
     animation: showModalWrapper 0.3s forwards;
 
+    @include viewport(mob) {
+      width: 95%;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
     @keyframes showModalWrapper {
       0% {
         opacity: 0;
@@ -110,6 +116,10 @@
       max-height: 100vh;
       transform: scale(1);
       animation: nuifadeIn 0s forwards;
+
+      @include viewport(mob) {
+        width: 100%;
+      }
     }
 
     .neeto-ui-modal__header {

--- a/src/styles/components/_no-data.scss
+++ b/src/styles/components/_no-data.scss
@@ -41,6 +41,14 @@
   &__action-block {
     margin-top: var(--neeto-ui-no-data-action-block-margin-top);
     gap: var(--neeto-ui-no-data-action-block-gap);
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    @include viewport(mob) {
+      flex-direction: column;
+    }
   }
 }
 

--- a/src/styles/components/_pane.scss
+++ b/src/styles/components/_pane.scss
@@ -60,6 +60,9 @@
     transform: translateX(100%);
     transition: all 0.3s;
 
+    display: flex;
+    flex-direction: column;
+
     &--small {
       --neeto-ui-pane-wrapper-width: 480px;
     }
@@ -94,6 +97,7 @@
     padding: var(--neeto-ui-pane-body-padding-y) var(--neeto-ui-pane-body-padding-x);
     font-size: var(--neeto-ui-pane-body-font-size);
     overflow-y: auto;
+    flex-grow: 1;
 
     &.neeto-ui-pane__body--has-footer {
       --neeto-ui-pane-body-height: calc(

--- a/src/styles/components/_pane.scss
+++ b/src/styles/components/_pane.scss
@@ -60,9 +60,6 @@
     transform: translateX(100%);
     transition: all 0.3s;
 
-    display: flex;
-    flex-direction: column;
-
     &--small {
       --neeto-ui-pane-wrapper-width: 480px;
     }
@@ -97,7 +94,6 @@
     padding: var(--neeto-ui-pane-body-padding-y) var(--neeto-ui-pane-body-padding-x);
     font-size: var(--neeto-ui-pane-body-font-size);
     overflow-y: auto;
-    flex-grow: 1;
 
     &.neeto-ui-pane__body--has-footer {
       --neeto-ui-pane-body-height: calc(

--- a/src/styles/components/_stepper.scss
+++ b/src/styles/components/_stepper.scss
@@ -50,6 +50,7 @@
     display: flex;
     align-items: center;
     gap: var(--neeto-ui-stepper-wrapper-gap);
+    flex-wrap: wrap;
   }
 
   &-item {
@@ -104,12 +105,24 @@
     display: flex;
     align-items: center;
 
+    @include viewport(mob) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
     &:not(:last-child) {
       &::after {
         content: "";
         width: var(--neeto-ui-stepper-item-separator-width);
         border-top: var(--neeto-ui-stepper-item-separator-border-top);
         margin-left: var(--neeto-ui-stepper-item-separator-margin-left);
+
+        @include viewport(mob) {
+          width: 1px;
+          height: var(--neeto-ui-stepper-item-separator-width);
+          border-left: var(--neeto-ui-stepper-item-separator-border-top);
+          margin-left: 22px;
+        }
       }
     }
 

--- a/src/styles/components/_stepper.scss
+++ b/src/styles/components/_stepper.scss
@@ -51,6 +51,11 @@
     align-items: center;
     gap: var(--neeto-ui-stepper-wrapper-gap);
     flex-wrap: wrap;
+
+    @include viewport(mob) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 
   &-item {

--- a/src/styles/components/_toast.scss
+++ b/src/styles/components/_toast.scss
@@ -67,6 +67,12 @@ body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
       "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !important;
 
+      @include viewport(xs-mob) {
+        width: 95%;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
       &::after {
         visibility: hidden;
       }
@@ -96,6 +102,7 @@ body {
           p {
             font-size: var(--neeto-ui-toastr-font-size);
             font-weight: var(--neeto-ui-toastr-font-weight);
+            word-break: break-word;
           }
         }
 

--- a/stories/Overlays/Alert.stories.jsx
+++ b/stories/Overlays/Alert.stories.jsx
@@ -70,8 +70,8 @@ const Sizes = () => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Small" onClick={() => setShowAlertSmall(true)} />
             <Button label="Medium" onClick={() => setShowAlertMedium(true)} />
             <Button label="Large" onClick={() => setShowAlertLarge(true)} />

--- a/stories/Overlays/Modal.stories.jsx
+++ b/stories/Overlays/Modal.stories.jsx
@@ -40,8 +40,8 @@ const Default = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Modal" onClick={() => setShowModal(true)} />
           </div>
         </div>
@@ -84,8 +84,8 @@ const Sizes = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button
               label="Small"
               onClick={() => setShowModalExtraSmall(true)}
@@ -219,8 +219,8 @@ const ModalFocusTrapping = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Modal" onClick={() => setShowModal(true)} />
           </div>
         </div>
@@ -269,8 +269,8 @@ const NestedModals = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Modal" onClick={() => setShowModal(true)} />
           </div>
         </div>
@@ -345,8 +345,8 @@ const InitialAndFinalFocusRef = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Modal" onClick={() => setShowModal(true)} />
             <Button
               label="Focus here on close"
@@ -401,8 +401,8 @@ const CSSCustomization = () => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Modal" onClick={() => setShowModal(true)} />
           </div>
         </div>

--- a/stories/Overlays/Pane.stories.jsx
+++ b/stories/Overlays/Pane.stories.jsx
@@ -45,8 +45,8 @@ const Default = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Pane" onClick={() => setShowPane(true)} />
           </div>
         </div>
@@ -95,8 +95,8 @@ const Sizes = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Small" onClick={() => setShowPaneExtraSmall(true)} />
             <Button label="Large" onClick={() => setShowPaneLarge(true)} />
           </div>
@@ -168,8 +168,8 @@ const PaneWithLongTitle = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Pane" onClick={() => setShowPane(true)} />
           </div>
         </div>
@@ -221,7 +221,7 @@ const PaneWithModalAndAlert = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
+        <div className="space-y-8">
           <div className="flex flex-row items-center justify-start space-x-2">
             <Button label="Show Pane" onClick={() => setShowPane(true)} />
           </div>
@@ -305,7 +305,7 @@ const MultiplePanes = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
+        <div className="space-y-8">
           <div className="flex flex-row items-center justify-start space-x-2">
             <Button
               label="Show Pane"
@@ -423,7 +423,7 @@ const PaneWithOverlayManager = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
+        <div className="space-y-8">
           <div className="flex flex-row items-center justify-start space-x-2">
             <Button
               label="Show Pane"
@@ -605,8 +605,8 @@ const DynamicFieldFocusInsidePane = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button
               label="Show Pane"
               onClick={() => {
@@ -689,8 +689,8 @@ const CSSCustomization = args => {
   return (
     <div className="w-full">
       <div className="space-y-6">
-        <div className="w-1/2 space-y-8">
-          <div className="flex flex-row items-center justify-start space-x-6">
+        <div className="space-y-8">
+          <div className="flex flex-row flex-wrap items-center justify-start gap-6">
             <Button label="Show Pane" onClick={() => setShowPane(true)} />
           </div>
         </div>


### PR DESCRIPTION
- Fixes #2042

**Description**
Enhanced the responsiveness of the following components

- Alert
- Modal
- Pane
- Toastr
- NoData
- DatePicker
- Stepper

**Screenshots**

<img width="339" alt="Screenshot 2023-12-12 at 3 22 21 AM" src="https://github.com/bigbinary/neeto-ui/assets/24496302/fb641a39-ad0d-4ae9-8dd7-400a86d1229d">
<img width="339" alt="Screenshot 2023-12-12 at 3 23 48 AM" src="https://github.com/bigbinary/neeto-ui/assets/24496302/572b57f6-7c45-4405-afc6-d3ab9b47a844">
<img width="343" alt="Screenshot 2023-12-12 at 3 26 02 AM" src="https://github.com/bigbinary/neeto-ui/assets/24496302/e5c47a01-d26e-4b50-a6db-7bdbf42849fd">
<img width="341" alt="Screenshot 2023-12-12 at 3 26 22 AM" src="https://github.com/bigbinary/neeto-ui/assets/24496302/7db5d9f5-8e4f-4aa8-91a5-5f0981d3c52b">



**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [ ] ~I have verified the functionality in some of the neeto web-apps.~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added the necessary label (patch/minor/major - If package publish
      is required).~

**Reviewers**
@praveen-murali-ind _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
