### PR TITLE
Added border to Popover arrow

### DIFF
--- a/src/styles/components/_tooltip.scss
+++ b/src/styles/components/_tooltip.scss
@@ -1,4 +1,6 @@
-:root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
+:root,
+.neeto-ui-theme--light,
+.neeto-ui-theme--dark {
   --neeto-ui-tooltip-max-width: calc(100vw - 10px);
   --neeto-ui-tooltip-font-size: var(--neeto-ui-text-xs);
   --neeto-ui-tooltip-bg-color: rgb(var(--neeto-ui-gray-800));
@@ -12,6 +14,8 @@
 
   // Arrow
   --neeto-ui-tooltip-arrow-color: rgb(var(--neeto-ui-gray-800));
+  --neeto-ui-tooltip-arrow-size: 6px;
+  --neeto-ui-tooltip-arrow-offset: 12px;
 
   // Light theme
   --neeto-ui-tooltip-light-theme-bg-color: rgb(var(--neeto-ui-white));
@@ -200,7 +204,8 @@
   border-top-color: var(--neeto-ui-tooltip-light-theme-arrow-border-color);
 }
 
-.tippy-box[data-theme~="light"][data-placement^="bottom"] > .tippy-arrow:before {
+.tippy-box[data-theme~="light"][data-placement^="bottom"]
+  > .tippy-arrow:before {
   border-bottom-color: var(--neeto-ui-tooltip-light-theme-arrow-border-color);
 }
 
@@ -224,4 +229,62 @@
   --neeto-ui-tooltip-bg-color: rgb(var(--neeto-ui-primary-800));
   --neeto-ui-tooltip-arrow-color: rgb(var(--neeto-ui-primary-800));
   --neeto-ui-tooltip-light-theme-color: rgb(var(--neeto-ui-primary-800));
+}
+
+// Adding border to popover
+
+.tippy-box[data-theme~="light"] {
+  .tippy-arrow {
+    transform-style: preserve-3d;
+    width: 0;
+    height: 0;
+    border: var(--neeto-ui-tooltip-arrow-size) solid transparent;
+    color: rgb(var(--neeto-ui-white));
+
+    &::before {
+      transform: translateZ(-1px);
+      border: var(--neeto-ui-tooltip-arrow-size) solid transparent;
+    }
+  }
+  &[data-placement^="right"] .tippy-arrow {
+    border-right-color: rgb(var(--neeto-ui-white));
+    left: calc(-1 * var(--neeto-ui-tooltip-arrow-offset));
+
+    &::before {
+      left: calc(-1 * (var(--neeto-ui-tooltip-arrow-size) + 1px));
+      top: calc(-1 * var(--neeto-ui-tooltip-arrow-size));
+      border-right-color: var(--neeto-ui-popover-light-theme-border-color);
+    }
+  }
+  &[data-placement^="left"] .tippy-arrow {
+    border-left-color: rgb(var(--neeto-ui-white));
+    right: calc(-1 * var(--neeto-ui-tooltip-arrow-offset));
+
+    &::before {
+      right: calc(-1 * (var(--neeto-ui-tooltip-arrow-size) + 1px));
+      top: calc(-1 * var(--neeto-ui-tooltip-arrow-size));
+      border-left-color: var(--neeto-ui-popover-light-theme-border-color);
+    }
+  }
+  &[data-placement^="bottom"] .tippy-arrow {
+    border-bottom-color: rgb(var(--neeto-ui-white));
+    top: calc(-1 * var(--neeto-ui-tooltip-arrow-offset));
+
+    &::before {
+      top: calc(-1 * (var(--neeto-ui-tooltip-arrow-size) + 1px));
+      left: calc(-1 * var(--neeto-ui-tooltip-arrow-size));
+      bottom: auto;
+      border-bottom-color: var(--neeto-ui-popover-light-theme-border-color);
+    }
+  }
+  &[data-placement^="top"] .tippy-arrow {
+    border-top-color: rgb(var(--neeto-ui-white));
+    bottom: calc(-1 * var(--neeto-ui-tooltip-arrow-offset));
+
+    &::before {
+      left: calc(-1 * var(--neeto-ui-tooltip-arrow-size));
+      top: calc(-1 * (var(--neeto-ui-tooltip-arrow-size) - 1px));
+      border-top-color: var(--neeto-ui-popover-light-theme-border-color);
+    }
+  }
 }

--- a/stories/Overlays/Popover.stories.jsx
+++ b/stories/Overlays/Popover.stories.jsx
@@ -29,7 +29,7 @@ const ShowPopover = args => {
         ref={popoverReferenceElement}
         style="secondary"
       />
-      <Popover reference={popoverReferenceElement} {...args} arrowType="sharp">
+      <Popover reference={popoverReferenceElement} {...args}>
         <Popover.Title>What is KB keywords?</Popover.Title>
         <Typography lineHeight="normal" style="body2">
           Keywords represent the key concepts of an article. These will be shown

--- a/stories/Overlays/Popover.stories.jsx
+++ b/stories/Overlays/Popover.stories.jsx
@@ -25,11 +25,17 @@ const ShowPopover = args => {
   return (
     <div className="space-y-8 p-10">
       <Button
+        className="m-80"
         label="Show Popover"
         ref={popoverReferenceElement}
         style="secondary"
       />
-      <Popover reference={popoverReferenceElement} {...args}>
+      <Popover
+        reference={popoverReferenceElement}
+        {...args}
+        arrowType="sharp"
+        trigger="click"
+      >
         <Popover.Title>What is KB keywords?</Popover.Title>
         <Typography lineHeight="normal" style="body2">
           Keywords represent the key concepts of an article. These will be shown

--- a/stories/Overlays/Popover.stories.jsx
+++ b/stories/Overlays/Popover.stories.jsx
@@ -25,17 +25,11 @@ const ShowPopover = args => {
   return (
     <div className="space-y-8 p-10">
       <Button
-        className="m-80"
         label="Show Popover"
         ref={popoverReferenceElement}
         style="secondary"
       />
-      <Popover
-        reference={popoverReferenceElement}
-        {...args}
-        arrowType="sharp"
-        trigger="click"
-      >
+      <Popover reference={popoverReferenceElement} {...args} arrowType="sharp">
         <Popover.Title>What is KB keywords?</Popover.Title>
         <Typography lineHeight="normal" style="body2">
           Keywords represent the key concepts of an article. These will be shown


### PR DESCRIPTION
- Fixes #2163 

**Description**

- Added: Customizable border to Popover arrow.

<img width="469" alt="Screenshot 2024-04-15 at 7 25 08 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/70358c5b-6376-476c-a366-6171f4461e0d">
<img width="567" alt="Screenshot 2024-04-15 at 7 24 56 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/2a179dd2-0dbe-4583-9e96-c12dddb3480b">
<img width="496" alt="Screenshot 2024-04-15 at 7 27 10 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/35a20f00-13f2-469a-b00f-5848a4c100e2">
<img width="479" alt="Screenshot 2024-04-15 at 7 25 54 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/1c1505de-be74-4253-8721-774e33737917">

Darkmode

<img width="527" alt="Screenshot 2024-04-15 at 7 40 37 PM" src="https://github.com/bigbinary/neeto-ui/assets/48869249/297a9cd4-e56c-4582-82a3-c104a254afc0">

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
