### PR TITLE
Fix table column width and button shrinking issue in table cell

### DIFF
--- a/src/styles/components/_table-overrides.scss
+++ b/src/styles/components/_table-overrides.scss
@@ -96,3 +96,15 @@
   --neeto-ui-table-header-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-table-header-text-transform: capitalize;
 }
+
+.ant-table-wrapper {
+  .ant-table-cell {
+    .neeto-ui-btn--icon-only {
+      flex-shrink: 0;
+    }
+    .neeto-ui-btn--style-link {
+      white-space: normal;
+      text-align: left;
+    }
+  }
+}


### PR DESCRIPTION
- Fixes #2072 

**Description**

- Fixed: Icon button shrinking issue in table cell.
- Fixed: Updated table cell [link button](https://neeto-ui.neeto.com/?path=/story/components-button--styles&hash=710ee799a61abebfaa6923e81c35d2d46aa793ef) text alignment to left.
- Added: `white-space: normal` to table cell [link button](https://neeto-ui.neeto.com/?path=/story/components-button--styles&hash=710ee799a61abebfaa6923e81c35d2d46aa793ef).

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
