### PR TITLE
Added support for disabling the create option for MultiEmailInput

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -293,6 +293,7 @@ export interface MultiEmailInputProps {
   required?: boolean;
   maxHeight?: number;
   labelProps?: LabelProps;
+  isCreateable?: boolean;
   [key: string]: any;
 }
 

--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -40,6 +40,7 @@ const MultiEmailInput = forwardRef(
       required = false,
       labelProps,
       visibleEmailsCount = 3,
+      isCreateable = true,
       ...otherProps
     },
     ref
@@ -101,6 +102,8 @@ const MultiEmailInput = forwardRef(
 
     if (isOptionsPresent) {
       const isValidNewOption = (inputValue, _, selectOptions) => {
+        if (!isCreateable) return false;
+
         const isInputEmpty = isEmpty(inputValue.trim());
         const doesInputContainSeparator =
           inputValue.includes(",") || inputValue.includes(" ");
@@ -285,6 +288,10 @@ MultiEmailInput.propTypes = {
    * To specify the number of email to be displayed in the input field when not in focus.
    */
   visibleEmailsCount: PropTypes.number,
+  /**
+   * To specify whether a new email option can be created or not.
+   */
+  isCreateable: PropTypes.bool,
 };
 
 export default MultiEmailInput;

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -86,7 +86,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onBlur when focus from the input field changes", async () => {
     const onBlur = jest.fn();
-    render(<MultiEmailInput onBlur={onBlur} />);
+    render(<MultiEmailInput {...{ onBlur }} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.click(emailInput);
     await userEvent.click(document.body);
@@ -95,7 +95,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onChange when input loses focus after entering email", async () => {
     const onChange = jest.fn();
-    render(<MultiEmailInput onChange={onChange} />);
+    render(<MultiEmailInput {...{ onChange }} />);
     const emailInput = screen.getByRole("combobox");
     emailInput.focus();
     await userEvent.paste("test@email.com test2@email.com");
@@ -109,7 +109,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onInputChange when email input value changes", async () => {
     const onInputChange = jest.fn();
-    render(<MultiEmailInput onInputChange={onInputChange} />);
+    render(<MultiEmailInput {...{ onInputChange }} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "test");
     expect(onInputChange).toHaveBeenCalledTimes(4);
@@ -126,7 +126,7 @@ describe("MultiEmailInput", () => {
   });
 
   it("shouldn't show create option when isCreateable is false", async () => {
-    render(<MultiEmailInput options={SAMPLE_EMAILS} isCreateable={false} />);
+    render(<MultiEmailInput isCreateable={false} options={SAMPLE_EMAILS} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "test");
     const optionsList = document.querySelector(
@@ -137,7 +137,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onChange when Enter key is pressed", async () => {
     const onChange = jest.fn();
-    render(<MultiEmailInput onChange={onChange} />);
+    render(<MultiEmailInput {...{ onChange }} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "email@domain.com{enter}");
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -148,7 +148,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onChange when Space key is pressed", async () => {
     const onChange = jest.fn();
-    render(<MultiEmailInput onChange={onChange} />);
+    render(<MultiEmailInput {...{ onChange }} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "email@domain.com ");
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -159,7 +159,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onChange when Tab key is pressed", async () => {
     const onChange = jest.fn();
-    render(<MultiEmailInput onChange={onChange} />);
+    render(<MultiEmailInput {...{ onChange }} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "email@domain.com{tab}");
     // await userEvent.tab();
@@ -171,7 +171,7 @@ describe("MultiEmailInput", () => {
 
   it("should call onChange when comma key is pressed", async () => {
     const onChange = jest.fn();
-    render(<MultiEmailInput onChange={onChange} />);
+    render(<MultiEmailInput {...{ onChange }} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "email@domain.com,");
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -184,15 +184,13 @@ describe("MultiEmailInput", () => {
     const onChange = jest.fn();
     render(
       <MultiEmailInput
+        {...{ onChange }}
         error="Invalid email"
-        filterInvalidEmails={{
-          label: "Filter invalid emails",
-        }}
+        filterInvalidEmails={{ label: "Filter invalid emails" }}
         value={[
           { label: "test@example.com", value: "test@example.com", valid: true },
           { label: "invalidEmail", value: "invalidEmail" },
         ]}
-        onChange={onChange}
       />
     );
     await userEvent.click(screen.getByText("Filter invalid emails"));
@@ -206,13 +204,13 @@ describe("MultiEmailInput", () => {
     const onChange = jest.fn();
     render(
       <MultiEmailInput
+        {...{ onChange }}
         error="Invalid email"
         filterInvalidEmails={{}}
         value={[
           { label: "test@example.com", value: "test@example.com", valid: true },
           { label: "invalidEmail", value: "invalidEmail" },
         ]}
-        onChange={onChange}
       />
     );
 
@@ -224,7 +222,7 @@ describe("MultiEmailInput", () => {
   it("should accept a generic string containing an email and should pluck out that email", async () => {
     const onChange = jest.fn();
     const user = userEvent.setup({ document });
-    render(<MultiEmailInput onChange={onChange} />);
+    render(<MultiEmailInput {...{ onChange }} />);
     const emailInput = screen.getByRole("combobox");
     emailInput.focus();
     await user.paste("John Doe <john@example.com>");

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -115,6 +115,26 @@ describe("MultiEmailInput", () => {
     expect(onInputChange).toHaveBeenCalledTimes(4);
   });
 
+  it("should show create option when isCreateable is true", async () => {
+    render(<MultiEmailInput options={SAMPLE_EMAILS} />);
+    const emailInput = screen.getByRole("combobox");
+    await userEvent.type(emailInput, "test");
+    const optionsList = document.querySelector(
+      ".neeto-ui-react-select__menu-list"
+    );
+    expect(optionsList).toHaveTextContent('Create "test"');
+  });
+
+  it("shouldn't show create option when isCreateable is false", async () => {
+    render(<MultiEmailInput options={SAMPLE_EMAILS} isCreateable={false} />);
+    const emailInput = screen.getByRole("combobox");
+    await userEvent.type(emailInput, "test");
+    const optionsList = document.querySelector(
+      ".neeto-ui-react-select__menu-list"
+    );
+    expect(optionsList).not.toHaveTextContent("Create");
+  });
+
   it("should call onChange when Enter key is pressed", async () => {
     const onChange = jest.fn();
     render(<MultiEmailInput onChange={onChange} />);

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -119,20 +119,14 @@ describe("MultiEmailInput", () => {
     render(<MultiEmailInput options={SAMPLE_EMAILS} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "test");
-    const optionsList = document.querySelector(
-      ".neeto-ui-react-select__menu-list"
-    );
-    expect(optionsList).toHaveTextContent('Create "test"');
+    expect(screen.getByText('Create "test"')).toBeInTheDocument();
   });
 
   it("shouldn't show create option when isCreateable is false", async () => {
     render(<MultiEmailInput isCreateable={false} options={SAMPLE_EMAILS} />);
     const emailInput = screen.getByRole("combobox");
     await userEvent.type(emailInput, "test");
-    const optionsList = document.querySelector(
-      ".neeto-ui-react-select__menu-list"
-    );
-    expect(optionsList).not.toHaveTextContent("Create");
+    expect(screen.queryByText('Create "test"')).not.toBeInTheDocument();
   });
 
   it("should call onChange when Enter key is pressed", async () => {


### PR DESCRIPTION
- Fixes #2060

**Description**
 - Added support for disabling the create option for MultiEmailInput from the host application

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
@ajmaln _a Please review

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
