### PR TITLE
Repositions color palette to top

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -121,6 +121,17 @@ const ColorPicker = ({
       {...dropdownProps}
     >
       <div className="neeto-ui-colorpicker__popover">
+        {colorPaletteProps && (
+          <div
+            data-testid="color-palette"
+            className={classnames("neeto-ui-colorpicker__palette-wrapper", {
+              "neeto-ui-colorpicker__palette-wrapper--hidden-picker":
+                !showPicker,
+            })}
+          >
+            <Palette {...colorPaletteProps} />
+          </div>
+        )}
         {showPicker && (
           <>
             <div
@@ -155,17 +166,6 @@ const ColorPicker = ({
               </div>
             </div>
           </>
-        )}
-        {colorPaletteProps && (
-          <div
-            data-testid="color-palette"
-            className={classnames("neeto-ui-colorpicker__palette-wrapper", {
-              "neeto-ui-colorpicker__palette-wrapper--hidden-picker":
-                !showPicker,
-            })}
-          >
-            <Palette {...colorPaletteProps} />
-          </div>
         )}
       </div>
     </Dropdown>

--- a/src/styles/components/_color-picker.scss
+++ b/src/styles/components/_color-picker.scss
@@ -8,7 +8,7 @@
   --neeto-ui-colorpicker-pointer-height: 20px;
 
   // Palette Wrapper
-  --neeto-ui-colorpicker-palette-wrapper-margin-top: 12px;
+  --neeto-ui-colorpicker-palette-wrapper-margin-bottom: 12px;
 
   // Palette Item
   --neeto-ui-colorpicker-palette-item-width: 32px;
@@ -68,10 +68,10 @@
   }
 
   .neeto-ui-colorpicker__palette-wrapper {
-    margin-top: var(--neeto-ui-colorpicker-palette-wrapper-margin-top);
+    margin-bottom: var(--neeto-ui-colorpicker-palette-wrapper-margin-bottom);
 
     &--hidden-picker {
-      --neeto-ui-colorpicker-palette-wrapper-margin-top: 0px;
+      --neeto-ui-colorpicker-palette-wrapper-margin-bottom: 0px;
     }
   }
 


### PR DESCRIPTION
- Fixes #2184 

**Description**
Repositions color palette to top

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
