### PR TITLE
Adds logic to prevent multiple submissions when enter key is pressed

### DIFF
--- a/src/formik/Form/FormWrapper.jsx
+++ b/src/formik/Form/FormWrapper.jsx
@@ -7,15 +7,9 @@ import ScrollToErrorField from "./ScrollToErrorField";
 import { scrollToError } from "./ScrollToErrorField/utils";
 
 const FormWrapper = forwardRef(
-  ({ className, formProps, children, onSubmit, scrollToErrorField }, ref) => {
-    const {
-      values,
-      validateForm,
-      setErrors,
-      setTouched,
-      submitForm,
-      ...formikBag
-    } = useFormikContext();
+  ({ className, formProps, children, scrollToErrorField }, ref) => {
+    const { validateForm, setErrors, setTouched, submitForm, ...formikBag } =
+      useFormikContext();
 
     const { dirty: isFormDirty, isSubmitting } = formikBag;
 
@@ -57,13 +51,12 @@ const FormWrapper = forwardRef(
         }
       },
       [
-        values,
         validateForm,
         setErrors,
         setTouched,
-        onSubmit,
         isFormDirty,
         isSubmitting,
+        submitForm,
       ]
     );
 
@@ -88,7 +81,6 @@ FormWrapper.displayName = "FormWrapper";
 FormWrapper.propTypes = {
   children: PropTypes.node,
   formProps: PropTypes.object,
-  onSubmit: PropTypes.func,
   scrollToErrorField: PropTypes.bool,
 };
 

--- a/src/formik/Form/FormWrapper.jsx
+++ b/src/formik/Form/FormWrapper.jsx
@@ -8,8 +8,14 @@ import { scrollToError } from "./ScrollToErrorField/utils";
 
 const FormWrapper = forwardRef(
   ({ className, formProps, children, onSubmit, scrollToErrorField }, ref) => {
-    const { values, validateForm, setErrors, setTouched, ...formikBag } =
-      useFormikContext();
+    const {
+      values,
+      validateForm,
+      setErrors,
+      setTouched,
+      submitForm,
+      ...formikBag
+    } = useFormikContext();
 
     const { dirty: isFormDirty, isSubmitting } = formikBag;
 
@@ -40,7 +46,7 @@ const FormWrapper = forwardRef(
             setTouched(errors);
             scrollToErrorField && scrollToError(formRef, errors);
           } else {
-            onSubmit(values, formikBag);
+            submitForm();
           }
         } catch (error) {
           // eslint-disable-next-line no-console

--- a/src/formik/Form/index.jsx
+++ b/src/formik/Form/index.jsx
@@ -12,10 +12,7 @@ const Form = forwardRef(
   ) => (
     <Formik {...formikProps}>
       {props => (
-        <FormWrapper
-          {...{ className, formProps, ref, scrollToErrorField }}
-          onSubmit={formikProps?.onSubmit}
-        >
+        <FormWrapper {...{ className, formProps, ref, scrollToErrorField }}>
           {typeof children === "function" ? children(props) : children}
         </FormWrapper>
       )}


### PR DESCRIPTION
- Fixes #2200 

**Description**
Adds logic to prevent multiple submissions when enter is pressed
Video: https://navaneeth-d.neetorecord.com/watch/91e0358f-dbaf-468a-a615-09bf4cfc90dc

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
~- [ ] I have verified the functionality in some of the neeto web-apps.~
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
