### PR TITLE
Return toastId when calling toastr

### DIFF
--- a/src/components/Toastr/index.jsx
+++ b/src/components/Toastr/index.jsx
@@ -73,6 +73,8 @@ const withUniqueCheck =
       customConfig = {},
     } = parseToastrConfig(toastrConfig);
 
+    let toastId = null;
+
     if (toastrList.add({ type, message, buttonLabel })) {
       const config = {
         ...TOAST_CONFIG,
@@ -80,20 +82,18 @@ const withUniqueCheck =
         onClose: () => toastrList.remove({ type, message, buttonLabel }),
         ...customConfig,
       };
-      toastFunc({ message, buttonLabel, onClick, config });
+
+      toastId = toastFunc({ message, buttonLabel, onClick, config });
     }
+
+    return toastId;
   };
 
 const showSuccessToastr = withUniqueCheck(
   "success",
   ({ message, buttonLabel, onClick, config }) =>
     toast.success(
-      <Toast
-        buttonLabel={buttonLabel}
-        message={message}
-        type="success"
-        onClick={onClick}
-      />,
+      <Toast {...{ buttonLabel, message, onClick }} type="success" />,
       config
     )
 );
@@ -102,12 +102,7 @@ const showInfoToastr = withUniqueCheck(
   "info",
   ({ message, buttonLabel, onClick, config }) =>
     toast.info(
-      <Toast
-        buttonLabel={buttonLabel}
-        message={message}
-        type="info"
-        onClick={onClick}
-      />,
+      <Toast {...{ buttonLabel, message, onClick }} type="info" />,
       config
     )
 );
@@ -116,12 +111,7 @@ const showWarningToastr = withUniqueCheck(
   "warning",
   ({ message, buttonLabel, onClick, config }) =>
     toast.warning(
-      <Toast
-        buttonLabel={buttonLabel}
-        message={message}
-        type="warning"
-        onClick={onClick}
-      />,
+      <Toast {...{ buttonLabel, message, onClick }} type="warning" />,
       config
     )
 );
@@ -194,12 +184,7 @@ const withParsedErrorMsg =
 const showErrorToastr = withParsedErrorMsg(
   withUniqueCheck("error", ({ message, buttonLabel, onClick, config }) =>
     toast.error(
-      <Toast
-        buttonLabel={buttonLabel}
-        message={message}
-        type="error"
-        onClick={onClick}
-      />,
+      <Toast {...{ buttonLabel, message, onClick }} type="error" />,
       config
     )
   )

--- a/tests/Toastr.test.jsx
+++ b/tests/Toastr.test.jsx
@@ -15,7 +15,7 @@ const renderToastrButton = (
   render(
     <>
       <ToastContainer />
-      <Button label={`${type} Toastr`} onClick={onClick} />
+      <Button {...{ onClick }} label={`${type} Toastr`} />
     </>
   );
 
@@ -40,7 +40,7 @@ const renderCustomConfigToastrButton = type => {
   render(
     <>
       <ToastContainer />
-      <Button label={`${type} Toastr`} onClick={onClick} />
+      <Button {...{ onClick }} label={`${type} Toastr`} />
     </>
   );
 
@@ -52,7 +52,7 @@ const renderCustomMessageToastrButton = (type, message) => {
   render(
     <>
       <ToastContainer />
-      <Button label={`${type} Toastr`} onClick={onClick} />
+      <Button {...{ onClick }} label={`${type} Toastr`} />
     </>
   );
 
@@ -213,7 +213,7 @@ describe("Toastr", () => {
     expect(errorToastr).toBeInTheDocument();
   });
 
-  it("should render Axios Error Toastr when response is undefined", async () => {
+  it("should render Axios Error Toastr when response is undefined", () => {
     const errorResponse = undefined;
     const expectedMessage = "Default Message";
     testToastrErrorMessages(errorResponse, expectedMessage);
@@ -373,5 +373,11 @@ describe("Toastr", () => {
     };
     const expectedMessage = "This is a Error toastr.";
     testToastrErrorMessages(errorResponse, expectedMessage);
+  });
+
+  it("should return toastId when toastr is called", () => {
+    const successMessage = "This is a success toastr.";
+    const toastId = Toastr.success(successMessage);
+    expect(toastId).toBeDefined();
   });
 });

--- a/types/Toastr.d.ts
+++ b/types/Toastr.d.ts
@@ -14,7 +14,7 @@ const Toastr: {
     message: React.ReactNode | Error,
     buttonLabel?: React.ReactNode,
     onClick?: () => void
-  ) => void;
+  ) => string | null;
   warning: ToastrFunction;
 };
 export default Toastr;


### PR DESCRIPTION
- Fixes #2178 

**Description**
Added: Logic to return `toastId` when calling __Toastr__.

**Checklist**

- ~[ ] I have made corresponding changes to the documentation.~
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- ~[ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
