### PR TITLE
Fixed the color picker dropdown height

### DIFF
--- a/src/styles/components/_color-picker.scss
+++ b/src/styles/components/_color-picker.scss
@@ -51,6 +51,12 @@
   --neeto-ui-colorpicker-target-hexcode-min-width: 72px;
 }
 
+.neeto-ui-colorpicker__dropdown{
+  .neeto-ui-dropdown__popup{
+    max-height: var(--neeto-ui-dropdown-popup-max-height);
+  }
+}
+
 .neeto-ui-colorpicker__popover {
   width: var(--neeto-ui-colorpicker-popover-width);
   padding: var(--neeto-ui-colorpicker-popover-padding);


### PR DESCRIPTION
- Fixes #2185 

**Description**

- Fixed: color picker dropdown height.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
