### PR TITLE
Updated full screen modal close button style and size

### DIFF
--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -55,6 +55,8 @@ const Modal = ({
     hasTransitionCompleted,
   });
 
+  const isFullScreenModal = size === SIZES.fullScreen;
+
   return (
     <Portal rootId="neeto-ui-portal">
       <CSSTransition
@@ -73,7 +75,7 @@ const Modal = ({
           className={classnames(
             "neeto-ui-modal__backdrop",
             {
-              "neeto-ui-modal__backdrop--fullscreen": size === SIZES.fullScreen,
+              "neeto-ui-modal__backdrop--fullscreen": isFullScreenModal,
             },
             backdropClassName
           )}
@@ -87,7 +89,7 @@ const Modal = ({
               "neeto-ui-modal__wrapper--small": size === SIZES.small,
               "neeto-ui-modal__wrapper--medium": size === SIZES.medium,
               "neeto-ui-modal__wrapper--large": size === SIZES.large,
-              "neeto-ui-modal__wrapper--fullscreen": size === SIZES.fullScreen,
+              "neeto-ui-modal__wrapper--fullscreen": isFullScreenModal,
               [className]: className,
             })}
             {...otherProps}
@@ -99,8 +101,8 @@ const Modal = ({
                 data-cy="modal-close-button"
                 data-testid="close-button"
                 icon={Close}
-                size="small"
-                style="text"
+                size={isFullScreenModal ? "large" : "small"}
+                style={isFullScreenModal ? "secondary" : "text"}
                 onClick={handleOverlayClose}
               />
             )}

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -112,6 +112,7 @@
       --neeto-ui-modal-wrapper-max-width: 100vw;
       --neeto-ui-modal-wrapper-height: 100%;
       --neeto-ui-modal-wrapper-border-radius: var(--neeto-ui-rounded-none);
+      --neeto-ui-modal-header-padding-top: 28px;
 
       max-height: 100vh;
       transform: scale(1);


### PR DESCRIPTION
- Fixes #2044 

**Screenshots**

Before:
<img width="1552" alt="Screenshot 2023-12-19 at 11 35 48 PM" src="https://github.com/bigbinary/neeto-ui/assets/24496302/e84f4248-772e-4e5f-bcdd-a1b79d78eebc">

After:
<img width="1552" alt="Screenshot 2023-12-19 at 11 33 42 PM" src="https://github.com/bigbinary/neeto-ui/assets/24496302/fea3d609-9f05-4858-8acc-b8eb99f6b60c">

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [ ] ~I have verified the functionality in some of the neeto web-apps.~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added the necessary label (patch/minor/major - If package publish
      is required).~

**Reviewers**
@praveen-murali-ind _a Please review.

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
