### PR TITLE
Added ability to reset timestamp value to null using value prop

### DIFF
--- a/src/components/DateTimePicker/index.jsx
+++ b/src/components/DateTimePicker/index.jsx
@@ -5,7 +5,6 @@ import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { isNotPresent } from "neetocist";
 import PropTypes from "prop-types";
-import { isNil } from "ramda";
 
 import DatePicker from "components/DatePicker";
 import Label from "components/Label";
@@ -50,7 +49,7 @@ const DateTimePicker = ({
   useEffect(() => {
     const inputValue = value || defaultValue;
 
-    if (isNil(inputValue) || isNotPresent(inputValue)) {
+    if (isNotPresent(inputValue)) {
       setDate(null);
       setTime(null);
 

--- a/src/components/DateTimePicker/index.jsx
+++ b/src/components/DateTimePicker/index.jsx
@@ -3,8 +3,9 @@ import React, { useState, useEffect } from "react";
 import classnames from "classnames";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import { isPresent, isNotPresent } from "neetocist";
+import { isNotPresent } from "neetocist";
 import PropTypes from "prop-types";
+import { isNil } from "ramda";
 
 import DatePicker from "components/DatePicker";
 import Label from "components/Label";
@@ -39,22 +40,20 @@ const DateTimePicker = ({
   onTimeInputBlur = noop,
   onBlur = noop,
 }) => {
-  const [date, setDate] = useState();
-  const [time, setTime] = useState();
+  const [date, setDate] = useState(null);
+  const [time, setTime] = useState(null);
   const [changedField, setChangedField] = useState();
   const timeRef = React.useRef(null);
   const defaultId = useId(id);
   const errorId = `error_${defaultId}`;
 
   useEffect(() => {
-    const inputValue = value || defaultValue;
-    if (isPresent(inputValue) && dayjs(inputValue).isValid()) {
-      const dateTime = dayjs.isDayjs(inputValue)
-        ? inputValue
-        : dayjs(inputValue);
-      setDate(dateTime);
-      setTime(dateTime);
-    }
+    const inputValue = isNil(value || defaultValue) ? null : value;
+    const dateTime = dayjs.isDayjs(inputValue) ? inputValue : dayjs(inputValue);
+
+    const isValidDateTime = !isNil(dateTime) && dayjs(dateTime).isValid();
+    setDate(isValidDateTime ? dateTime : null);
+    setTime(isValidDateTime ? dateTime : null);
   }, [value, defaultValue]);
 
   useEffect(() => {

--- a/src/components/DateTimePicker/index.jsx
+++ b/src/components/DateTimePicker/index.jsx
@@ -48,12 +48,22 @@ const DateTimePicker = ({
   const errorId = `error_${defaultId}`;
 
   useEffect(() => {
-    const inputValue = isNil(value || defaultValue) ? null : value;
-    const dateTime = dayjs.isDayjs(inputValue) ? inputValue : dayjs(inputValue);
+    const inputValue = value || defaultValue;
 
-    const isValidDateTime = !isNil(dateTime) && dayjs(dateTime).isValid();
-    setDate(isValidDateTime ? dateTime : null);
-    setTime(isValidDateTime ? dateTime : null);
+    if (isNil(inputValue) || isNotPresent(inputValue)) {
+      setDate(null);
+      setTime(null);
+
+      return;
+    }
+
+    if (dayjs(inputValue).isValid()) {
+      const dateTime = dayjs.isDayjs(inputValue)
+        ? inputValue
+        : dayjs(inputValue);
+      setDate(dateTime);
+      setTime(dateTime);
+    }
   }, [value, defaultValue]);
 
   useEffect(() => {

--- a/src/components/TimePickerInput/index.jsx
+++ b/src/components/TimePickerInput/index.jsx
@@ -6,6 +6,7 @@ import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { isNotPresent } from "neetocist";
 import PropTypes from "prop-types";
+import { isNil } from "ramda";
 import TimePicker from "react-time-picker";
 
 import Label from "components/Label";
@@ -55,14 +56,17 @@ const TimePickerInput = forwardRef(
     const errorId = `error_${id}`;
 
     useEffect(() => {
-      if (isNotPresent(inputValue) && isNotPresent(defaultValue)) return;
+      const value = inputValue || defaultValue;
+      if (isNil(value) || isNotPresent(value)) {
+        setValue(null);
+
+        return;
+      }
 
       setValue(
-        (type === "range" ? getFormattedRange : getFormattedTime)(
-          inputValue || defaultValue
-        )
+        (type === "range" ? getFormattedRange : getFormattedTime)(value)
       );
-    }, [type, inputValue]);
+    }, [type, inputValue, defaultValue]);
 
     const handleChange = newValue => {
       setValue(newValue);

--- a/src/components/TimePickerInput/index.jsx
+++ b/src/components/TimePickerInput/index.jsx
@@ -6,7 +6,6 @@ import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { isNotPresent } from "neetocist";
 import PropTypes from "prop-types";
-import { isNil } from "ramda";
 import TimePicker from "react-time-picker";
 
 import Label from "components/Label";
@@ -57,7 +56,7 @@ const TimePickerInput = forwardRef(
 
     useEffect(() => {
       const value = inputValue || defaultValue;
-      if (isNil(value) || isNotPresent(value)) {
+      if (isNotPresent(value)) {
         setValue(null);
 
         return;


### PR DESCRIPTION
- Fixes #2175 

**Description**

- Added: ability to reset timestamp value to null using value prop

**Checklist**
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@josephmathew900 _a