### PR TITLE
Added functionality for selecting all rows in multi-page table

### DIFF
--- a/src/components/Table/components/SelectAllRowsCallout.jsx
+++ b/src/components/Table/components/SelectAllRowsCallout.jsx
@@ -10,10 +10,15 @@ const SelectAllRowsCallout = ({
   selectAllRowButtonLabel,
   selectAllRowMessage,
 }) => (
-  <Callout className="my-2" {...calloutProps}>
+  <Callout
+    className="my-2"
+    {...calloutProps}
+    data-testid="select-all-rows-callout"
+  >
     <div className="flex space-x-3">
       <Typography style="body2">{selectAllRowMessage}</Typography>
       <Button
+        data-testid="select-all-rows-button"
         label={selectAllRowButtonLabel}
         style="link"
         onClick={onBulkSelectAllRows}

--- a/src/components/Table/components/SelectAllRowsCallout.jsx
+++ b/src/components/Table/components/SelectAllRowsCallout.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import Button from "../../Button";
+import Callout from "../../Callout";
+import Typography from "../../Typography";
+
+const SelectAllRowsCallout = ({
+  calloutProps,
+  onBulkSelectAllRows,
+  selectAllRowButtonLabel,
+  selectAllRowMessage,
+}) => (
+  <Callout className="my-2" {...calloutProps}>
+    <div className="flex space-x-3">
+      <Typography style="body2">{selectAllRowMessage}</Typography>
+      <Button
+        label={selectAllRowButtonLabel}
+        style="link"
+        onClick={onBulkSelectAllRows}
+      />
+    </div>
+  </Callout>
+);
+
+export default SelectAllRowsCallout;

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -18,13 +18,13 @@ import { useHistory } from "react-router-dom";
 import { useQueryParams, useTimeout } from "hooks";
 import { ANT_DESIGN_GLOBAL_TOKEN_OVERRIDES, buildUrl, noop } from "utils";
 
+import SelectAllRowsCallout from "./components/SelectAllRowsCallout";
 import { TABLE_SORT_ORDERS } from "./constants";
 import useColumns from "./hooks/useColumns";
 import useTableSort from "./hooks/useTableSort";
 import { getHeaderCell, isIncludedIn } from "./utils";
 
 import Button from "../Button";
-import Callout from "../Callout";
 import Typography from "../Typography";
 
 const TABLE_PAGINATION_HEIGHT = 64;
@@ -61,6 +61,7 @@ const Table = ({
   onColumnDelete,
   onChange,
   onMoreActionClick,
+  bulkSelectAllRowsProps,
   ...otherProps
 }) => {
   const [containerHeight, setContainerHeight] = useState(null);
@@ -72,6 +73,9 @@ const Table = ({
     sortedInfo,
     setSortedInfo,
   } = useTableSort();
+
+  const { setBulkSelectedAllRows: setSelectedAllRows } =
+    bulkSelectAllRowsProps ?? {};
 
   const isDefaultPageChangeHandler = handlePageChange === noop;
 
@@ -189,6 +193,7 @@ const Table = ({
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {
     selectedRowKeys.length !== defaultPageSize && setBulkSelectedAllRows(false);
+    setSelectedAllRows && setSelectedAllRows(false);
     onRowSelect && onRowSelect(selectedRowKeys, selectedRows);
   };
 
@@ -335,19 +340,14 @@ const Table = ({
         },
       }}
     >
-      {showBulkSelectionCallout && (
-        <Callout className="my-2">
-          <div className="flex space-x-3">
-            <Typography style="body2">
-              All {selectedRowKeys.length} submissions on this page are selected
-            </Typography>
-            <Button
-              label={`Select all ${totalCount || rowData.length} submissions`}
-              style="link"
-              onClick={() => setBulkSelectedAllRows(true)}
-            />
-          </div>
-        </Callout>
+      {bulkSelectAllRowsProps && showBulkSelectionCallout && (
+        <SelectAllRowsCallout
+          {...bulkSelectAllRowsProps}
+          onBulkSelectAllRows={() => {
+            setBulkSelectedAllRows(true);
+            setSelectedAllRows && setSelectedAllRows(true);
+          }}
+        />
       )}
       <AntTable
         {...{ bordered, loading, locale, rowKey }}
@@ -512,6 +512,14 @@ Table.propTypes = {
    * Make sure to pass `id` in `rowData` for this to work.
    */
   rowSelection: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+  /**
+   * Props for adding `Select all rows` option for multi-page table.
+   */
+  bulkSelectAllRowsProps: PropTypes.shape({
+    selectAllRowMessage: PropTypes.string.isRequired,
+    selectAllRowButtonLabel: PropTypes.string.isRequired,
+    setBulkSelectedAllRows: PropTypes.func.isRequired,
+  }),
 };
 
 export default Table;

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -74,7 +74,7 @@ const Table = ({
     setSortedInfo,
   } = useTableSort();
 
-  const { setBulkSelectedAllRows: setSelectedAllRows } =
+  const { setBulkSelectedAllRows: handleSetBulkSelectedAllRows } =
     bulkSelectAllRowsProps ?? {};
 
   const isDefaultPageChangeHandler = handlePageChange === noop;
@@ -170,7 +170,7 @@ const Table = ({
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {
     selectedRowKeys.length !== defaultPageSize && setBulkSelectedAllRows(false);
-    setSelectedAllRows && setSelectedAllRows(false);
+    handleSetBulkSelectedAllRows && handleSetBulkSelectedAllRows(false);
     onRowSelect && onRowSelect(selectedRowKeys, selectedRows);
   };
 
@@ -322,7 +322,7 @@ const Table = ({
           {...bulkSelectAllRowsProps}
           onBulkSelectAllRows={() => {
             setBulkSelectedAllRows(true);
-            setSelectedAllRows && setSelectedAllRows(true);
+            handleSetBulkSelectedAllRows && handleSetBulkSelectedAllRows(true);
           }}
         />
       )}

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -157,38 +157,15 @@ const Table = ({
   }));
 
   const selectedRowKeys = bulkSelectedAllRows
-    ? pluck(
-        rowKey,
-        rowData.slice(
-          (currentPageNumber - 1) * defaultPageSize,
-          currentPageNumber * defaultPageSize
-        )
-      )
+    ? pluck(rowKey, rowData)
     : initialSelectedRowKeys;
 
   const showBulkSelectionCallout = useMemo(
     () =>
-      isIncludedIn(
-        selectedRowKeys,
-        pluck(
-          rowKey,
-          rowData.slice(
-            (currentPageNumber - 1) * defaultPageSize,
-            currentPageNumber * defaultPageSize
-          )
-        )
-      ) &&
-      selectedRowKeys.length !== (totalCount || rowData.length) &&
+      isIncludedIn(selectedRowKeys, pluck(rowKey, rowData)) &&
+      selectedRowKeys.length !== totalCount &&
       !bulkSelectedAllRows,
-    [
-      selectedRowKeys,
-      rowKey,
-      rowData,
-      currentPageNumber,
-      defaultPageSize,
-      totalCount,
-      bulkSelectedAllRows,
-    ]
+    [selectedRowKeys, rowKey, rowData, totalCount, bulkSelectedAllRows]
   );
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -152,7 +152,6 @@ const Table = ({
     }),
   }));
 
-  //TODO: Check if there's better way to accomplish this
   const selectedRowKeys = bulkSelectedAllRows
     ? pluck(
         rowKey,
@@ -175,12 +174,13 @@ const Table = ({
           )
         )
       ) &&
-      selectedRowKeys.length !== totalCount &&
+      selectedRowKeys.length !== (totalCount || rowData.length) &&
       !bulkSelectedAllRows,
     [
       selectedRowKeys,
       rowKey,
       rowData,
+      currentPageNumber,
       defaultPageSize,
       totalCount,
       bulkSelectedAllRows,
@@ -188,7 +188,6 @@ const Table = ({
   );
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {
-    //TODO: Match the keys with the selected rows
     selectedRowKeys.length !== defaultPageSize && setBulkSelectedAllRows(false);
     onRowSelect && onRowSelect(selectedRowKeys, selectedRows);
   };
@@ -343,7 +342,7 @@ const Table = ({
               All {selectedRowKeys.length} submissions on this page are selected
             </Typography>
             <Button
-              label={`Select all ${totalCount} submissions`}
+              label={`Select all ${totalCount || rowData.length} submissions`}
               style="link"
               onClick={() => setBulkSelectedAllRows(true)}
             />

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -1,3 +1,5 @@
+import { __, all, includes } from "ramda";
+
 import {
   CellContent,
   HeaderCell,
@@ -14,3 +16,6 @@ export const getHeaderCell = ({ enableColumnResize, enableColumnReorder }) => {
 
   return { cell: CellContent };
 };
+
+export const isIncludedIn = (array1, array2) =>
+  all(includes(__, array1), array2);

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -354,7 +354,11 @@ const TableWithBulkSelectAllRowsOption = ({
         columnData={getColumns()}
         currentPageNumber={pageNumber}
         handlePageChange={page => setPageNumber(page)}
-        rowData={TABLE_DATA}
+        // Mimicking data-source coming from api call and at a time only defaultPageSize rows are present
+        rowData={TABLE_DATA.slice(
+          (pageNumber - 1) * defaultPageSize,
+          pageNumber * defaultPageSize
+        )}
         {...{ ...args, defaultPageSize, selectedRowKeys }}
         rowSelection
         bulkSelectAllRowsProps={{
@@ -375,6 +379,7 @@ TableWithBulkSelectAllRowsOption.args = {
   defaultPageSize: 15,
   selectedRowKeys: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   bulkSelectAllRowsProps: {},
+  totalCount: TABLE_DATA.length,
 };
 
 const TableWithSorting = args => (

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -334,6 +334,49 @@ TableWithSelectedRowKeys.parameters = {
   },
 };
 
+const TableWithBulkSelectAllRowsOption = ({
+  selectedRowKeys: selectedRowKeysProp,
+  defaultPageSize,
+  ...args
+}) => {
+  const [pageNumber, setPageNumber] = useState(1);
+  const [selectedRowKeys, setSelectedRowKeys] = useState(selectedRowKeysProp);
+  const [bulkSelectedAllRows, setBulkSelectedAllRows] = useState(false);
+
+  return (
+    <>
+      <Typography className="mb-2" style="h4">
+        Selected{" "}
+        {bulkSelectedAllRows ? TABLE_DATA.length : selectedRowKeys.length} of{" "}
+        {TABLE_DATA.length} users
+      </Typography>
+      <Table
+        columnData={getColumns()}
+        currentPageNumber={pageNumber}
+        handlePageChange={page => setPageNumber(page)}
+        rowData={TABLE_DATA}
+        {...{ ...args, defaultPageSize, selectedRowKeys }}
+        rowSelection
+        bulkSelectAllRowsProps={{
+          setBulkSelectedAllRows,
+          selectAllRowMessage: `All ${defaultPageSize} users on this page are selected`,
+          selectAllRowButtonLabel: `Select all ${TABLE_DATA.length} users`,
+        }}
+        onRowSelect={selectedRowKeys => setSelectedRowKeys(selectedRowKeys)}
+      />
+    </>
+  );
+};
+
+TableWithBulkSelectAllRowsOption.storyName =
+  "Table with bulk select all rows option";
+
+TableWithBulkSelectAllRowsOption.args = {
+  defaultPageSize: 15,
+  selectedRowKeys: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+  bulkSelectAllRowsProps: {},
+};
+
 const TableWithSorting = args => (
   <Table
     columnData={getColumns()}
@@ -587,6 +630,7 @@ export {
   TableWithTooltipsOnHeader,
   TableWithFixedRightColumn,
   TableWithSelectedRowKeys,
+  TableWithBulkSelectAllRowsOption,
   TableWithSorting,
   TableWithFixedHeight,
   TableWithoutCheckbox,

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -343,6 +343,11 @@ const TableWithBulkSelectAllRowsOption = ({
   const [selectedRowKeys, setSelectedRowKeys] = useState(selectedRowKeysProp);
   const [bulkSelectedAllRows, setBulkSelectedAllRows] = useState(false);
 
+  const rowData = TABLE_DATA.slice(
+    (pageNumber - 1) * defaultPageSize,
+    pageNumber * defaultPageSize
+  );
+
   return (
     <>
       <Typography className="mb-2" style="h4">
@@ -353,17 +358,13 @@ const TableWithBulkSelectAllRowsOption = ({
       <Table
         columnData={getColumns()}
         currentPageNumber={pageNumber}
-        handlePageChange={page => setPageNumber(page)}
         // Mimicking data-source coming from api call and at a time only defaultPageSize rows are present
-        rowData={TABLE_DATA.slice(
-          (pageNumber - 1) * defaultPageSize,
-          pageNumber * defaultPageSize
-        )}
-        {...{ ...args, defaultPageSize, selectedRowKeys }}
+        handlePageChange={page => setPageNumber(page)}
+        {...{ ...args, defaultPageSize, rowData, selectedRowKeys }}
         rowSelection
         bulkSelectAllRowsProps={{
           setBulkSelectedAllRows,
-          selectAllRowMessage: `All ${defaultPageSize} users on this page are selected`,
+          selectAllRowMessage: `All ${rowData.length} users on this page are selected`,
           selectAllRowButtonLabel: `Select all ${TABLE_DATA.length} users`,
         }}
         onRowSelect={selectedRowKeys => setSelectedRowKeys(selectedRowKeys)}


### PR DESCRIPTION
- Fixes #2126

**Description**
Added: `bulkSelectAllRowsProps` for tables to allow selecting all rows for multipage tables

**Checklist**

- [x] I have made corresponding changes to the documentation.
~- [] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
