### PR TITLE
Added pruning with user feedback

### DIFF
--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -48,6 +48,7 @@ const MultiEmailInput = forwardRef(
   ) => {
     const [inputValue, setInputValue] = useState("");
     const [isFocused, setIsFocused] = useState(false);
+    const [duplicateEmails, setDuplicateEmails] = useState([]);
 
     const isCounterVisible =
       !!counter &&
@@ -63,7 +64,12 @@ const MultiEmailInput = forwardRef(
         inputValue.match(UNSTRICT_EMAIL_REGEX) || inputValues || [];
 
       const emails = emailMatches.map(email => formatEmailInputOptions(email));
-      onChange(pruneDuplicates([...value, ...emails]));
+      const { uniqueEmails, duplicates } = pruneDuplicates([
+        ...value,
+        ...emails,
+      ]);
+      onChange(uniqueEmails);
+      setDuplicateEmails(duplicates);
       setInputValue("");
     };
 
@@ -90,13 +96,16 @@ const MultiEmailInput = forwardRef(
 
     const onCreateOption = input => {
       const email = formatEmailInputOptions(input);
-      onChange(pruneDuplicates([...value, email]));
+      const { uniqueEmails, duplicates } = pruneDuplicates([...value, email]);
+      onChange(uniqueEmails);
+      setDuplicateEmails(duplicates);
       otherProps?.onCreateOption?.(input);
     };
 
     const handleBlur = event => {
       inputValue ? handleEmailChange(inputValue) : onBlur(event);
       setIsFocused(false);
+      setDuplicateEmails([]);
     };
 
     let overrideProps = {};
@@ -211,6 +220,14 @@ const MultiEmailInput = forwardRef(
             data-cy={`${hyphenize(label)}-input-help`}
           >
             {helpText}
+          </p>
+        )}
+        {!!duplicateEmails.length && (
+          <p
+            className="neeto-ui-input__warning"
+            data-cy={`${hyphenize(label)}-duplicate-emails`}
+          >
+            Duplicate emails removed: {duplicateEmails.join(", ")}
           </p>
         )}
       </div>

--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -225,7 +225,7 @@ const MultiEmailInput = forwardRef(
         {!!duplicateEmails.length && (
           <p
             className="neeto-ui-input__warning"
-            data-cy={`${hyphenize(label)}-duplicate-emails`}
+            data-cy={`${hyphenize(label)}-duplicate-emails-warning`}
           >
             Duplicate emails removed: {duplicateEmails.join(", ")}
           </p>

--- a/src/components/MultiEmailInput/utils.js
+++ b/src/components/MultiEmailInput/utils.js
@@ -11,8 +11,14 @@ export const formatEmailInputOptions = label => ({
 export const pruneDuplicates = inputValues => {
   const values = pluck("value", inputValues);
   const uniqueValues = [...new Set(values)];
+  const duplicates = values.filter(
+    (item, index) => values.indexOf(item) !== index
+  );
 
-  return uniqueValues.map(email => formatEmailInputOptions(email));
+  return {
+    uniqueEmails: uniqueValues.map(email => formatEmailInputOptions(email)),
+    duplicates,
+  };
 };
 
 export const renderValidEmails = values =>

--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -62,6 +62,12 @@
   --neeto-ui-input-help-text-color: rgb(var(--neeto-ui-gray-700));
   --neeto-ui-input-help-text-line-height: 1.1;
 
+  // Warning Text
+  --neeto-ui-input-warning-text-margin: 8px;
+  --neeto-ui-input-warning-text-font-size: var(--neeto-ui-text-xs);
+  --neeto-ui-input-warning-text-color: rgb(var(--neeto-ui-warning-800));
+  --neeto-ui-input-warning-text-line-height: 1.1;
+
   // Error Text
   --neeto-ui-input-error-text-margin: 8px;
   --neeto-ui-input-error-text-font-size: var(--neeto-ui-text-xs);
@@ -302,6 +308,13 @@
   font-size: var(--neeto-ui-input-error-text-font-size);
   color: var(--neeto-ui-input-error-text-color);
   line-height: var(--neeto-ui-input-error-text-line-height);
+}
+
+.neeto-ui-input__warning {
+  margin-top: var(--neeto-ui-input-warning-text-margin);
+  font-size: var(--neeto-ui-input-warning-text-font-size);
+  color: var(--neeto-ui-input-warning-text-color);
+  line-height: var(--neeto-ui-input-warning-text-line-height);
 }
 
 .neetix-input {

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -256,4 +256,15 @@ describe("MultiEmailInput", () => {
       expect(screen.getByText(email.label)).toBeInTheDocument();
     });
   });
+
+  it("should provide feedback when duplicate emails are pruned", async () => {
+    render(<MultiEmailInput counter value={SAMPLE_EMAILS} />);
+    const emailInput = screen.getByRole("combobox");
+
+    await userEvent.type(emailInput, "test@example.com{enter}");
+
+    expect(
+      screen.getByText("Duplicate emails removed: test@example.com")
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Fixes #2229 

**Description**
https://navaneeth-d.neetorecord.com/watch/f777bc32-f8f1-4dd0-85bb-04be9c369c7b

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
