### PR TITLE
Added support for overriding props of the dropdown in the ColorPicker

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ export interface ColorPickerProps {
   showHexValue?: boolean;
   showTransparencyControl?: boolean;
   showPicker?: boolean;
+  dropdownProps?: DropdownProps;
 }
 
 interface PopupProps {

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -28,6 +28,7 @@ const ColorPicker = ({
   size = TARGET_SIZES.large,
   onChange = noop,
   colorPaletteProps,
+  dropdownProps,
   showEyeDropper = false,
   showHexValue = false,
   showTransparencyControl = false,
@@ -35,14 +36,7 @@ const ColorPicker = ({
 }) => {
   const [colorInternal, setColorInternal] = useState(color);
   const isInputChanged = useRef(false);
-  const { open, isSupported } = useEyeDropper({
-    pickRadius: 3,
-    // cursorActive: CSS Cursors,
-    // cursorInactive: CSS Cursors,
-    // onPickStart?: () => void
-    // onPickEnd?: () => void
-    // onPickCancel?: () => void
-  });
+  const { open, isSupported } = useEyeDropper({ pickRadius: 3 });
 
   const PickerComponent = showTransparencyControl
     ? HexAlphaColorPicker
@@ -121,9 +115,10 @@ const ColorPicker = ({
     <Dropdown
       className="neeto-ui-colorpicker__dropdown"
       closeOnSelect={false}
-      customTarget={<Target size={size} />}
+      customTarget={<Target {...{ size }} />}
       label={colorValue}
       position="bottom-start"
+      {...dropdownProps}
     >
       <div className="neeto-ui-colorpicker__popover">
         {showPicker && (
@@ -151,9 +146,9 @@ const ColorPicker = ({
                   data-cy="colorpicker-editable-input"
                 >
                   <HexColorInput
+                    {...{ onBlur }}
                     alpha={!!showTransparencyControl}
                     color={colorValue}
-                    onBlur={onBlur}
                     onChange={onColorInputChange}
                   />
                 </div>


### PR DESCRIPTION
- Fixes #2120 

**Description**

- Added: Support for overriding the dropdown props in the _ColorPicker_ component so that it can be further customised.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~~I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
