### PR TITLE
Updated antd version to the correct version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ working, please import the neetoUI stylesheet to your main `scss` entry point.
 properly. Install the peer dependencies using the below command:
 
 ```
-yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 @bigbinary/neeto-icons antd@4.24.3 i18next@21.7.0
+yarn add react-toastify@9.0.1 formik@2.2.0 react-router-dom@5.2.0 @bigbinary/neeto-icons antd@5.9.2 i18next@21.7.0
 ```
 
 ### `react-toastify`


### PR DESCRIPTION
- Fixes #2059 

**Description**
Fixes: The readme had the wrong version of the `antd` package mentioned as peer dependency, it is now fixed.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
