### PR TITLE
Select: fix `strategy="fixed"` not scrolling to selected

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -73,15 +73,24 @@ const CustomInput = props => {
   );
 };
 
-const CustomOption = props => (
-  <components.Option
-    {...props}
-    innerProps={{
-      ...props.innerProps,
-      "data-cy": `${hyphenize(props.label)}-select-option`,
-    }}
-  />
-);
+const CustomOption = props => {
+  const ref = useRef();
+
+  useEffect(() => {
+    props.isSelected && ref.current.scrollIntoView();
+  }, [props.isSelected]);
+
+  return (
+    <components.Option
+      {...props}
+      innerRef={ref}
+      innerProps={{
+        ...props.innerProps,
+        "data-cy": `${hyphenize(props.label)}-select-option`,
+      }}
+    />
+  );
+};
 
 const Placeholder = props => {
   const { selectProps } = props;

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -31,7 +31,7 @@ const Template = args => (
   </div>
 );
 
-const OPTIONS = Array.from({ length: 100 }, (_, index) => ({
+const OPTIONS = Array.from({ length: 20 }, (_, index) => ({
   value: `value${index}`,
   label: `Value ${index}`,
 }));
@@ -39,7 +39,7 @@ const OPTIONS = Array.from({ length: 100 }, (_, index) => ({
 const Default = Template.bind({});
 Default.args = {
   label: "Select",
-  defaultValue: { value: "value50", label: "Value 50" },
+  defaultValue: { value: "value15", label: "Value 15" },
   placeholder: "Select an option",
   isDisabled: false,
   isClearable: true,
@@ -47,6 +47,7 @@ Default.args = {
   name: "ValueList",
   optionRemapping: {},
   options: OPTIONS,
+  strategy: "fixed",
 };
 
 const Sizes = args => (

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -31,23 +31,22 @@ const Template = args => (
   </div>
 );
 
+const OPTIONS = Array.from({ length: 100 }, (_, index) => ({
+  value: `value${index}`,
+  label: `Value ${index}`,
+}));
+
 const Default = Template.bind({});
 Default.args = {
   label: "Select",
-  defaultValue: { value: "value3", label: "Value three" },
+  defaultValue: { value: "value50", label: "Value 50" },
   placeholder: "Select an option",
   isDisabled: false,
   isClearable: true,
   isSearchable: true,
   name: "ValueList",
   optionRemapping: {},
-  options: [
-    { value: "value1", label: "Value one" },
-    { value: "value2", label: "Value two" },
-    { value: "value3", label: "Value three" },
-    { value: "value4", label: "Value four" },
-    { value: "value5", label: "Value five" },
-  ],
+  options: OPTIONS,
 };
 
 const Sizes = args => (


### PR DESCRIPTION
- Fixes #2098 

**Description**
Fixed: Select strategy="fixed"` not scrolling to selected

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
