### PR TITLE
Replaced info Icon with Help icon in Label component

### DIFF
--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -36,10 +36,10 @@ const Label = ({
       {helpIconProps && (
         <Tooltip {...tooltipProps} disabled={!tooltipProps}>
           <span
+            {...{ onClick }}
             className={classnames("neeto-ui-label__help-icon-wrap", {
               [helpIconClassName]: helpIconClassName,
             })}
-            onClick={onClick}
           >
             <HelpIcon size={16} {...otherHelpIconProps} />
           </span>
@@ -68,9 +68,7 @@ Label.propTypes = {
   helpIconProps: PropTypes.shape({
     onClick: PropTypes.func,
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    tooltipProps: PropTypes.shape({
-      ...Tooltip.propTypes,
-    }),
+    tooltipProps: PropTypes.shape({ ...Tooltip.propTypes }),
   }),
 };
 

--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import classnames from "classnames";
-import { Info } from "neetoicons";
+import { Help } from "neetoicons";
 import PropTypes from "prop-types";
 
 import Tooltip from "./Tooltip";
@@ -21,7 +21,7 @@ const Label = ({
     ...otherHelpIconProps
   } = helpIconProps || {};
 
-  const HelpIcon = icon || Info;
+  const HelpIcon = icon || Help;
 
   return (
     <label


### PR DESCRIPTION
- Fixes #2085

**Description**

Before

![Screenshot 2024-02-15 at 5 47 48 PM](https://github.com/bigbinary/neeto-form-web/assets/16187886/b57929f4-5aec-433f-b4e0-f0aad47760cf)

After

![2a-after](https://github.com/bigbinary/neeto-ui/assets/16187886/a4b009a5-b372-4677-aa1d-cc80217ad5b2)

---

Before

![3-before](https://github.com/bigbinary/neeto-site-web/assets/16187886/aa68d9c2-a960-48aa-a94f-d325b30f5e1b)

After

![Screenshot 2024-02-21 at 11 32 00 PM](https://github.com/bigbinary/neeto-ui/assets/16187886/2fe7d125-b701-4513-b44e-f19801c8ca25)

**Checklist**



~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
