### PR TITLE
Allow overriding `allowClear`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,6 +199,7 @@ export type DatePickerProps = {
   id?: string;
   disabled?: boolean;
   labelProps?: LabelProps;
+  allowClear?: boolean;
   [key: string]: any;
 };
 

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -151,13 +151,9 @@ const DatePicker = forwardRef(
             superNextIcon={<IconOverride icon={Right} />}
             superPrevIcon={<IconOverride icon={Left} />}
             allowClear={
-              allowClear === true
-                ? {
-                    clearIcon: (
-                      <Close data-cy="date-time-clear-icon" size={16} />
-                    ),
-                  }
-                : allowClear
+              allowClear && {
+                clearIcon: <Close data-cy="date-time-clear-icon" size={16} />,
+              }
             }
           />
           {!!error && typeof error === "string" && (

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -151,13 +151,13 @@ const DatePicker = forwardRef(
             superNextIcon={<IconOverride icon={Right} />}
             superPrevIcon={<IconOverride icon={Left} />}
             allowClear={
-              allowClear
+              allowClear === true
                 ? {
                     clearIcon: (
                       <Close data-cy="date-time-clear-icon" size={16} />
                     ),
                   }
-                : false
+                : allowClear
             }
           />
           {!!error && typeof error === "string" && (
@@ -251,6 +251,10 @@ DatePicker.propTypes = {
    * To specify whether the Date picker is required or not.
    */
   required: PropTypes.bool,
+  /**
+   * To specify whether the Date picker value can be cleared or not.
+   */
+  allowClear: PropTypes.bool,
 };
 
 export default DatePicker;

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -48,6 +48,7 @@ const DatePicker = forwardRef(
       value,
       labelProps,
       required = false,
+      allowClear = true,
       ...otherProps
     },
     ref
@@ -149,9 +150,15 @@ const DatePicker = forwardRef(
             suffixIcon={<Calendar size={16} />}
             superNextIcon={<IconOverride icon={Right} />}
             superPrevIcon={<IconOverride icon={Left} />}
-            allowClear={{
-              clearIcon: <Close data-cy="date-time-clear-icon" size={16} />,
-            }}
+            allowClear={
+              allowClear
+                ? {
+                    clearIcon: (
+                      <Close data-cy="date-time-clear-icon" size={16} />
+                    ),
+                  }
+                : false
+            }
           />
           {!!error && typeof error === "string" && (
             <p


### PR DESCRIPTION
- Fixes #2077 

**Description**
Added: Support for `allowClear` prop in _DatePicker_ to be `false`

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] ~~I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
