### PR TITLE
Adds logic to prevent multiple submissions when enter is pressed

### DIFF
--- a/src/formik/Form/FormWrapper.jsx
+++ b/src/formik/Form/FormWrapper.jsx
@@ -8,8 +8,14 @@ import { scrollToError } from "./ScrollToErrorField/utils";
 
 const FormWrapper = forwardRef(
   ({ className, formProps, children, onSubmit, scrollToErrorField }, ref) => {
-    const { values, validateForm, setErrors, setTouched, ...formikBag } =
-      useFormikContext();
+    const {
+      values,
+      validateForm,
+      setErrors,
+      setTouched,
+      setSubmitting,
+      ...formikBag
+    } = useFormikContext();
 
     const { dirty: isFormDirty, isSubmitting } = formikBag;
 
@@ -40,6 +46,7 @@ const FormWrapper = forwardRef(
             setTouched(errors);
             scrollToErrorField && scrollToError(formRef, errors);
           } else {
+            setSubmitting(true);
             onSubmit(values, formikBag);
           }
         } catch (error) {


### PR DESCRIPTION
- Fixes #2200 

**Description**
Adds logic to prevent multiple submissions when enter is pressed
Video: https://navaneeth-d.neetorecord.com/watch/2fe8f21a-3753-4253-b54b-2b29e4480dab

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
