### PR TITLE
Prevents form submission when the server errors are set.

### DIFF
--- a/src/formik/Form/FormWrapper.jsx
+++ b/src/formik/Form/FormWrapper.jsx
@@ -4,14 +4,17 @@ import { Form as FormikForm, useFormikContext } from "formik";
 import PropTypes from "prop-types";
 
 import ScrollToErrorField from "./ScrollToErrorField";
-import { scrollToError } from "./ScrollToErrorField/utils";
+import {
+  getFieldsWithServerError,
+  scrollToError,
+} from "./ScrollToErrorField/utils";
 
 const FormWrapper = forwardRef(
   ({ className, formProps, children, scrollToErrorField }, ref) => {
     const { validateForm, setErrors, setTouched, submitForm, ...formikBag } =
       useFormikContext();
 
-    const { dirty: isFormDirty, isSubmitting } = formikBag;
+    const { dirty: isFormDirty, isSubmitting, status } = formikBag;
 
     const formRefForScrollToErrorField = useRef();
 
@@ -34,11 +37,15 @@ const FormWrapper = forwardRef(
 
         try {
           const errors = await validateForm();
+          const fieldStatuses = getFieldsWithServerError(status);
 
-          if (Object.keys(errors).length > 0) {
+          if (
+            Object.keys(errors).length > 0 ||
+            Object.keys(fieldStatuses).length > 0
+          ) {
             setErrors(errors);
-            setTouched(errors);
-            scrollToErrorField && scrollToError(formRef, errors);
+            setTouched({ ...errors, ...status });
+            scrollToErrorField && scrollToError(formRef, errors, status);
           } else {
             submitForm();
           }
@@ -57,6 +64,7 @@ const FormWrapper = forwardRef(
         isFormDirty,
         isSubmitting,
         submitForm,
+        status,
       ]
     );
 

--- a/src/formik/Form/ScrollToErrorField/index.js
+++ b/src/formik/Form/ScrollToErrorField/index.js
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { useFormikContext } from "formik";
+import { isEmpty } from "ramda";
 
 import { getFieldsWithServerError, scrollToError } from "./utils";
 
@@ -9,7 +10,7 @@ const ScrollToErrorField = ({ formRef }) => {
 
   useEffect(() => {
     const fieldsWithServerError = getFieldsWithServerError(status);
-    if (!formRef.current || (isValid && fieldsWithServerError.length > 0)) {
+    if (!formRef.current || (isValid && isEmpty(fieldsWithServerError))) {
       return;
     }
 

--- a/src/formik/Form/ScrollToErrorField/index.js
+++ b/src/formik/Form/ScrollToErrorField/index.js
@@ -2,15 +2,18 @@ import { useEffect } from "react";
 
 import { useFormikContext } from "formik";
 
-import { scrollToError } from "./utils";
+import { getFieldsWithServerError, scrollToError } from "./utils";
 
 const ScrollToErrorField = ({ formRef }) => {
-  const { submitCount, isValid, errors } = useFormikContext();
+  const { submitCount, isValid, errors, status } = useFormikContext();
 
   useEffect(() => {
-    if (!formRef.current || isValid) return;
+    const fieldsWithServerError = getFieldsWithServerError(status);
+    if (!formRef.current || (isValid && fieldsWithServerError.length > 0)) {
+      return;
+    }
 
-    scrollToError(formRef, errors);
+    scrollToError(formRef, errors, status);
   }, [submitCount]);
 
   return null;

--- a/src/formik/Form/ScrollToErrorField/utils.js
+++ b/src/formik/Form/ScrollToErrorField/utils.js
@@ -1,3 +1,4 @@
+import { isPresent } from "neetocist";
 import { is } from "ramda";
 
 const transformObjectToDotNotation = (object, prefix = "") => {
@@ -19,12 +20,18 @@ const transformObjectToDotNotation = (object, prefix = "") => {
 const getErrorFieldName = formikErrors =>
   transformObjectToDotNotation(formikErrors)?.[0];
 
-export const scrollToError = (formRef, errors) => {
-  const fieldErrorName = getErrorFieldName(errors);
-  if (!fieldErrorName) return;
+export const getFieldsWithServerError = (status = {}) =>
+  Object.keys(status).filter(fieldName => isPresent(status[fieldName]));
 
+export const scrollToError = (formRef, errors, status) => {
+  const fieldErrorName = getErrorFieldName(errors);
+  const [fieldWithServerError] = getFieldsWithServerError(status);
+
+  if (!fieldErrorName && !fieldWithServerError) return;
+
+  const errorFieldName = fieldErrorName || fieldWithServerError;
   const errorFormElement = formRef.current.querySelector(
-    `[name="${fieldErrorName}"]`
+    `[name="${errorFieldName}"]`
   );
 
   errorFormElement?.scrollIntoView({

--- a/src/formik/Form/index.jsx
+++ b/src/formik/Form/index.jsx
@@ -1,23 +1,42 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useRef } from "react";
 
 import { Formik } from "formik";
 import PropTypes from "prop-types";
 
 import FormWrapper from "./FormWrapper";
+import { getFieldsWithServerError } from "./ScrollToErrorField/utils";
 
 const Form = forwardRef(
   (
     { className, children, formikProps, formProps, scrollToErrorField = false },
     ref
-  ) => (
-    <Formik {...formikProps}>
-      {props => (
-        <FormWrapper {...{ className, formProps, ref, scrollToErrorField }}>
-          {typeof children === "function" ? children(props) : children}
-        </FormWrapper>
-      )}
-    </Formik>
-  )
+  ) => {
+    const formikRef = useRef();
+
+    const handleSubmit = (values, actions) => {
+      const fieldsWithServerError = getFieldsWithServerError(
+        formikRef.current?.status
+      );
+
+      if (fieldsWithServerError.length > 0) {
+        actions.setSubmitting(false);
+
+        return;
+      }
+
+      formikProps.onSubmit(values, actions);
+    };
+
+    return (
+      <Formik innerRef={formikRef} {...formikProps} onSubmit={handleSubmit}>
+        {props => (
+          <FormWrapper {...{ className, formProps, ref, scrollToErrorField }}>
+            {typeof children === "function" ? children(props) : children}
+          </FormWrapper>
+        )}
+      </Formik>
+    );
+  }
 );
 
 Form.displayName = "Form";


### PR DESCRIPTION
Fixes #2263 

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
