### PR TITLE
Fix alignment issue with Label

### DIFF
--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -24,22 +24,21 @@ const Label = ({
   const HelpIcon = icon || Help;
 
   return (
-    <label
-      className={classnames(
-        "neeto-ui-label neeto-ui-flex neeto-ui-items-center",
-        className
-      )}
-      {...otherProps}
-    >
+    <label className={classnames("neeto-ui-label", className)} {...otherProps}>
       {children}
-      {required && <span aria-hidden>*</span>}
+      {required && (
+        <span aria-hidden className="neeto-ui-inline-flex">
+          *
+        </span>
+      )}
       {helpIconProps && (
         <Tooltip {...tooltipProps} disabled={!tooltipProps}>
           <span
             {...{ onClick }}
-            className={classnames("neeto-ui-label__help-icon-wrap", {
-              [helpIconClassName]: helpIconClassName,
-            })}
+            className={classnames(
+              "neeto-ui-label__help-icon-wrap neeto-ui-inline-flex",
+              { [helpIconClassName]: helpIconClassName }
+            )}
           >
             <HelpIcon size={16} {...otherHelpIconProps} />
           </span>

--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -102,6 +102,7 @@
 
   .neeto-ui-label {
     margin-bottom: var(--neeto-ui-input-label-margin);
+    display: block;
   }
 
   .neeto-ui-input {


### PR DESCRIPTION
- Fixes #2110

@nitinprojects _a 

After
<img width="614" alt="Screenshot 2024-03-25 at 5 35 09 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/faa88438-8bca-464c-a09e-f03c3f59aeff">

Before
<img width="1215" alt="Screenshot 2024-03-06 at 12 35 41 AM" src="https://github.com/bigbinary/neeto-ui/assets/48003440/7e9843ee-bdcd-4414-85da-86e519ea18c2">

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
