### PR TITLE
Navigating through pages in table will not reset selected rows by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ checkout the `Publish to npm` workflow in GitHub Actions to get a live update.
 Please note that before publishing the package, you need to verify the
 functionality in some of the neeto web-apps locally using `yalc` package
 manager. The usage of yalc is explained in this video:
-https://youtu.be/QBiYGP0Rhe0
+https://youtu.be/F4zZFnrNTq8
 
 ## Documentation
 

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -146,6 +146,7 @@ const Table = ({
   const rowSelectionProps = rowSelection
     ? {
         type: "checkbox",
+        preserveSelectedRowKeys: true,
         ...rowSelection,
         onChange: (selectedRowKeys, selectedRows) =>
           onRowSelect && onRowSelect(selectedRowKeys, selectedRows),


### PR DESCRIPTION
- Fixes #2123

**Description**
While changing the page for multi-paged table, the selected rows will not be deselected.

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
