### PR TITLE
Introduces a better Modal popup for unsaved changes in Forms.

### DIFF
--- a/src/formik/BlockNavigation/Alert.jsx
+++ b/src/formik/BlockNavigation/Alert.jsx
@@ -11,8 +11,6 @@ import { getLocale } from "utils";
 const Alert = ({
   isOpen = false,
   isSubmitting = false,
-  className = "",
-  closeOnOutsideClick = true,
   onClose,
   onSaveChanges,
   onDiscardChanges,
@@ -35,9 +33,10 @@ const Alert = ({
 
   return (
     <Modal
-      {...{ className, closeOnOutsideClick, isOpen, onClose }}
+      {...{ isOpen, onClose }}
       closeButton
       closeOnEsc
+      closeOnOutsideClick
       data-cy="alert-box"
       initialFocusRef={saveChangesButtonRef}
       size="medium"

--- a/src/formik/BlockNavigation/Alert.jsx
+++ b/src/formik/BlockNavigation/Alert.jsx
@@ -1,0 +1,76 @@
+/* eslint-disable @bigbinary/neeto/file-name-and-export-name-standards */
+import React, { useRef } from "react";
+
+import { useTranslation } from "react-i18next";
+
+import Button from "components/Button";
+import Modal from "components/Modal";
+import Typography from "components/Typography";
+import { getLocale } from "utils";
+
+const Alert = ({
+  isOpen = false,
+  isSubmitting = false,
+  className = "",
+  closeOnOutsideClick = true,
+  onClose,
+  onSaveChanges,
+  onDiscardChanges,
+}) => {
+  const { t, i18n } = useTranslation();
+
+  const saveChangesButtonRef = useRef(null);
+
+  const cancelButtonLabel = getLocale(
+    i18n,
+    t,
+    "neetoui.blockNavigation.cancelButtonLabel"
+  );
+
+  const submitButtonLabel = getLocale(
+    i18n,
+    t,
+    "neetoui.blockNavigation.submitButtonLabel"
+  );
+
+  return (
+    <Modal
+      {...{ className, closeOnOutsideClick, isOpen, onClose }}
+      closeButton
+      closeOnEsc
+      data-cy="alert-box"
+      initialFocusRef={saveChangesButtonRef}
+      size="medium"
+    >
+      <Modal.Header>
+        <Typography data-cy="alert-title" style="h2">
+          {getLocale(i18n, t, "neetoui.blockNavigation.alertTitle")}
+        </Typography>
+      </Modal.Header>
+      <Modal.Body>
+        <Typography data-cy="alert-message" lineHeight="normal" style="body2">
+          {getLocale(i18n, t, "neetoui.blockNavigation.alertMessage")}
+        </Typography>
+      </Modal.Body>
+      <Modal.Footer className="neeto-ui-gap-2 neeto-ui-flex neeto-ui-justify-end neeto-ui-items-center">
+        <Button
+          data-cy="alert-cancel-button"
+          label={cancelButtonLabel}
+          style="danger"
+          onClick={onDiscardChanges}
+        />
+        <Button
+          data-cy="alert-submit-button"
+          disabled={!isOpen}
+          label={submitButtonLabel}
+          loading={isSubmitting}
+          ref={saveChangesButtonRef}
+          style="primary"
+          onClick={onSaveChanges}
+        />
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default Alert;

--- a/src/formik/BlockNavigation/index.jsx
+++ b/src/formik/BlockNavigation/index.jsx
@@ -3,14 +3,12 @@ import React from "react";
 
 import { useFormikContext } from "formik";
 import PropTypes from "prop-types";
-import { useTranslation } from "react-i18next";
 
-import Alert from "components/Alert";
 import { useNavPrompt } from "hooks";
-import { getLocale } from "utils";
+
+import Alert from "./Alert";
 
 const BlockNavigation = ({ isDirty = false, ...otherProps }) => {
-  const { t, i18n } = useTranslation();
   const formikContext = useFormikContext();
   const shouldBlock =
     isDirty || (Boolean(formikContext) && Boolean(formikContext.dirty));
@@ -19,23 +17,27 @@ const BlockNavigation = ({ isDirty = false, ...otherProps }) => {
     shouldBlock,
   });
 
-  const continueAction = () => {
+  const handleDiscardChanges = () => {
     if (formikContext) formikContext.resetForm();
+    hidePrompt();
     continueNavigation();
+  };
+
+  const handleSaveChanges = () => {
+    if (formikContext.isValid) {
+      formikContext.submitForm();
+      continueNavigation();
+    } else formikContext.setTouched(formikContext.errors);
+
+    hidePrompt();
   };
 
   return (
     <Alert
       isOpen={isBlocked}
-      message={getLocale(i18n, t, "neetoui.blockNavigation.alertMessage")}
-      title={getLocale(i18n, t, "neetoui.blockNavigation.alertTitle")}
-      submitButtonLabel={getLocale(
-        i18n,
-        t,
-        "neetoui.blockNavigation.submitButtonLabel"
-      )}
       onClose={hidePrompt}
-      onSubmit={continueAction}
+      onDiscardChanges={handleDiscardChanges}
+      onSaveChanges={handleSaveChanges}
       {...otherProps}
     />
   );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2,7 +2,8 @@
   "neetoui": {
     "blockNavigation": {
       "alertMessage": "All of your unsaved changes will be lost. This can't be undone.",
-      "submitButtonLabel": "Discard changes",
+      "submitButtonLabel": "Save and continue",
+      "cancelButtonLabel": "Discard changes",
       "alertTitle": "You have unsaved changes"
     },
     "actionBlock": {

--- a/stories/Formik/BlockNavigation.stories.jsx
+++ b/stories/Formik/BlockNavigation.stories.jsx
@@ -33,7 +33,7 @@ const FormikStory = args => (
           />
           <Form
             formikProps={{
-              initialValues: { firstName: "", lastName: "" },
+              initialValues: { firstName: "Oliver", lastName: "" },
               validationSchema: yup.object({
                 firstName: yup.string().required("First name is required"),
                 lastName: yup.string().required("Last name is required"),

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -82,7 +82,10 @@ describe("formik/BlockNavigation", () => {
     expect(
       screen.getByRole("button", { name: "Discard changes" })
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: "Save and continue" })
+    ).toBeInTheDocument();
   });
 
   it("should close the modal and return to previous state on clicking the Cancel button", async () => {

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -169,4 +169,26 @@ describe("formik/BlockNavigation", () => {
     expect(screen.getByText(/Home page/i)).toBeInTheDocument();
     expect(mockSubmit).toBeCalledTimes(1);
   });
+
+  it("should not allow navigation and save the form if the Save and continue button is clicked and the form has an error", async () => {
+    render(<TestBlockNavigation isDirty />);
+
+    const lastNameInput = screen.getByPlaceholderText("Last name");
+    await userEvent.type(
+      lastNameInput,
+      repeat("{backspace}", lastName.length).join("")
+    );
+    expect(lastNameInput.value).toBe("");
+
+    await userEvent.click(screen.getByRole("link"));
+
+    const saveButton = screen.getByRole("button", {
+      name: "Save and continue",
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => expect(saveButton).not.toBeInTheDocument());
+    expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
+    expect(mockSubmit).not.toBeCalled();
+  });
 });

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -158,19 +158,4 @@ describe("formik/BlockNavigation", () => {
     expect(screen.getByText(/Home page/i)).toBeInTheDocument();
     expect(mockSubmit).toBeCalledTimes(1);
   });
-    await userEvent.type(input, "Testing save changes");
-
-    expect(input.value).toBe("Testing save changes");
-
-    await userEvent.click(screen.getByRole("link"));
-
-    const saveButton = screen.getByRole("button", {
-      name: "Save and continue",
-    });
-    await userEvent.click(saveButton);
-
-    await waitFor(() => expect(saveButton).not.toBeInTheDocument());
-    expect(screen.getByText(/Test page/i)).toBeInTheDocument();
-    expect(mockSubmit).toBeCalledTimes(1);
-  });
 });

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -88,17 +88,19 @@ describe("formik/BlockNavigation", () => {
     ).toBeInTheDocument();
   });
 
-  it("should close the modal and return to previous state on clicking the Cancel button", async () => {
+  it("should close the modal and return to previous state on clicking the close button", async () => {
     render(<TestBlockNavigation isDirty />);
 
     const input = screen.getByRole("textbox");
 
     await userEvent.click(screen.getByRole("link"));
 
-    const cancelButton = screen.getByRole("button", { name: "Cancel" });
-    await userEvent.click(cancelButton);
+    const alertCloseButton = screen.getByTestId("close-button");
+    await userEvent.click(alertCloseButton);
 
-    await waitFor(() => expect(cancelButton).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
     expect(input).toBeInTheDocument();
   });
 

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -11,7 +11,7 @@ import { Input } from "components";
 import BlockNavigation from "formikcomponents/BlockNavigation";
 import Form from "formikcomponents/Form";
 
-const TestComponent = () => <div>test page</div>;
+const TestComponent = () => <div>Test page</div>;
 const mockSubmit = jest.fn();
 const TestForm = ({ isDirty }) => (
   <>
@@ -53,14 +53,14 @@ describe("formik/BlockNavigation", () => {
     render(<TestBlockNavigation />);
 
     expect(screen.getByRole("textbox")).toBeInTheDocument();
-    expect(screen.queryByText(/test page/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Test page/i)).not.toBeInTheDocument();
   });
 
   it("should allow navigation when form is empty", async () => {
     render(<TestBlockNavigation />);
 
     await userEvent.click(screen.getByRole("link"));
-    expect(screen.getByText(/test page/i)).toBeInTheDocument();
+    expect(screen.getByText(/Test page/i)).toBeInTheDocument();
   });
 
   it("should not allow navigation when form isn't empty", async () => {
@@ -70,14 +70,14 @@ describe("formik/BlockNavigation", () => {
     await userEvent.type(input, "test");
     await userEvent.click(screen.getByRole("link"));
 
-    expect(screen.queryByText(/test page/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Test page/i)).not.toBeInTheDocument();
   });
 
   it("should not allow navigation if isDirty prop is true", async () => {
     render(<TestBlockNavigation isDirty />);
 
     await userEvent.click(screen.getByRole("link"));
-    expect(screen.queryByText(/test page/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Test page/i)).not.toBeInTheDocument();
   });
 
   it("should display an Alert modal with Continue and Cancel buttons", async () => {
@@ -115,9 +115,9 @@ describe("formik/BlockNavigation", () => {
 
     const input = screen.getByRole("textbox");
     await userEvent.type(input, repeat("{backspace}", "test".length).join(""));
-    await userEvent.type(input, "testing discard changes");
+    await userEvent.type(input, "Testing discard changes");
 
-    expect(input.value).toBe("testing discard changes");
+    expect(input.value).toBe("Testing discard changes");
 
     await userEvent.click(screen.getByRole("link"));
 
@@ -127,7 +127,28 @@ describe("formik/BlockNavigation", () => {
     await userEvent.click(continueButton);
 
     await waitFor(() => expect(continueButton).not.toBeInTheDocument());
-    expect(screen.getByText(/test page/i)).toBeInTheDocument();
+    expect(screen.getByText(/Test page/i)).toBeInTheDocument();
     expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("should allow navigation and save the form if the Save and continue button is clicked", async () => {
+    render(<TestBlockNavigation isDirty />);
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, repeat("{backspace}", "test".length).join(""));
+    await userEvent.type(input, "Testing save changes");
+
+    expect(input.value).toBe("Testing save changes");
+
+    await userEvent.click(screen.getByRole("link"));
+
+    const saveButton = screen.getByRole("button", {
+      name: "Save and continue",
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => expect(saveButton).not.toBeInTheDocument());
+    expect(screen.getByText(/Test page/i)).toBeInTheDocument();
+    expect(mockSubmit).toBeCalledTimes(1);
   });
 });

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -11,24 +11,25 @@ import { Input } from "components";
 import BlockNavigation from "formikcomponents/BlockNavigation";
 import Form from "formikcomponents/Form";
 
-const TestComponent = () => <div>Test page</div>;
+const firstName = "Oliver";
+const TestComponent = () => <div>Home page</div>;
 const mockSubmit = jest.fn();
 const TestForm = ({ isDirty }) => (
   <>
-    <Link to="/test">Navigate</Link>
+    <Link to="/home">Home</Link>
     <Form
       formikProps={{
-        initialValues: { formikInput: "test" },
+        initialValues: { firstName },
         onSubmit: mockSubmit,
       }}
     >
       <BlockNavigation {...{ isDirty }} />
-      <Field name="formikInput">
+      <Field name="firstName">
         {({ field }) => (
           <Input
             {...field}
-            label="Formik Input"
-            placeholder="Type Something"
+            label="First name"
+            placeholder="First name"
             type="text"
           />
         )}
@@ -43,7 +44,7 @@ const TestBlockNavigation = ({ isDirty }) => (
       <Route exact path="/">
         <TestForm {...{ isDirty }} />
       </Route>
-      <Route component={TestComponent} path="/test" />
+      <Route component={TestComponent} path="/home" />
     </Switch>
   </Router>
 );
@@ -53,31 +54,31 @@ describe("formik/BlockNavigation", () => {
     render(<TestBlockNavigation />);
 
     expect(screen.getByRole("textbox")).toBeInTheDocument();
-    expect(screen.queryByText(/Test page/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
   });
 
   it("should allow navigation when form is empty", async () => {
     render(<TestBlockNavigation />);
 
     await userEvent.click(screen.getByRole("link"));
-    expect(screen.getByText(/Test page/i)).toBeInTheDocument();
+    expect(screen.getByText(/Home page/i)).toBeInTheDocument();
   });
 
   it("should not allow navigation when form isn't empty", async () => {
     render(<TestBlockNavigation />);
 
     const input = screen.getByRole("textbox");
-    await userEvent.type(input, "test");
+    await userEvent.type(input, "Sam");
     await userEvent.click(screen.getByRole("link"));
 
-    expect(screen.queryByText(/Test page/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
   });
 
   it("should not allow navigation if isDirty prop is true", async () => {
     render(<TestBlockNavigation isDirty />);
 
     await userEvent.click(screen.getByRole("link"));
-    expect(screen.queryByText(/Test page/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
   });
 
   it("should display an Alert modal with Continue and Cancel buttons", async () => {
@@ -114,7 +115,10 @@ describe("formik/BlockNavigation", () => {
     render(<TestBlockNavigation isDirty />);
 
     const input = screen.getByRole("textbox");
-    await userEvent.type(input, repeat("{backspace}", "test".length).join(""));
+    await userEvent.type(
+      input,
+      repeat("{backspace}", firstName.length).join("")
+    );
     await userEvent.type(input, "Testing discard changes");
 
     expect(input.value).toBe("Testing discard changes");
@@ -127,7 +131,7 @@ describe("formik/BlockNavigation", () => {
     await userEvent.click(continueButton);
 
     await waitFor(() => expect(continueButton).not.toBeInTheDocument());
-    expect(screen.getByText(/Test page/i)).toBeInTheDocument();
+    expect(screen.getByText(/Home page/i)).toBeInTheDocument();
     expect(mockSubmit).not.toHaveBeenCalled();
   });
 
@@ -135,7 +139,25 @@ describe("formik/BlockNavigation", () => {
     render(<TestBlockNavigation isDirty />);
 
     const input = screen.getByRole("textbox");
-    await userEvent.type(input, repeat("{backspace}", "test".length).join(""));
+    await userEvent.type(
+      input,
+      repeat("{backspace}", firstName.length).join("")
+    );
+    await userEvent.type(input, "Testing save changes");
+
+    expect(input.value).toBe("Testing save changes");
+
+    await userEvent.click(screen.getByRole("link"));
+
+    const saveButton = screen.getByRole("button", {
+      name: "Save and continue",
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => expect(saveButton).not.toBeInTheDocument());
+    expect(screen.getByText(/Home page/i)).toBeInTheDocument();
+    expect(mockSubmit).toBeCalledTimes(1);
+  });
     await userEvent.type(input, "Testing save changes");
 
     expect(input.value).toBe("Testing save changes");


### PR DESCRIPTION
Fixes https://github.com/bigbinary/neeto-engineering-web/issues/732

**Description**
![blocknavigation-changes](https://github.com/user-attachments/assets/40c1504a-6f47-4e75-8a54-515cdd4e4991)

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
