### PR TITLE
Fixed formik folder link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Available components in neetoUI formik:
 - Slider
 
 You can refer the
-[formik folder](https://github.com/bigbinary/neeto-ui/tree/main/src/components/formik)
-to check for latest Formik components.
+[formik folder](https://github.com/bigbinary/neeto-ui/tree/main/src/formik) to
+check for latest Formik components.
 
 In order to use the neetoUI formik components, you need to wrap your form with
 the `Form` component.


### PR DESCRIPTION
- Fixes #2247 

**Description**
- Fixed: Formik folder link in README.md

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
