### PR TITLE
Fixed alignment of thumbs up toastr on mobile view

### DIFF
--- a/src/components/Toastr/index.jsx
+++ b/src/components/Toastr/index.jsx
@@ -24,6 +24,7 @@ const TOAST_CONFIG = {
     />
   ),
   role: "log",
+  className: "neeto-ui-toastr",
 };
 
 const TOAST_ICON = {

--- a/src/components/Toastr/index.jsx
+++ b/src/components/Toastr/index.jsx
@@ -24,7 +24,6 @@ const TOAST_CONFIG = {
     />
   ),
   role: "log",
-  className: "neeto-ui-toastr",
 };
 
 const TOAST_ICON = {

--- a/src/styles/components/_toast.scss
+++ b/src/styles/components/_toast.scss
@@ -61,7 +61,7 @@ body {
       left: 12px !important;
     }
 
-    .Toastify__toast{
+    .Toastify__toast, .neeto-ui-toastr{
       min-height: var(--neeto-ui-toastr-min-height);
       padding: var(--neeto-ui-toastr-padding-y) var(--neeto-ui-toastr-padding-x);
       margin: var(--neeto-ui-toastr-margin-y) var(--neeto-ui-toastr-margin-x);

--- a/src/styles/components/_toast.scss
+++ b/src/styles/components/_toast.scss
@@ -56,8 +56,12 @@ body {
       background-color: var(--neeto-ui-warning-toastr-bg-color);
     }
 
-    .Toastify__toast,
-    .neeto-ui-toastr {
+   &.Toastify__toast-container--bottom-left{
+      bottom: 12px !important;
+      left: 12px !important;
+    }
+
+    .Toastify__toast{
       min-height: var(--neeto-ui-toastr-min-height);
       padding: var(--neeto-ui-toastr-padding-y) var(--neeto-ui-toastr-padding-x);
       margin: var(--neeto-ui-toastr-margin-y) var(--neeto-ui-toastr-margin-x);
@@ -68,9 +72,7 @@ body {
       "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !important;
 
       @include viewport(xs-mob) {
-        width: 95%;
-        margin-left: auto;
-        margin-right: auto;
+        max-width: calc(100% - 24px);
       }
 
       &::after {

--- a/src/styles/components/_toast.scss
+++ b/src/styles/components/_toast.scss
@@ -57,8 +57,8 @@ body {
     }
 
    &.Toastify__toast-container--bottom-left{
-      bottom: 12px !important;
-      left: 12px !important;
+      bottom: 12px;
+      left: 12px;
     }
 
     .Toastify__toast, .neeto-ui-toastr{


### PR DESCRIPTION
- Fixes #2213 

**Description**

### Before
![Screenshot 2024-05-31 at 11 59 55 PM](https://github.com/bigbinary/neeto-ui/assets/16187886/7c65bc7b-cffb-4c0f-915d-9fd169418028)

---

### After

![Screenshot 2024-06-01 at 12 33 53 AM](https://github.com/bigbinary/neeto-ui/assets/16187886/9e898fd1-c92e-4bcf-95b8-8e25420c42a6)

![Screenshot 2024-06-01 at 12 33 17 AM](https://github.com/bigbinary/neeto-ui/assets/16187886/0e69e26d-f467-4ed0-a984-9e8e73f53983)


**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
