### PR TITLE
Added onBlur handler for textarea to trim leading and trailing spaces

### DIFF
--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -31,6 +31,8 @@ const Textarea = forwardRef(
       maxLength,
       unlimitedChars = false,
       labelProps,
+      onBlur,
+      disableTrimOnBlur = false,
       ...otherProps
     },
     ref
@@ -58,6 +60,21 @@ const Textarea = forwardRef(
       const scrollHeight = textareaRef.current.scrollHeight;
       textareaRef.current.style.height = `${scrollHeight + 1}px`;
     }, [value]);
+
+    const handleTrimmedChangeOnBlur = e => {
+      if (disableTrimOnBlur || typeof value !== "string") return;
+
+      const trimmedValue = value.trim();
+      if (value === trimmedValue) return;
+
+      e.target.value = trimmedValue;
+      onChange(e);
+    };
+
+    const handleOnBlur = e => {
+      handleTrimmedChangeOnBlur(e);
+      onBlur?.(e);
+    };
 
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>
@@ -106,6 +123,7 @@ const Textarea = forwardRef(
               onChange,
               value,
             }}
+            onBlur={handleOnBlur}
           />
           {suffix && <div className="neeto-ui-input__suffix">{suffix}</div>}
         </div>

--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -217,6 +217,10 @@ Textarea.propTypes = {
    * To specify the content to be added at the beginning of the Textarea.
    */
   prefix: PropTypes.node,
+  /**
+   * To disable leading and trailing white spaces onBlur.
+   */
+  disableTrimOnBlur: PropTypes.bool,
 };
 
 export default Textarea;

--- a/tests/Textarea.test.jsx
+++ b/tests/Textarea.test.jsx
@@ -21,10 +21,18 @@ describe("Textarea", () => {
   it("should call onChange when textarea value changes", async () => {
     const onChange = jest.fn();
     const { getByLabelText } = render(
-      <Textarea id="text" label="Textarea" onChange={onChange} />
+      <Textarea {...{ onChange }} id="text" label="Textarea" />
     );
     await userEvent.type(getByLabelText("Textarea"), "Test");
     expect(onChange).toHaveBeenCalledTimes(4);
+  });
+
+  it("should properly handle disableTrimOnBlur", async () => {
+    const { getByLabelText } = render(<Textarea id="text" label="Textarea" />);
+
+    await userEvent.type(getByLabelText("Textarea"), "  Test  ");
+    await userEvent.tab(); // go out of focus
+    expect(getByLabelText("Textarea")).toHaveValue("Test");
   });
 
   it("should display helpText", () => {


### PR DESCRIPTION
- Fixes #2171 

**Description**

- Added: onBlur handler for textarea to trim leading and trailing spaces

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@gaagul _a