### PR TITLE
Fix lint staged not triggering for tests and stories

### DIFF
--- a/.scripts/fix-lints.sh
+++ b/.scripts/fix-lints.sh
@@ -1,0 +1,3 @@
+prettier --write "$@"
+eslint --fix "$@"
+git add "$@"

--- a/package.json
+++ b/package.json
@@ -177,8 +177,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "5.3.3",
-    "react-toastify": "8.0.2",
-    "@bigbinary/neeto-commons-frontend": "latest"
+    "react-toastify": "8.0.2"
   },
   "resolutions": {
     "@storybook/addon-essentials/**/glob-parent": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "managers.*"
   ],
   "lint-staged": {
-    "src/**/*.{html,md,js,jsx,json}": [
-      "eslint --fix"
+    "**/*.{html,md,js,jsx,json}": [
+      ".scripts/fix-lints.sh"
     ]
   },
   "engines": {
@@ -177,7 +177,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "5.3.3",
-    "react-toastify": "8.0.2"
+    "react-toastify": "8.0.2",
+    "@bigbinary/neeto-commons-frontend": "latest"
   },
   "resolutions": {
     "@storybook/addon-essentials/**/glob-parent": "5.1.2",


### PR DESCRIPTION
- Fixes #2076

**Description**
Fix lint staged not triggering for tests and stories

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
~- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).~

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
