### PR TITLE
Added option to show timezone next to the date in datepicker

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -6,6 +6,7 @@ import { isNotPresent } from "neetocist";
 import { Left, Right, Calendar, Close } from "neetoicons";
 import PropTypes from "prop-types";
 
+import { Tag } from "components";
 import Label from "components/Label";
 import { useSyncedRef, useId } from "hooks";
 import { convertToDayjsObjects, noop, hyphenize } from "utils";
@@ -53,6 +54,7 @@ const DatePicker = forwardRef(
       maxDate,
       minDate,
       timePickerProps,
+      timezone,
       ...otherProps
     },
     ref
@@ -150,13 +152,15 @@ const DatePicker = forwardRef(
             }}
             nextIcon={<IconOverride icon={Right} />}
             prevIcon={<IconOverride icon={Left} />}
-            suffixIcon={<Calendar size={16} />}
             superNextIcon={<IconOverride icon={Right} />}
             superPrevIcon={<IconOverride icon={Left} />}
             allowClear={
               allowClear && {
                 clearIcon: <Close data-cy="date-time-clear-icon" size={16} />,
               }
+            }
+            suffixIcon={
+              timezone ? <Tag label={timezone} /> : <Calendar size={16} />
             }
           />
           {!!error && typeof error === "string" && (
@@ -225,6 +229,10 @@ DatePicker.propTypes = {
    * To specify props to be passed to the time picker.
    */
   timePickerProps: PropTypes.object,
+  /**
+   * To specify the timezone.
+   */
+  timezone: PropTypes.string,
   /**
    * For `DateInput`,(date, dateString) => {} <br />
    * For `DateRange`, (date, [startDate, endDate]) => {}

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -5,6 +5,7 @@ import classnames from "classnames";
 import { Clock } from "neetoicons";
 import PropTypes from "prop-types";
 
+import { Tag } from "components";
 import Label from "components/Label";
 import { useSyncedRef, useId } from "hooks";
 import {
@@ -44,6 +45,7 @@ const TimePicker = forwardRef(
       labelProps,
       required = false,
       placeholder,
+      timezone,
       ...otherProps
     },
     ref
@@ -150,8 +152,10 @@ const TimePicker = forwardRef(
             mode={undefined}
             picker="time"
             placeholder={placeholder ?? format}
-            suffixIcon={<Clock size={16} />}
             value={convertToDayjsObjects(value)}
+            suffixIcon={
+              timezone ? <Tag label={timezone} /> : <Clock size={16} />
+            }
           />
           {!!error && (
             <p
@@ -199,6 +203,10 @@ TimePicker.propTypes = {
    * To specify the time format.
    */
   format: PropTypes.string,
+  /**
+   * To specify the timezone.
+   */
+  timezone: PropTypes.string,
   /**
    * To set the placeholder text for the TimePicker, if not provided, the format will be used as placeholder.
    */

--- a/types/DatePicker.d.ts
+++ b/types/DatePicker.d.ts
@@ -16,6 +16,7 @@ export type DatePickerProps = {
   picker?: "date" | "week" | "month" | "quarter" | "year";
   showTime?: boolean;
   timePickerProps?: any;
+  timezone?: string;
   type?: "range" | "date";
   nakedInput?: boolean;
   error?: string;

--- a/types/TimePicker.d.ts
+++ b/types/TimePicker.d.ts
@@ -21,6 +21,7 @@ export type TimePickerProps = {
   value?: any;
   id?: string;
   labelProps?: LabelProps;
+  timezone?: string;
   required: boolean;
   [key: string]: any;
 };


### PR DESCRIPTION
- Fixes #2149

**Description**

- Added option to show timezone next to the date in datepicker

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@josephmathew900 _a