### PR TITLE
Added documentation on handling server side validation errors in the form.

### DIFF
--- a/stories/Formik/Form.stories.jsx
+++ b/stories/Formik/Form.stories.jsx
@@ -46,7 +46,7 @@ const FormikStory = args => (
 FormikStory.storyName = "Form";
 FormikStory.args = { scrollToErrorField: true };
 
-const HandlingServerValidationErrors = args => {
+const HandlingServerValidationErrors = () => {
   const handleSubmit = (_, actions) =>
     new Promise(resolve => {
       setTimeout(() => {
@@ -59,14 +59,13 @@ const HandlingServerValidationErrors = args => {
   return (
     <Form
       formikProps={{
-        initialValues: { firstName: "", lastName: "", email: "" },
+        initialValues: { firstName: "", lastName: "", username: "" },
         validationSchema: yup.object().shape({
           firstName: yup.string().required(),
           username: yup.string().required(),
         }),
         onSubmit: handleSubmit,
       }}
-      {...args}
     >
       <div className="flex h-auto w-full flex-col items-start gap-4 p-6">
         <Input required className="w-80" label="First name" name="firstName" />

--- a/stories/Formik/Form.stories.jsx
+++ b/stories/Formik/Form.stories.jsx
@@ -33,10 +33,10 @@ const FormikStory = args => (
     }}
     {...args}
   >
-    <div className="flex h-40 w-full flex-col items-center space-y-4 p-10">
-      <Input required className="w-40" label="First name" name="firstName" />
-      <Input required className="w-40" label="Last name" name="lastName" />
-      <Input required className="w-40" label="Email" name="email" />
+    <div className="flex h-auto w-full flex-col items-start gap-4 p-6">
+      <Input required className="w-80" label="First name" name="firstName" />
+      <Input required className="w-80" label="Last name" name="lastName" />
+      <Input required className="w-80" label="Email" name="email" />
       <Button className="w-20" disabled={false} label="Submit" type="submit" />
     </div>
   </Form>

--- a/stories/Formik/Form.stories.jsx
+++ b/stories/Formik/Form.stories.jsx
@@ -6,6 +6,7 @@ import { Input, Button } from "formikcomponents";
 import Form from "formikcomponents/Form";
 
 import FormStoriesDocs from "!raw-loader!./FormStories.mdx";
+import ServerValidationErrorDocs from "!raw-loader!./ServerValidationErrors.mdx";
 
 const metadata = {
   title: "Formik/Form",
@@ -45,6 +46,50 @@ const FormikStory = args => (
 FormikStory.storyName = "Form";
 FormikStory.args = { scrollToErrorField: true };
 
-export { FormikStory };
+const HandlingServerValidationErrors = args => {
+  const handleSubmit = (_, actions) =>
+    new Promise(resolve => {
+      setTimeout(() => {
+        actions.setStatus({ username: "Username is already taken!" });
+        actions.setSubmitting(false);
+        resolve();
+      }, 2000);
+    });
+
+  return (
+    <Form
+      formikProps={{
+        initialValues: { firstName: "", lastName: "", email: "" },
+        validationSchema: yup.object().shape({
+          firstName: yup.string().required(),
+          username: yup.string().required(),
+        }),
+        onSubmit: handleSubmit,
+      }}
+      {...args}
+    >
+      <div className="flex h-auto w-full flex-col items-start gap-4 p-6">
+        <Input required className="w-80" label="First name" name="firstName" />
+        <Input required className="w-80" label="Last name" name="lastName" />
+        <Input required className="w-80" label="Username" name="username" />
+        <Button
+          className="w-20"
+          disabled={false}
+          label="Submit"
+          type="submit"
+        />
+      </div>
+    </Form>
+  );
+};
+
+HandlingServerValidationErrors.storyName =
+  "Handling server side validation errors";
+
+HandlingServerValidationErrors.parameters = {
+  docs: { description: { story: ServerValidationErrorDocs } },
+};
+
+export { FormikStory, HandlingServerValidationErrors };
 
 export default metadata;

--- a/stories/Formik/ServerValidationErrors.mdx
+++ b/stories/Formik/ServerValidationErrors.mdx
@@ -1,0 +1,16 @@
+Often times, we will have to handle server validation errors in the forms.
+It's not ideal to show toasts in such cases; the user would not get any clue about which
+field caused the error or what action they should take.
+
+The recommended way to handle this is to set the errors in the Formik state.
+Thus, the user could see the error near the field and act on it. The problem with using the errors
+state of Formik is that it gets mixed with the frontend validation schema, leading to unexpected
+results.
+
+To solve this, we have added a feature to the neetoUI Form and Formik components. We will use `status`
+in the Formik state to handle this. When there's a server-side validation error, you can set it in `status` as
+a key-value pair with the `key` as the field name and the `value` as the error using the `setStatus`
+helper from the Formik actions.
+
+The Formik components will show the set status as an inline error. It will reset the status when the user
+types in something in the field and additionally prevents submission if there are statuses set for some of the fields.

--- a/stories/Formik/ServerValidationErrors.mdx
+++ b/stories/Formik/ServerValidationErrors.mdx
@@ -1,13 +1,13 @@
-Often times, we will have to handle server validation errors in the forms.
+Often times, we will have to handle server-side validation errors in the forms.
 It's not ideal to show toasts in such cases; the user would not get any clue about which
 field caused the error or what action they should take.
 
-The recommended way to handle this is to set the errors in the Formik state.
-Thus, the user could see the error near the field and act on it. The problem with using the errors
+The recommended way to handle this is to set the `errors` in the Formik state.
+Thus, the user could see the error near the field and act on it. The problem with using the `errors`
 state of Formik is that it gets mixed with the frontend validation schema, leading to unexpected
 results.
 
-To solve this, we have added a feature to the neetoUI Form and Formik components. We will use `status`
+To solve this, we have added a feature to the NeetoUI Form and Formik components. We will use `status`
 in the Formik state to handle this. When there's a server-side validation error, you can set it in `status` as
 a key-value pair with the `key` as the field name and the `value` as the error using the `setStatus`
 helper from the Formik actions.


### PR DESCRIPTION
Fixes #2266 

**Description**
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/298408c6-60dc-4e29-a0c7-efb1c3350a29">

Main story UI
Before
<img width="914" alt="image" src="https://github.com/user-attachments/assets/d7121a93-ad2d-4ac7-9353-6c5706ab1752">

After
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/a322fb68-023c-4a3c-9ec1-d3a02238b5a6">

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [ ] ~I have updated the types definition of modified exports.~
- [ ] ~I have verified the functionality in some of the neeto web-apps.~
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
