### PR TITLE
Replaces tooltip with popover in Label component

### DIFF
--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 
 import classnames from "classnames";
-import { isNotPresent } from "neetocist";
 import { Help } from "neetoicons";
 import PropTypes from "prop-types";
 
@@ -28,12 +27,11 @@ const Label = ({
     ...otherHelpIconProps
   } = helpIconProps || {};
 
-  const { title, description, helpLinkProps } = popoverProps || {};
+  const { title, description, helpLinkProps, ...otherPopoverProps } =
+    popoverProps || {};
 
   const HelpIcon = icon || Help;
   const popoverReferenceElement = useRef();
-
-  const isCompact = isNotPresent(title) && isNotPresent(helpLinkProps);
 
   const renderHelpIcon = () => (
     <span
@@ -64,7 +62,10 @@ const Label = ({
           ) : popoverProps ? (
             <>
               {renderHelpIcon()}
-              <Popover reference={popoverReferenceElement}>
+              <Popover
+                reference={popoverReferenceElement}
+                {...otherPopoverProps}
+              >
                 <div className="flex flex-col">
                   {title && (
                     <Title
@@ -74,7 +75,7 @@ const Label = ({
                       {title}
                     </Title>
                   )}
-                  {typeof description === "string" && !isCompact ? (
+                  {typeof description === "string" ? (
                     <Typography
                       data-cy="help-popover-description"
                       data-testid="help-popover-description"

--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -5,6 +5,7 @@ import { Help } from "neetoicons";
 import PropTypes from "prop-types";
 
 import Popover from "./Popover";
+import Tooltip from "./Tooltip";
 
 const Label = ({
   children,
@@ -17,13 +18,25 @@ const Label = ({
     onClick,
     icon,
     tooltipProps,
+    popoverProps,
     className: helpIconClassName,
     ...otherHelpIconProps
   } = helpIconProps || {};
 
   const HelpIcon = icon || Help;
-
   const popoverReferenceElement = useRef();
+
+  const renderHelpIcon = () => (
+    <span
+      {...{ onClick }}
+      ref={popoverProps ? popoverReferenceElement : undefined}
+      className={classnames("neeto-ui-label__help-icon-wrap", {
+        [helpIconClassName]: helpIconClassName,
+      })}
+    >
+      <HelpIcon size={16} {...otherHelpIconProps} />
+    </span>
+  );
 
   return (
     <label
@@ -37,20 +50,16 @@ const Label = ({
       {required && <span aria-hidden>*</span>}
       {helpIconProps && (
         <>
-          <span
-            {...{ onClick }}
-            ref={popoverReferenceElement}
-            className={classnames("neeto-ui-label__help-icon-wrap", {
-              [helpIconClassName]: helpIconClassName,
-            })}
-          >
-            <HelpIcon size={16} {...otherHelpIconProps} />
-          </span>
-          <Popover
-            reference={popoverReferenceElement}
-            {...tooltipProps}
-            disabled={!tooltipProps}
-          />
+          {tooltipProps ? (
+            <Tooltip {...tooltipProps}>{renderHelpIcon()}</Tooltip>
+          ) : popoverProps ? (
+            <>
+              {renderHelpIcon()}
+              <Popover reference={popoverReferenceElement} {...popoverProps} />
+            </>
+          ) : (
+            renderHelpIcon()
+          )}
         </>
       )}
     </label>
@@ -76,7 +85,9 @@ Label.propTypes = {
   helpIconProps: PropTypes.shape({
     onClick: PropTypes.func,
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    tooltipProps: PropTypes.shape({ ...Popover.propTypes }),
+    tooltipProps: PropTypes.shape({ ...Tooltip.propTypes }),
+    popoverProps: PropTypes.shape({ ...Popover.propTypes }),
+    className: PropTypes.string,
   }),
 };
 

--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 
 import classnames from "classnames";
 import { Help } from "neetoicons";
 import PropTypes from "prop-types";
 
-import Tooltip from "./Tooltip";
+import Popover from "./Popover";
 
 const Label = ({
   children,
@@ -23,6 +23,8 @@ const Label = ({
 
   const HelpIcon = icon || Help;
 
+  const popoverReferenceElement = useRef();
+
   return (
     <label
       className={classnames(
@@ -34,16 +36,22 @@ const Label = ({
       {children}
       {required && <span aria-hidden>*</span>}
       {helpIconProps && (
-        <Tooltip {...tooltipProps} disabled={!tooltipProps}>
+        <>
           <span
             {...{ onClick }}
+            ref={popoverReferenceElement}
             className={classnames("neeto-ui-label__help-icon-wrap", {
               [helpIconClassName]: helpIconClassName,
             })}
           >
             <HelpIcon size={16} {...otherHelpIconProps} />
           </span>
-        </Tooltip>
+          <Popover
+            reference={popoverReferenceElement}
+            {...tooltipProps}
+            disabled={!tooltipProps}
+          />
+        </>
       )}
     </label>
   );
@@ -68,7 +76,7 @@ Label.propTypes = {
   helpIconProps: PropTypes.shape({
     onClick: PropTypes.func,
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    tooltipProps: PropTypes.shape({ ...Tooltip.propTypes }),
+    tooltipProps: PropTypes.shape({ ...Popover.propTypes }),
   }),
 };
 

--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -1,11 +1,16 @@
 import React, { useRef } from "react";
 
 import classnames from "classnames";
+import { isNotPresent } from "neetocist";
 import { Help } from "neetoicons";
 import PropTypes from "prop-types";
 
+import Button from "./Button";
 import Popover from "./Popover";
 import Tooltip from "./Tooltip";
+import Typography from "./Typography";
+
+const { Title } = Popover;
 
 const Label = ({
   children,
@@ -23,8 +28,12 @@ const Label = ({
     ...otherHelpIconProps
   } = helpIconProps || {};
 
+  const { title, description, helpLinkProps } = popoverProps || {};
+
   const HelpIcon = icon || Help;
   const popoverReferenceElement = useRef();
+
+  const isCompact = isNotPresent(title) && isNotPresent(helpLinkProps);
 
   const renderHelpIcon = () => (
     <span
@@ -55,7 +64,42 @@ const Label = ({
           ) : popoverProps ? (
             <>
               {renderHelpIcon()}
-              <Popover reference={popoverReferenceElement} {...popoverProps} />
+              <Popover reference={popoverReferenceElement}>
+                <div className="flex flex-col">
+                  {title && (
+                    <Title
+                      data-cy="help-popover-title"
+                      data-testid="help-popover-title"
+                    >
+                      {title}
+                    </Title>
+                  )}
+                  {typeof description === "string" && !isCompact ? (
+                    <Typography
+                      data-cy="help-popover-description"
+                      data-testid="help-popover-description"
+                      lineHeight="normal"
+                      style="body2"
+                      weight="normal"
+                    >
+                      {description}
+                    </Typography>
+                  ) : (
+                    description
+                  )}
+                  {helpLinkProps && (
+                    <Button
+                      className="neeto-ui-mt-3"
+                      data-cy="help-popover-link-button"
+                      size="small"
+                      {...helpLinkProps}
+                      data-testid="help-popover-link-button"
+                      style="link"
+                      target="_blank"
+                    />
+                  )}
+                </div>
+              </Popover>
             </>
           ) : (
             renderHelpIcon()
@@ -86,7 +130,11 @@ Label.propTypes = {
     onClick: PropTypes.func,
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
     tooltipProps: PropTypes.shape({ ...Tooltip.propTypes }),
-    popoverProps: PropTypes.shape({ ...Popover.propTypes }),
+    popoverProps: PropTypes.shape({
+      title: PropTypes.node,
+      description: PropTypes.node,
+      helpLinkProps: PropTypes.shape({ ...Button.propTypes }),
+    }),
     className: PropTypes.string,
   }),
 };

--- a/stories/Components/Label.stories.jsx
+++ b/stories/Components/Label.stories.jsx
@@ -2,11 +2,8 @@ import React from "react";
 
 import { Help } from "neetoicons";
 
-import Button from "components/Button";
 import Label from "components/Label";
-import Popover from "components/Popover";
 import Tooltip from "components/Tooltip";
-import Typography from "components/Typography";
 
 import LabelCSSCustomization from "!raw-loader!./LabelStoriesDocs/LabelCSSCustomization.mdx";
 import LabelDocs from "!raw-loader!./LabelStoriesDocs/LabelDocs.mdx";
@@ -37,26 +34,12 @@ WithHelpIconAndPopover.args = {
   children: "This is a Label with a help icon",
   required: true,
   helpIconProps: {
-    onClick: () => window.open("https://neetoui.onrender.com"),
     icon: Help,
     popoverProps: {
-      content: (
-        <>
-          <Popover.Title>What is KB keywords?</Popover.Title>
-          <Typography lineHeight="normal" style="body2">
-            Keywords represent the key concepts of an article. These will be
-            shown on the KB and will be used for SEO
-          </Typography>
-          <Button
-            className="neeto-ui-mt-3"
-            label="View help article"
-            size="small"
-            style="link"
-            onClick={() => window.open("https://neetoui.onrender.com")}
-          />
-        </>
-      ),
-      position: "auto",
+      title: "What is KB keywords?",
+      description:
+        "Keywords represent the key concepts of an article. These will be shown on the KB and will be used for SEO",
+      helpLinkProps: { label: "KB", href: "https://google.com/kb" },
     },
   },
 };

--- a/stories/Components/Label.stories.jsx
+++ b/stories/Components/Label.stories.jsx
@@ -2,8 +2,11 @@ import React from "react";
 
 import { Help } from "neetoicons";
 
+import Button from "components/Button";
 import Label from "components/Label";
+import Popover from "components/Popover";
 import Tooltip from "components/Tooltip";
+import Typography from "components/Typography";
 
 import LabelCSSCustomization from "!raw-loader!./LabelStoriesDocs/LabelCSSCustomization.mdx";
 import LabelDocs from "!raw-loader!./LabelStoriesDocs/LabelDocs.mdx";
@@ -36,7 +39,25 @@ WithHelpIcon.args = {
   helpIconProps: {
     onClick: () => window.open("https://neetoui.onrender.com"),
     icon: Help,
-    tooltipProps: { content: "Help icon tooltip", position: "auto" },
+    tooltipProps: {
+      content: (
+        <>
+          <Popover.Title>What is KB keywords?</Popover.Title>
+          <Typography lineHeight="normal" style="body2">
+            Keywords represent the key concepts of an article. These will be
+            shown on the KB and will be used for SEO
+          </Typography>
+          <Button
+            className="neeto-ui-mt-3"
+            label="View help article"
+            size="small"
+            style="link"
+            onClick={() => window.open("https://neetoui.onrender.com")}
+          />
+        </>
+      ),
+      position: "auto",
+    },
   },
 };
 WithHelpIcon.storyName = "With help icon";

--- a/stories/Components/Label.stories.jsx
+++ b/stories/Components/Label.stories.jsx
@@ -32,14 +32,14 @@ Required.args = {
   required: true,
 };
 
-const WithHelpIcon = Template.bind({});
-WithHelpIcon.args = {
+const WithHelpIconAndPopover = Template.bind({});
+WithHelpIconAndPopover.args = {
   children: "This is a Label with a help icon",
   required: true,
   helpIconProps: {
     onClick: () => window.open("https://neetoui.onrender.com"),
     icon: Help,
-    tooltipProps: {
+    popoverProps: {
       content: (
         <>
           <Popover.Title>What is KB keywords?</Popover.Title>
@@ -60,7 +60,19 @@ WithHelpIcon.args = {
     },
   },
 };
-WithHelpIcon.storyName = "With help icon";
+WithHelpIconAndPopover.storyName = "With help icon and Popover";
+
+const WithHelpIconAndTooltip = Template.bind({});
+WithHelpIconAndTooltip.args = {
+  children: "This is a Label with a help icon",
+  required: true,
+  helpIconProps: {
+    onClick: () => window.open("https://neetoui.onrender.com"),
+    icon: Help,
+    tooltipProps: { content: "Help icon tooltip", position: "auto" },
+  },
+};
+WithHelpIconAndTooltip.storyName = "With help icon and Tooltip";
 
 const CSSCustomization = args => <Label {...args} />;
 
@@ -75,6 +87,12 @@ CSSCustomization.parameters = {
   docs: { description: { story: LabelCSSCustomization } },
 };
 
-export { Default, Required, WithHelpIcon, CSSCustomization };
+export {
+  Default,
+  Required,
+  WithHelpIconAndTooltip,
+  WithHelpIconAndPopover,
+  CSSCustomization,
+};
 
 export default metadata;

--- a/tests/Label.test.jsx
+++ b/tests/Label.test.jsx
@@ -30,11 +30,11 @@ describe("Label", () => {
     expect(getByTestId("icon")).toBeInTheDocument();
   });
 
-  it("should show tooltip when provided in helpIconProps", async () => {
+  it("should show popover when provided in helpIconProps", async () => {
     const { getByText, getByTestId } = render(
       <Label
         helpIconProps={{
-          tooltipProps: { content: "Tooltip" },
+          tooltipProps: { content: "Popover" },
           "data-testid": "icon",
         }}
       >
@@ -42,18 +42,13 @@ describe("Label", () => {
       </Label>
     );
     await userEvent.hover(getByTestId("icon"));
-    expect(getByText("Tooltip")).toBeInTheDocument();
+    expect(getByText("Popover")).toBeInTheDocument();
   });
 
   it("should trigger onClick when provided in helpIconProps", async () => {
     const onClick = jest.fn();
     const { getByTestId } = render(
-      <Label
-        helpIconProps={{
-          onClick,
-          "data-testid": "icon",
-        }}
-      >
+      <Label helpIconProps={{ onClick, "data-testid": "icon" }}>
         <p>Content</p>
       </Label>
     );

--- a/tests/Label.test.jsx
+++ b/tests/Label.test.jsx
@@ -30,11 +30,26 @@ describe("Label", () => {
     expect(getByTestId("icon")).toBeInTheDocument();
   });
 
+  it("should show tooltip when provided in helpIconProps", async () => {
+    const { getByText, getByTestId } = render(
+      <Label
+        helpIconProps={{
+          tooltipProps: { content: "Tooltip" },
+          "data-testid": "icon",
+        }}
+      >
+        <p>Content</p>
+      </Label>
+    );
+    await userEvent.hover(getByTestId("icon"));
+    expect(getByText("Tooltip")).toBeInTheDocument();
+  });
+
   it("should show popover when provided in helpIconProps", async () => {
     const { getByText, getByTestId } = render(
       <Label
         helpIconProps={{
-          tooltipProps: { content: "Popover" },
+          popoverProps: { description: "Popover" },
           "data-testid": "icon",
         }}
       >

--- a/types/Label.d.ts
+++ b/types/Label.d.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { TooltipProps } from "./Tooltip";
+import { ButtonProps } from "./Button";
 
 export type LabelProps = {
   className?: string;
@@ -8,6 +9,11 @@ export type LabelProps = {
     onClick?: () => void;
     icon?: any;
     tooltipProps?: TooltipProps;
+    popoverProps?: {
+      title?: string;
+      description?: React.ReactNode;
+      helpLinkProps?: ButtonProps;
+    };
     className?: string;
   } & React.SVGProps<SVGSVGElement>;
 } & React.DetailedHTMLProps<

--- a/types/Label.d.ts
+++ b/types/Label.d.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { TooltipProps } from "./Tooltip";
 import { ButtonProps } from "./Button";
+import { PopoverProps } from "./Popover";
 
 export type LabelProps = {
   className?: string;

--- a/types/Label.d.ts
+++ b/types/Label.d.ts
@@ -13,7 +13,7 @@ export type LabelProps = {
       title?: string;
       description?: React.ReactNode;
       helpLinkProps?: ButtonProps;
-    };
+    } & PopoverProps;
     className?: string;
   } & React.SVGProps<SVGSVGElement>;
 } & React.DetailedHTMLProps<


### PR DESCRIPTION
- Fixes #2198 

**Description**
Adds support for Popover component along with Tooltip component  in Label help icon

**Checklist**

- [x] I have made corresponding changes to the documentation.
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
