### PR TITLE
Update the default font family to Inter on Windows

### DIFF
--- a/.storybook/neetoTheme.js
+++ b/.storybook/neetoTheme.js
@@ -15,7 +15,7 @@ export default create({
 
   // Typography
   fontBase:
-    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+    '-apple-system, BlinkMacSystemFont, "Inter", Arial, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
   fontCode: "monospace",
 
   // Text colors

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,9 +5,6 @@
 <style>
   body {
     -webkit-font-smoothing: initial !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-      "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
   }
   .sbdocs p {
     font-size: 16px;
@@ -15,32 +12,20 @@
     max-width: 80ch;
     color: #000 !important;
     -webkit-font-smoothing: initial !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-      "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
   }
   .sbdocs li {
     font-size: 16px;
     color: #000 !important;
     position: relative;
     -webkit-font-smoothing: initial !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-      "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
   }
   .sbdocs .sbdocs-a {
     color: #2d36d4;
     -webkit-font-smoothing: initial !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-      "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
   }
   .neeto-language-page h3 .sbdocs-a,
   .neeto-language-page h2 .sbdocs-a {
     color: #1b1f23 !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-      "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
   }
   .sbdocs h1,
   .sbdocs h2,
@@ -50,9 +35,6 @@
   .sbdocs h6,
   .sbdocs-title {
     -webkit-font-smoothing: initial !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-      "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
   }
 
   .subheading {

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -1,7 +1,7 @@
 $prefix: "neeto-ui-";
 
 // Body
-$neeto-ui-body-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+$neeto-ui-body-font-family: -apple-system, BlinkMacSystemFont, "Inter", Arial, "Segoe UI",
 "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
 sans-serif !important;
 $neeto-ui-body-font-size: 14px;

--- a/src/styles/base/_base.scss
+++ b/src/styles/base/_base.scss
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap");
+
 // Custom
 
 audio,
@@ -88,9 +90,7 @@ pre {
 }
 
 body {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif !important;
+  font-family: var(--neeto-ui-body-font-family) !important;
   font-size: 14px;
   font-weight: 400;
   line-height: 1.3;

--- a/src/styles/components/_table-overrides.scss
+++ b/src/styles/components/_table-overrides.scss
@@ -9,6 +9,7 @@
 
 .ant-table-wrapper {
   table {
+    font-family: var(--neeto-ui-body-font-family) !important;
     thead {
       tr {
         th {

--- a/src/styles/components/_toast.scss
+++ b/src/styles/components/_toast.scss
@@ -68,8 +68,7 @@ body {
       box-shadow: var(--neeto-ui-toastr-box-shadow);
       border-radius: var(--neeto-ui-toastr-border-radius);
 
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-      "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !important;
+      font-family: var(--neeto-ui-body-font-family) !important;
 
       @include viewport(xs-mob) {
         max-width: calc(100% - 24px);

--- a/stories/Introduction/Welcome.stories.mdx
+++ b/stories/Introduction/Welcome.stories.mdx
@@ -34,7 +34,6 @@ import Team from "../assets/images/team.svg";
     line-height:1.1;
     -webkit-font-smoothing: initial;
     font-size: 40px;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   }
 
   .sbdocs .sbdocs-hero-banner__desc{
@@ -43,7 +42,6 @@ import Team from "../assets/images/team.svg";
     font-size: 18px;
     max-width:80ch;
     -webkit-font-smoothing: initial;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   }
 
   .sbdocs .sbdocs-hero-banner__desc a{
@@ -51,7 +49,6 @@ import Team from "../assets/images/team.svg";
     text-decoration: underline;
     -webkit-font-smoothing: initial;
     font-family: "Inter",sans-serif !important;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   }
 
   .sbdocs .sbdocs-hero-banner__title strong {
@@ -127,7 +124,6 @@ import Team from "../assets/images/team.svg";
     position: relative;
     color:#000 !important;
     -webkit-font-smoothing: initial;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   }
 
   .sbdocs-featured__item p{
@@ -135,7 +131,6 @@ import Team from "../assets/images/team.svg";
     -webkit-font-smoothing: initial;
     margin-top:0;
     font-size:16px;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   }
 
   .sbdocs-featured__item-link{
@@ -145,7 +140,6 @@ import Team from "../assets/images/team.svg";
     font-weight:500;
      -webkit-font-smoothing: initial;
     text-decoration: underline;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   }
 
   `}


### PR DESCRIPTION
- Fixes #2272 

**Description**

- Changed: default font family to Inter on Windows.
- Removed: font family overrides in Storybook.
- Fixed: the usage of CSS font variable.

@praveen-murali-ind _a

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
