### PR TITLE
Added Button tertiary variant

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ export interface ButtonProps {
   loading?: boolean;
   to?: string;
   type?: "button" | "reset" | "submit";
-  style?: "primary" | "secondary" | "danger" | "danger-text" | "text" | "link";
+  style?: "primary" | "secondary" | "tertiary" | "danger" | "danger-text" | "text" | "link";
   fullWidth?: boolean;
   className?: string;
   disabled?: boolean;
@@ -251,6 +251,7 @@ export interface DropdownProps {
   buttonStyle?:
     | "primary"
     | "secondary"
+    | "tertiary"
     | "text"
     | "danger"
     | "danger-text"

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -12,6 +12,7 @@ import Tooltip from "./Tooltip";
 const BUTTON_STYLES = {
   primary: "primary",
   secondary: "secondary",
+  tertiary: "tertiary",
   danger: "danger",
   danger_text: "danger-text",
   text: "text",
@@ -80,6 +81,7 @@ const Button = React.forwardRef(
           className={classnames("neeto-ui-btn", [className], {
             "neeto-ui-btn--style-primary": style === BUTTON_STYLES.primary,
             "neeto-ui-btn--style-secondary": style === BUTTON_STYLES.secondary,
+            "neeto-ui-btn--style-tertiary": style === BUTTON_STYLES.tertiary,
             "neeto-ui-btn--style-danger": style === BUTTON_STYLES.danger,
             "neeto-ui-btn--style-danger-text":
               style === BUTTON_STYLES.danger_text,

--- a/src/components/Dropdown/index.jsx
+++ b/src/components/Dropdown/index.jsx
@@ -16,6 +16,7 @@ import MenuItem from "./MenuItem";
 const BTN_STYLES = {
   primary: "primary",
   secondary: "secondary",
+  tertiary: "tertiary",
   danger: "danger",
   danger_text: "danger-text",
   text: "text",

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -169,6 +169,17 @@
     --neeto-ui-btn-focus-visible-color: rgb(var(--neeto-ui-black));
   }
 
+  &-tertiary {
+    --neeto-ui-btn-color: rgb(var(--neeto-ui-black));
+    --neeto-ui-btn-bg-color: rgb(var(--neeto-ui-white));
+    --neeto-ui-btn-hover-color: rgb(var(--neeto-ui-black));
+    --neeto-ui-btn-hover-bg-color: rgb(var(--neeto-ui-gray-100));
+    --neeto-ui-btn-focus-color: rgb(var(--neeto-ui-black));
+    --neeto-ui-btn-box-shadow: inset 0 0 0 1px rgba(var(--neeto-ui-gray-400));
+    --neeto-ui-btn-focus-box-shadow: 0 0 0 3px rgba(var(--neeto-ui-gray-800), 15%);
+    --neeto-ui-btn-focus-visible-color: rgb(var(--neeto-ui-black));
+  }
+
   &-text {
     --neeto-ui-btn-color: rgb(var(--neeto-ui-gray-800));
     --neeto-ui-btn-hover-color: rgb(var(--neeto-ui-gray-800));

--- a/stories/Components/Button.stories.jsx
+++ b/stories/Components/Button.stories.jsx
@@ -58,6 +58,7 @@ const Styles = args => (
       <div className="flex flex-wrap items-center gap-4">
         <Button {...args} label="Primary" style="primary" />
         <Button {...args} label="Secondary" style="secondary" />
+        <Button {...args} label="Tertiary" style="tertiary" />
         <Button {...args} label="Text" style="text" />
         <Button {...args} label="Link" style="link" />
       </div>


### PR DESCRIPTION
- Fixes #2125 

**Description**

- Added: tertiary variant Button.

<img width="104" alt="Screenshot 2024-03-27 at 5 44 48 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/e02cb5cc-3633-444f-b0ce-71004dda55bb">


**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
