### PR TITLE
DatePicker: fix unable to switch to different month or year 

### DIFF
--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -67,6 +67,7 @@ const DatePicker = forwardRef(
     ref
   ) => {
     const [mode, setMode] = useState(inputMode);
+    const [pickerValue, setPickerValue] = useState();
     const id = useId(otherProps.id);
     const datePickerRef = useSyncedRef(ref);
 
@@ -179,8 +180,12 @@ const DatePicker = forwardRef(
               ...otherProps,
               ...(type === "date" && {
                 mode,
+                pickerValue,
                 renderExtraFooter,
-                onPanelChange: (_, mode) => setMode(mode),
+                onPanelChange: (pickerValue, mode) => {
+                  setPickerValue(pickerValue);
+                  setMode(mode);
+                },
               }),
             }}
             nextIcon={<IconOverride icon={Right} />}


### PR DESCRIPTION
- Fixes #2144 

**Description**
Fixed: DatePicker unable to switch to different month or year.

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
