### PR TITLE
More actions on table header

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -270,10 +270,11 @@ export interface DropdownProps {
   [key: string]: any;
 }
 
-export interface MenuItemProps extends React.DetailedHTMLProps<
-  React.LiHTMLAttributes<HTMLLIElement>,
-  HTMLLIElement
-> {
+export interface MenuItemProps
+  extends React.DetailedHTMLProps<
+    React.LiHTMLAttributes<HTMLLIElement>,
+    HTMLLIElement
+  > {
   tooltipProps?: TooltipProps;
 }
 
@@ -425,6 +426,7 @@ export interface TableProps {
   onColumnDelete?: (key: string) => void;
   preserveTableStateInQuery?: boolean;
   onColumnHide?: (columnKey: string) => void;
+  onMoreActionClick?: (actionType: string, column: any) => void;
   [key: string]: any;
 }
 

--- a/src/components/Table/components/HeaderCell/CellContent.jsx
+++ b/src/components/Table/components/HeaderCell/CellContent.jsx
@@ -15,16 +15,20 @@ const CellContent = ({
   onColumnHide,
   onAddColumn,
   onColumnDelete,
+  onMoreActionClick,
   column,
+  moreActions = [],
   ...headerProps
 }) => {
   const isColumnHidable = isHidable && isPresent(onColumnHide);
   const isColumnDeletable = isDeletable && isPresent(onColumnDelete);
+  const hasMoreActions = moreActions?.length && isPresent(onMoreActionClick);
   const hasMoreMenu =
     isSortable ||
     isPresent(column?.description) ||
     isColumnHidable ||
-    isAddEnabled;
+    isAddEnabled ||
+    hasMoreActions;
 
   return (
     <th
@@ -41,9 +45,11 @@ const CellContent = ({
               isAddEnabled,
               isColumnDeletable,
               isSortable,
+              moreActions,
               onAddColumn,
               onColumnDelete,
               onColumnHide,
+              onMoreActionClick,
               onSort,
               sortedInfo,
             }}

--- a/src/components/Table/components/HeaderCell/CellContent.jsx
+++ b/src/components/Table/components/HeaderCell/CellContent.jsx
@@ -43,6 +43,7 @@ const CellContent = ({
           <HeaderCellMenu
             {...{
               column,
+              hasMoreActions,
               isAddEnabled,
               isColumnDeletable,
               isSortable,

--- a/src/components/Table/components/HeaderCell/CellContent.jsx
+++ b/src/components/Table/components/HeaderCell/CellContent.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { isPresent, noop } from "neetocist";
+import { isEmpty } from "ramda";
 
 import HeaderCellMenu from "./HeaderCellMenu";
 
@@ -22,7 +23,7 @@ const CellContent = ({
 }) => {
   const isColumnHidable = isHidable && isPresent(onColumnHide);
   const isColumnDeletable = isDeletable && isPresent(onColumnDelete);
-  const hasMoreActions = moreActions?.length && isPresent(onMoreActionClick);
+  const hasMoreActions = !isEmpty(moreActions) && isPresent(onMoreActionClick);
   const hasMoreMenu =
     isSortable ||
     isPresent(column?.description) ||

--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -22,9 +22,12 @@ const HeaderCellMenu = ({
   onColumnHide,
   onAddColumn,
   onColumnDelete,
+  onMoreActionClick,
   columnTitle = null,
+  moreActions = [],
 }) => {
   const columnInfoButtonReference = useRef();
+  const hasMoreActions = moreActions?.length && isPresent(onMoreActionClick);
 
   return (
     <div onClick={event => event.stopPropagation()}>
@@ -133,6 +136,16 @@ const HeaderCellMenu = ({
               Delete column
             </MenuItem.Button>
           )}
+          {hasMoreActions
+            ? moreActions.map((item, index) => (
+                <MenuItem.Button
+                  key={index}
+                  onClick={() => onMoreActionClick(item.type, column)}
+                >
+                  {item.label}
+                </MenuItem.Button>
+              ))
+            : null}
         </Menu>
       </Dropdown>
     </div>

--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -136,16 +136,15 @@ const HeaderCellMenu = ({
               Delete column
             </MenuItem.Button>
           )}
-          {hasMoreActions
-            ? moreActions.map((item, index) => (
-                <MenuItem.Button
-                  key={index}
-                  onClick={() => onMoreActionClick(item.type, column)}
-                >
-                  {item.label}
-                </MenuItem.Button>
-              ))
-            : null}
+          {hasMoreActions &&
+            moreActions.map((item, index) => (
+              <MenuItem.Button
+                key={index}
+                onClick={() => onMoreActionClick(item.type, column)}
+              >
+                {item.label}
+              </MenuItem.Button>
+            ))}
         </Menu>
       </Dropdown>
     </div>

--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -22,12 +22,12 @@ const HeaderCellMenu = ({
   onColumnHide,
   onAddColumn,
   onColumnDelete,
+  hasMoreActions,
   onMoreActionClick,
   columnTitle = null,
   moreActions = [],
 }) => {
   const columnInfoButtonReference = useRef();
-  const hasMoreActions = moreActions?.length && isPresent(onMoreActionClick);
 
   return (
     <div onClick={event => event.stopPropagation()}>

--- a/src/components/Table/hooks/useColumns.js
+++ b/src/components/Table/hooks/useColumns.js
@@ -16,6 +16,7 @@ const useColumns = ({
   sortedInfo,
   setSortedInfo,
   onColumnHide,
+  onMoreActionClick,
   onTableChange,
   tableOnChangeProps,
   handleTableSortChange,
@@ -69,6 +70,7 @@ const useColumns = ({
     handleSort,
     sortedInfo,
     onColumnHide,
+    onMoreActionClick,
     tableOnChangeProps,
   });
 

--- a/src/components/Table/hooks/useResizableColumns.js
+++ b/src/components/Table/hooks/useResizableColumns.js
@@ -15,6 +15,7 @@ const useResizableColumns = ({
   handleSort,
   sortedInfo,
   onColumnHide,
+  onMoreActionClick,
   tableOnChangeProps,
 }) => {
   const handleResize =
@@ -38,11 +39,13 @@ const useResizableColumns = ({
             onSort: handleSort,
             sortedInfo,
             onColumnHide,
+            onMoreActionClick,
             isAddEnabled: isAddEnabled && !col.fixed,
             onAddColumn: positionOffset => onColumnAdd(index + positionOffset),
             onColumnDelete,
             isHidable: col.isHidable,
             isDeletable: col.isDeletable,
+            moreActions: col.moreActions,
             column: col,
           }),
           sortIcon: SortIcon,

--- a/src/components/Table/hooks/useResizableColumns.js
+++ b/src/components/Table/hooks/useResizableColumns.js
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import { isPresent, noop } from "neetocist";
+import { has } from "ramda";
 
 import SortIcon from "../components/SortIcon";
 
@@ -55,7 +56,7 @@ const useResizableColumns = ({
               : null,
         };
 
-        if (!col.ellipsis) {
+        if (!has("ellipsis", col)) {
           modifiedColumn.ellipsis = true;
         }
 

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -52,6 +52,7 @@ const Table = ({
   onColumnAdd = noop,
   onColumnDelete,
   onChange,
+  onMoreActionClick,
   ...otherProps
 }) => {
   const [containerHeight, setContainerHeight] = useState(null);
@@ -109,6 +110,7 @@ const Table = ({
     sortedInfo,
     setSortedInfo,
     onColumnHide,
+    onMoreActionClick,
     onColumnAdd,
     onColumnDelete,
     tableOnChangeProps,

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -438,6 +438,12 @@ Table.propTypes = {
    */
   onColumnDelete: PropTypes.func,
   /**
+   * Function that gets called when a more action item in header is clicked.
+   *
+   * `onMoreActionClick={(type, column) => {}}`
+   */
+  onMoreActionClick: PropTypes.func,
+  /**
    * Additional props for row selection. Refer [row selection docs](https://ant.design/components/table/#rowSelection) from AntD Table
    * Make sure to pass `id` in `rowData` for this to work.
    */

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -540,9 +540,8 @@ const TableWithMoreActionOnHeader = args => {
         currentPageNumber={pageNumber}
         handlePageChange={page => setPageNumber(page)}
         rowData={TABLE_DATA}
-        onMoreActionClick={(type, { title, key }) => {
-          const text = typeof title === "string" ? title : key;
-          alert(`${type} clicked on ${text}`);
+        onMoreActionClick={(type, { key }) => {
+          alert(`${type} clicked on ${key}`);
         }}
         {...args}
       />

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from "react";
+import { assoc } from "ramda";
 
 import { MenuHorizontal } from "neetoicons";
 import { BrowserRouter } from "react-router-dom";
@@ -240,9 +241,6 @@ const Default = args => {
       currentPageNumber={pageNumber}
       handlePageChange={page => setPageNumber(page)}
       rowData={TABLE_DATA}
-      onMoreActionClick={(actionType, columnId) => {
-        console.log(actionType, columnId);
-      }}
       {...args}
     />
   );
@@ -525,13 +523,12 @@ const TableWithMoreActionOnHeader = args => {
 
   const columns = useMemo(
     () =>
-      getColumns().map(column => ({
-        ...column,
-        moreActions: [
+      getColumns().map(
+        assoc("moreActions", [
           { type: "action1", label: "Action 1" },
           { type: "action2", label: "Action 2" },
-        ],
-      })),
+        ])
+      ),
     []
   );
 
@@ -543,8 +540,9 @@ const TableWithMoreActionOnHeader = args => {
         currentPageNumber={pageNumber}
         handlePageChange={page => setPageNumber(page)}
         rowData={TABLE_DATA}
-        onMoreActionClick={(type, column) => {
-          alert(`${type} clicked on ${column.title}`);
+        onMoreActionClick={(type, { title, key }) => {
+          const text = typeof title === "string" ? title : key;
+          alert(`${type} clicked on ${text}`);
         }}
         {...args}
       />

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 
 import { MenuHorizontal } from "neetoicons";
 import { BrowserRouter } from "react-router-dom";
@@ -13,6 +13,7 @@ import TableDocs from "!raw-loader!./TableStoriesDocs/TableDocs.mdx";
 import TableFixedHeightDocs from "!raw-loader!./TableStoriesDocs/TableFixedHeightDocs.mdx";
 import TableSortingDocs from "!raw-loader!./TableStoriesDocs/TableSortingDocs.mdx";
 import TableWithoutCheckboxDocs from "!raw-loader!./TableStoriesDocs/TableWithoutCheckboxDocs.mdx";
+import MoreActionsOnHeaderDocs from "!raw-loader!./TableStoriesDocs/MoreActionsOnHeaderDocs.mdx";
 
 const { Menu, MenuItem } = Dropdown;
 
@@ -239,6 +240,9 @@ const Default = args => {
       currentPageNumber={pageNumber}
       handlePageChange={page => setPageNumber(page)}
       rowData={TABLE_DATA}
+      onMoreActionClick={(actionType, columnId) => {
+        console.log(actionType, columnId);
+      }}
       {...args}
     />
   );
@@ -516,6 +520,49 @@ const TableWithColumnWithHideColumnOption = args => {
 TableWithColumnWithHideColumnOption.storyName = "Table with hide column option";
 TableWithColumnWithHideColumnOption.args = { defaultPageSize: 10 };
 
+const TableWithMoreActionOnHeader = args => {
+  const [pageNumber, setPageNumber] = useState(1);
+
+  const columns = useMemo(
+    () =>
+      getColumns().map(column => ({
+        ...column,
+        moreActions: [
+          { type: "action1", label: "Action 1" },
+          { type: "action2", label: "Action 2" },
+        ],
+      })),
+    []
+  );
+
+  return (
+    <div className="h-96">
+      <Table
+        enableColumnReorder
+        columnData={columns}
+        currentPageNumber={pageNumber}
+        handlePageChange={page => setPageNumber(page)}
+        rowData={TABLE_DATA}
+        onMoreActionClick={(type, column) => {
+          alert(`${type} clicked on ${column.title}`);
+        }}
+        {...args}
+      />
+    </div>
+  );
+};
+
+TableWithMoreActionOnHeader.storyName = "Table with more actions on header";
+TableWithMoreActionOnHeader.args = { defaultPageSize: 10 };
+TableWithMoreActionOnHeader.parameters = {
+  docs: {
+    description: { story: MoreActionsOnHeaderDocs },
+    source: {
+      code: getTableSource("onMoreActionClick={(type, column) => {}}"),
+    },
+  },
+};
+
 const CSSCustomization = args => {
   const [pageNumber, setPageNumber] = useState(1);
 
@@ -551,6 +598,7 @@ export {
   TableWithReordableColumns,
   TableWithColumnDescriptionPopover,
   TableWithColumnWithHideColumnOption,
+  TableWithMoreActionOnHeader,
   CSSCustomization,
 };
 

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo } from "react";
-import { assoc } from "ramda";
 
 import { MenuHorizontal } from "neetoicons";
+import { assoc } from "ramda";
 import { BrowserRouter } from "react-router-dom";
 
 import { Tooltip, Tag, Avatar, Button, Dropdown, Typography } from "components";
@@ -9,12 +9,12 @@ import NeetoTable from "components/Table";
 
 import { getTableSource, TABLE_DATA, SIMPLE_TABLE_DATA } from "../constants";
 
+import MoreActionsOnHeaderDocs from "!raw-loader!./TableStoriesDocs/MoreActionsOnHeaderDocs.mdx";
 import TableCSSCustomization from "!raw-loader!./TableStoriesDocs/TableCSSCustomization.mdx";
 import TableDocs from "!raw-loader!./TableStoriesDocs/TableDocs.mdx";
 import TableFixedHeightDocs from "!raw-loader!./TableStoriesDocs/TableFixedHeightDocs.mdx";
 import TableSortingDocs from "!raw-loader!./TableStoriesDocs/TableSortingDocs.mdx";
 import TableWithoutCheckboxDocs from "!raw-loader!./TableStoriesDocs/TableWithoutCheckboxDocs.mdx";
-import MoreActionsOnHeaderDocs from "!raw-loader!./TableStoriesDocs/MoreActionsOnHeaderDocs.mdx";
 
 const { Menu, MenuItem } = Dropdown;
 

--- a/stories/Components/TableStoriesDocs/MoreActionsOnHeaderDocs.mdx
+++ b/stories/Components/TableStoriesDocs/MoreActionsOnHeaderDocs.mdx
@@ -1,0 +1,31 @@
+To add more actions to table header
+
+- Add `moreActions` key to column definitions. Each action should have a `type`
+  and `label`. eg:
+
+```js
+const columns = [
+  {
+    title: "ID",
+    dataIndex: "id",
+    key: "id",
+    width: 75,
+    moreActions: [{ type: "action1", label: "Action 1" }],
+  },
+  // other columns
+];
+```
+
+- Add `onMoreActionClick` prop to `Table` component. When user click on an
+  action this function will be called with action `type` and `column` object.
+  eg:
+
+```jsx
+<Table
+  rowData={TABLE_DATA}
+  columnData={columns}
+  onMoreActionClick={(type, column) => {
+    // Do your actions here.
+  }}
+/>
+```

--- a/stories/constants.jsx
+++ b/stories/constants.jsx
@@ -24,6 +24,7 @@ const columnData = [
     sorter: () => {},
     title: "ID",
     width: 75,
+    moreActions: [{ type: "action1", label: "Action 1" }],
   },
   {
     dataIndex: "guid",

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -49,6 +49,7 @@ const columnData = [
     sorter: true,
     isDeletable: false,
     width: 150,
+    moreActions: [{ type: "action1", label: "Action 1" }],
   },
 ];
 
@@ -337,5 +338,24 @@ describe("Table", () => {
     await userEvent.click(screen.getByText("Delete column"));
 
     expect(onColumnDelete).toBeCalledWith(columnData[3].id);
+  });
+
+  it("should call the onMoreActionClick when any of the more action item is clicked", async () => {
+    const onMoreActionClick = jest.fn();
+    render(
+      <NeetoUITable
+        {...{ columnData, onMoreActionClick, rowData }}
+        defaultPageSize={2}
+        shouldDynamicallyRenderRowSize={false}
+      />
+    );
+    const column = screen.getByText("Position");
+    const menuButton = within(column.closest("th")).getByTestId(
+      "column-menu-button"
+    );
+    await userEvent.click(menuButton);
+    expect(await screen.findByText("Action 1")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("Action 1"));
+    expect(onMoreActionClick).toBeCalledWith("action1", columnData[5]);
   });
 });


### PR DESCRIPTION
- Fixes #2067
- Fixes #2069 

**Description**
- Add ability to add more actions to the table header. 

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
