### PR TITLE
Fixed toastId returning undefined when using Toastr.error

### DIFF
--- a/src/components/Toastr/index.jsx
+++ b/src/components/Toastr/index.jsx
@@ -172,7 +172,7 @@ const withParsedErrorMsg =
     const { buttonLabel, onClick, customConfig } =
       parseToastrConfig(toastrConfig);
 
-    toastrFunc(errorMessage, {
+    return toastrFunc(errorMessage, {
       buttonLabel,
       onClick,
       role: "alert",

--- a/tests/Toastr.test.jsx
+++ b/tests/Toastr.test.jsx
@@ -375,9 +375,10 @@ describe("Toastr", () => {
     testToastrErrorMessages(errorResponse, expectedMessage);
   });
 
-  it("should return toastId when toastr is called", () => {
-    const successMessage = "This is a success toastr.";
-    const toastId = Toastr.success(successMessage);
-    expect(toastId).toBeDefined();
+  ["Success", "Info", "Warning", "Error"].forEach(type => {
+    it(`should return toastId when ${type} Toastr is called`, () => {
+      const toastId = Toastr[type.toLowerCase()](`This is a ${type} toastr.`);
+      expect(toastId).toBeDefined();
+    });
   });
 });

--- a/types/Toastr.d.ts
+++ b/types/Toastr.d.ts
@@ -4,7 +4,7 @@ type ToastrFunction = (
   message: React.ReactNode,
   buttonLabel?: React.ReactNode,
   onClick?: () => void
-) => void;
+) => string | null;
 
 const Toastr: {
   show: ToastrFunction;


### PR DESCRIPTION
- Fixes #2180 

**Description**
- Fixed: `toastId` returning `undefined` when using __Toastr.error__

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
