### PR TITLE
Added styles for ActionBlock component

### DIFF
--- a/src/components/formik/ActionBlock.jsx
+++ b/src/components/formik/ActionBlock.jsx
@@ -23,7 +23,7 @@ const ActionBlock = ({
   const isSubmitting = isFormSubmitting ?? isFormikSubmitting;
 
   return (
-    <div className={classnames(["flex items-center gap-x-2", className])}>
+    <div className={classnames(["neeto-ui-action-block__wrapper", className])}>
       <SubmitButton
         data-cy="save-changes-button"
         data-test-id="save-changes-button"

--- a/src/components/formik/ActionBlock.jsx
+++ b/src/components/formik/ActionBlock.jsx
@@ -23,7 +23,7 @@ const ActionBlock = ({
   const isSubmitting = isFormSubmitting ?? isFormikSubmitting;
 
   return (
-    <div className={classnames(["neeto-ui-action-block__wrapper", className])}>
+    <div className={classnames(["flex items-center gap-x-2", className])}>
       <SubmitButton
         data-cy="save-changes-button"
         data-test-id="save-changes-button"

--- a/src/styles/components/_action-block.scss
+++ b/src/styles/components/_action-block.scss
@@ -1,5 +1,5 @@
 .neeto-ui-action-block__wrapper {
   display: flex;
   align-items: center;
-  column-gap: 0.5rem;
+  gap: 0.5rem;
 }

--- a/src/styles/components/_action-block.scss
+++ b/src/styles/components/_action-block.scss
@@ -1,0 +1,5 @@
+.neeto-ui-action-block__wrapper {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -47,6 +47,7 @@
 @import "./components/slider";
 @import "./components/time-picker-input";
 @import "./components/stepper";
+@import "./components/action-block";
 
 //Layouts
 @import "./layout/common";


### PR DESCRIPTION
- Fixes #2142 

**Description**
Added: Styles for _ActionBlock_ wrapper

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
