### PR TITLE
Fixed not able to clear selections when bulk selected all row is true

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -174,11 +174,11 @@ const Table = ({
   );
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {
-    selectedRowKeys.length !== defaultPageSize && setBulkSelectedAllRows(false);
-    selectedRowKeys.length !== defaultPageSize &&
-      handleSetBulkSelectedAllRows &&
-      handleSetBulkSelectedAllRows(false);
-    onRowSelect && onRowSelect(selectedRowKeys, selectedRows);
+    if (selectedRowKeys.length !== defaultPageSize) {
+      setBulkSelectedAllRows(false);
+      handleSetBulkSelectedAllRows?.(false);
+    }
+    onRowSelect?.(selectedRowKeys, selectedRows);
   };
 
   const rowSelectionProps = rowSelection
@@ -252,7 +252,7 @@ const Table = ({
     if (isNotEmpty(initialSelectedRowKeys)) return;
 
     setBulkSelectedAllRows(false);
-    handleSetBulkSelectedAllRows && handleSetBulkSelectedAllRows(false);
+    handleSetBulkSelectedAllRows?.(false);
   }, [handleSetBulkSelectedAllRows, initialSelectedRowKeys]);
 
   useEffect(() => {
@@ -336,7 +336,7 @@ const Table = ({
           {...bulkSelectAllRowsProps}
           onBulkSelectAllRows={() => {
             setBulkSelectedAllRows(true);
-            handleSetBulkSelectedAllRows && handleSetBulkSelectedAllRows(true);
+            handleSetBulkSelectedAllRows?.(true);
           }}
         />
       )}

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -8,7 +8,12 @@ import React, {
 
 import { Table as AntTable, ConfigProvider } from "antd";
 import classnames from "classnames";
-import { dynamicArray, modifyBy, snakeToCamelCase } from "neetocist";
+import {
+  dynamicArray,
+  isNotEmpty,
+  modifyBy,
+  snakeToCamelCase,
+} from "neetocist";
 import { Left, Right, MenuHorizontal } from "neetoicons";
 import PropTypes from "prop-types";
 import { assoc, isEmpty, mergeLeft, pluck } from "ramda";
@@ -170,7 +175,9 @@ const Table = ({
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {
     selectedRowKeys.length !== defaultPageSize && setBulkSelectedAllRows(false);
-    handleSetBulkSelectedAllRows && handleSetBulkSelectedAllRows(false);
+    selectedRowKeys.length !== defaultPageSize &&
+      handleSetBulkSelectedAllRows &&
+      handleSetBulkSelectedAllRows(false);
     onRowSelect && onRowSelect(selectedRowKeys, selectedRows);
   };
 
@@ -240,6 +247,13 @@ const Table = ({
 
     return originalElement;
   };
+
+  useEffect(() => {
+    if (isNotEmpty(initialSelectedRowKeys)) return;
+
+    setBulkSelectedAllRows(false);
+    handleSetBulkSelectedAllRows && handleSetBulkSelectedAllRows(false);
+  }, [handleSetBulkSelectedAllRows, initialSelectedRowKeys]);
 
   useEffect(() => {
     const shouldNavigateToLastPage =


### PR DESCRIPTION
- Fixes #2150 

**Description**
Fixed: Clearing all rows by directly changing `selectedRowKeys` not working when `bulkSelectedAllRowsProps` is passed.

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
