### PR TITLE
TimePickerInput: Remove unnecessary onBlur trigger on amPm change.

### DIFF
--- a/src/components/TimePickerInput/index.jsx
+++ b/src/components/TimePickerInput/index.jsx
@@ -72,7 +72,6 @@ const TimePickerInput = forwardRef(
     };
 
     const onBlurHandle = () => {
-      const value = valueRef.current;
       if (isValid(minTime, maxTime, value)) {
         onBlur(toDayJs(value), value);
       } else {
@@ -85,9 +84,18 @@ const TimePickerInput = forwardRef(
       return true;
     };
 
+    const onAmPmChange = () => {
+      const value = valueRef.current;
+      if (!isValid(minTime, maxTime, value)) {
+        const validValue = getValid(minTime, maxTime, value);
+        setValue(validValue);
+        onChange(toDayJs(validValue), validValue);
+      }
+    };
+
     // If you just make amPm select change, onBlurHandle is not triggering. A work around
     useEffect(() => {
-      const amPmChange = () => setTimeout(onBlurHandle);
+      const amPmChange = () => setTimeout(onAmPmChange);
       const selectElements = document
         .getElementById(id)
         ?.querySelectorAll("[name='amPm']");


### PR DESCRIPTION
- Fixes #2158 

**Description**
Fixed: Remove unnecessary onBlur trigger on amPm change in TimePickerInput

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
-~ [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
