### PR TITLE
Added `isSubmitting` prop for `ActionBlock` component

### DIFF
--- a/formik.d.ts
+++ b/formik.d.ts
@@ -19,6 +19,7 @@ export interface ActionBlockProps {
   className?: string;
   submitButtonProps?: ButtonProps;
   cancelButtonProps?: ButtonProps;
+  isSubmitting?: boolean;
 }
 export interface BlockNavigationProps {
   isDirty?: boolean;

--- a/src/components/formik/ActionBlock.jsx
+++ b/src/components/formik/ActionBlock.jsx
@@ -3,22 +3,33 @@ import React from "react";
 import classnames from "classnames";
 import { useFormikContext } from "formik";
 import PropTypes from "prop-types";
-import { equals } from "ramda";
 
 import Button from "components/Button";
 
 import SubmitButton from "./Button";
 
-const ActionBlock = ({ className, submitButtonProps, cancelButtonProps }) => {
-  const { handleReset, isSubmitting, values, initialValues } =
-    useFormikContext();
+const ActionBlock = ({
+  className,
+  submitButtonProps,
+  cancelButtonProps,
+  isSubmitting: isFormSubmitting,
+}) => {
+  const {
+    handleReset,
+    isSubmitting: isFormikSubmitting,
+    dirty,
+  } = useFormikContext();
+
+  const isSubmitting = isFormSubmitting ?? isFormikSubmitting;
 
   return (
     <div className={classnames(["neeto-ui-action-block__wrapper", className])}>
       <SubmitButton
         data-cy="save-changes-button"
         data-test-id="save-changes-button"
+        disabled={isSubmitting || !dirty}
         label="Save changes"
+        loading={isSubmitting}
         style="primary"
         type="submit"
         {...submitButtonProps}
@@ -26,7 +37,7 @@ const ActionBlock = ({ className, submitButtonProps, cancelButtonProps }) => {
       <Button
         data-cy="cancel-button"
         data-test-id="cancel-button"
-        disabled={isSubmitting || equals(values, initialValues)}
+        disabled={isSubmitting}
         label="Cancel"
         style="text"
         onClick={handleReset}
@@ -50,6 +61,10 @@ ActionBlock.propTypes = {
    *  To provide props for cancel button.
    */
   cancelButtonProps: PropTypes.object,
+  /**
+   *  Optional prop to specify the state of form submission, typically used to provide React Query mutation loading state. If not provided, Formik's `isSubmitting` prop is used.
+   */
+  isSubmitting: PropTypes.bool,
 };
 
 export default ActionBlock;

--- a/tests/formik/ActionBlock.test.jsx
+++ b/tests/formik/ActionBlock.test.jsx
@@ -24,10 +24,7 @@ const TestActionBlock = ({
       }}
     >
       <Input label="Input label" name="input" />
-      <ActionBlock
-        cancelButtonProps={cancelButtonProps}
-        submitButtonProps={submitButtonProps}
-      />
+      <ActionBlock {...{ cancelButtonProps, submitButtonProps }} />
     </Form>
   );
 };
@@ -80,16 +77,14 @@ describe("formik/ActionBlock", () => {
 
   it("should submit with correct values", async () => {
     const onSubmit = jest.fn();
-    render(<TestActionBlock onSubmit={onSubmit} />);
+    render(<TestActionBlock {...{ onSubmit }} />);
 
     const submitButton = screen.getByRole("button", { name: /Save changes/i });
     const input = screen.getByRole("textbox");
     await userEvent.type(input, "test");
     await userEvent.click(submitButton);
     await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith({
-        input: "test",
-      })
+      expect(onSubmit).toHaveBeenCalledWith({ input: "test" })
     );
   });
 
@@ -103,17 +98,17 @@ describe("formik/ActionBlock", () => {
     await waitFor(() => expect(input).toHaveValue(""));
   });
 
-  it("Cancel button should be disabled if form value is same", async () => {
+  it("Cancel button should not be disabled if form value is same", async () => {
     const onSubmit = jest.fn();
-    render(<TestActionBlock input="Oliver" onSubmit={onSubmit} />);
+    render(<TestActionBlock {...{ onSubmit }} input="Oliver" />);
 
     const cancelButton = screen.getByRole("button", { name: /Cancel/i });
-    expect(cancelButton).toBeDisabled();
+    expect(cancelButton).not.toBeDisabled();
     const input = screen.getByRole("textbox");
     await userEvent.type(input, "test");
     await waitFor(() => expect(cancelButton).not.toBeDisabled());
     await userEvent.type(input, repeat("{backspace}", "test".length).join(""));
-    await waitFor(() => expect(cancelButton).toBeDisabled());
+    await waitFor(() => expect(cancelButton).not.toBeDisabled());
     await userEvent.click(cancelButton);
     await waitFor(() => expect(onSubmit).not.toBeCalled());
   });
@@ -126,7 +121,7 @@ describe("formik/ActionBlock", () => {
 
     const cancelButton = screen.getByRole("button", { name: /Cancel/i });
     const submitButton = screen.getByRole("button", { name: /Save changes/i });
-    expect(cancelButton).toBeDisabled();
+    expect(cancelButton).not.toBeDisabled();
     const input = screen.getByRole("textbox");
     await userEvent.type(input, "test");
     await waitFor(() => expect(cancelButton).not.toBeDisabled());


### PR DESCRIPTION
- Fixes #2137 

**Description**
- Added: `isSubmitting` prop for _ActionBlock_

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
