### PR TITLE
Added optional chaining to prevent scrollTo being accessed on a null value

### DIFF
--- a/src/components/Table/hooks/useRestoreScrollPosition.js
+++ b/src/components/Table/hooks/useRestoreScrollPosition.js
@@ -28,7 +28,7 @@ export const useRestoreScrollPosition = ({ tableRef, scrollRef, loading }) => {
     setTimeout(() => {
       const position = scrollPositions[key];
       const config = position === 0 ? { index: 0 } : { top: position };
-      scrollRef.current.scrollTo(config);
+      scrollRef.current?.scrollTo(config);
     });
   }, [key, tableRef, loading]);
 


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-cal-web/issues/9611

**Description**

- Fixed: Fixed the scrollTo property of tables from being undefined.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] ~I have added tests that prove my fix is effective or that my feature works.~
- [x] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

patch _t
@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
