### PR TITLE
Added support for displaying tooltips for disabled buttons in NoData component

### DIFF
--- a/src/components/NoData/index.jsx
+++ b/src/components/NoData/index.jsx
@@ -2,9 +2,10 @@ import React from "react";
 
 import classnames from "classnames";
 import PropTypes from "prop-types";
-import { isEmpty } from "ramda";
+import { isEmpty, isNil, omit } from "ramda";
 
 import Button from "components/Button";
+import Tooltip from "components/Tooltip";
 import Typography from "components/Typography";
 
 import { renderImage } from "./utils";
@@ -18,6 +19,7 @@ const NoData = ({
   primaryButtonProps = {},
   secondaryButtonProps = {},
   buttonSeparatorText = "",
+  showTooltipWhenButtonDisabled = false,
   ...otherProps
 }) => {
   const hasPrimaryButtonProps = !isEmpty(primaryButtonProps);
@@ -69,7 +71,21 @@ const NoData = ({
       {(hasPrimaryButtonProps || hasSecondaryButtonProps) && (
         <div className="neeto-ui-no-data__action-block">
           {hasPrimaryButtonProps && (
-            <Button data-cy="no-data-primary-button" {...primaryButtonProps} />
+            <Tooltip
+              {...primaryButtonProps?.tooltipProps}
+              disabled={
+                isNil(primaryButtonProps?.tooltipProps) ||
+                (!showTooltipWhenButtonDisabled && primaryButtonProps?.disabled)
+              }
+            >
+              <div>
+                <Button
+                  data-cy="no-data-primary-button"
+                  data-testid="no-data-primary-button"
+                  {...omit(["tooltipProps"], primaryButtonProps)}
+                />
+              </div>
+            </Tooltip>
           )}
           {showButtonSeparator && (
             <Typography lineHeight="normal" style="body2">
@@ -77,11 +93,23 @@ const NoData = ({
             </Typography>
           )}
           {hasSecondaryButtonProps && (
-            <Button
-              data-cy="no-data-secondary-button"
-              style="secondary"
-              {...secondaryButtonProps}
-            />
+            <Tooltip
+              {...secondaryButtonProps?.tooltipProps}
+              disabled={
+                isNil(secondaryButtonProps?.tooltipProps) ||
+                (!showTooltipWhenButtonDisabled &&
+                  secondaryButtonProps?.disabled)
+              }
+            >
+              <div>
+                <Button
+                  data-cy="no-data-secondary-button"
+                  data-testid="no-data-secondary-button"
+                  style="secondary"
+                  {...omit(["tooltipProps"], secondaryButtonProps)}
+                />
+              </div>
+            </Tooltip>
           )}
         </div>
       )}
@@ -118,6 +146,10 @@ NoData.propTypes = {
    * To specify the props to be passed to the secondary button.
    */
   secondaryButtonProps: PropTypes.object,
+  /**
+   * To specify if the tooltip should be shown when the button is disabled.
+   */
+  showTooltipWhenButtonDisabled: PropTypes.bool,
   /**
    * To specify the text that appears between the primary and secondary buttons.
    * */

--- a/tests/NoData.test.jsx
+++ b/tests/NoData.test.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { NoData } from "components";
+
+describe("Typography", () => {
+  it("should render without error", () => {
+    const { getByText } = render(
+      <NoData
+        primaryButtonProps={{ label: "Add new ticket" }}
+        title="There are no tickets to show"
+      />
+    );
+    expect(getByText("There are no tickets to show")).toBeInTheDocument();
+  });
+
+  it("should display primary and secondary button tooltips when button is disabled and showTooltipWhenButtonDisabled is true", async () => {
+    const { getByTestId } = render(
+      <NoData
+        showTooltipWhenButtonDisabled
+        title="There are no tickets to show"
+        primaryButtonProps={{
+          label: "Add new ticket",
+          tooltipProps: { content: "Primary tooltip" },
+          disabled: true,
+        }}
+        secondaryButtonProps={{
+          label: "Add new ticket",
+          tooltipProps: { content: "Secondary tooltip" },
+          disabled: true,
+        }}
+      />
+    );
+
+    const primaryButton = getByTestId("no-data-primary-button");
+    await userEvent.hover(primaryButton);
+    await expect(screen.getByText("Primary tooltip")).toBeInTheDocument();
+
+    const secondaryButton = getByTestId("no-data-secondary-button");
+    await userEvent.hover(secondaryButton);
+    await expect(screen.getByText("Secondary tooltip")).toBeInTheDocument();
+  });
+
+  it("should not display primary and secondary button tooltips when button is disabled and showTooltipWhenDisabled is false", async () => {
+    const { getByTestId } = render(
+      <NoData
+        showTooltipWhenButtonDisabled={false}
+        title="There are no tickets to show"
+        primaryButtonProps={{
+          label: "Add new ticket",
+          tooltipProps: { content: "Primary tooltip" },
+          disabled: true,
+        }}
+        secondaryButtonProps={{
+          label: "Add new ticket",
+          tooltipProps: { content: "Secondary tooltip" },
+          disabled: true,
+        }}
+      />
+    );
+
+    const primaryButton = getByTestId("no-data-primary-button");
+    await userEvent.hover(primaryButton);
+    await expect(screen.queryByText("Primary tooltip")).not.toBeInTheDocument();
+
+    const secondaryButton = getByTestId("no-data-secondary-button");
+    await userEvent.hover(secondaryButton);
+    await expect(
+      screen.queryByText("Secondary tooltip")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should display primary and secondary button tooltips when button is not disabled", async () => {
+    const { getByTestId } = render(
+      <NoData
+        title="There are no tickets to show"
+        primaryButtonProps={{
+          label: "Add new ticket",
+          tooltipProps: { content: "Primary tooltip" },
+        }}
+        secondaryButtonProps={{
+          label: "Add new ticket",
+          tooltipProps: { content: "Secondary tooltip" },
+        }}
+      />
+    );
+
+    const primaryButton = getByTestId("no-data-primary-button");
+    await userEvent.hover(primaryButton);
+    await expect(screen.getByText("Primary tooltip")).toBeInTheDocument();
+
+    const secondaryButton = getByTestId("no-data-secondary-button");
+    await userEvent.hover(secondaryButton);
+    await expect(screen.getByText("Secondary tooltip")).toBeInTheDocument();
+  });
+});

--- a/types/NoData.d.ts
+++ b/types/NoData.d.ts
@@ -7,6 +7,7 @@ export type NoDataProps = {
   helpText?: React.ReactNode;
   primaryButtonProps?: ButtonProps;
   secondaryButtonProps?: ButtonProps;
+  showTooltipWhenButtonDisabled?: 
   className?: string;
 };
 

--- a/types/NoData.d.ts
+++ b/types/NoData.d.ts
@@ -7,7 +7,7 @@ export type NoDataProps = {
   helpText?: React.ReactNode;
   primaryButtonProps?: ButtonProps;
   secondaryButtonProps?: ButtonProps;
-  showTooltipWhenButtonDisabled?: 
+  showTooltipWhenButtonDisabled?: boolean;
   className?: string;
 };
 


### PR DESCRIPTION
- Fixes #2240 

**Description**

- Added support for displaying tooltips for disabled buttons in NoData component

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@josephmathew900 _A

cc: @abilash-sajeev 