### PR TITLE
Fixed disabled prop of Dropdown not working when a customTarget is used

### DIFF
--- a/src/components/Dropdown/index.jsx
+++ b/src/components/Dropdown/index.jsx
@@ -158,6 +158,7 @@ const Dropdown = ({
     >
       {customTarget ? (
         <span
+          {...{ onClick }}
           className={classnames({ "neeto-ui-cursor-not-allowed": disabled })}
         >
           {typeof customTarget === "function" ? customTarget() : customTarget}

--- a/src/components/Dropdown/index.jsx
+++ b/src/components/Dropdown/index.jsx
@@ -154,10 +154,12 @@ const Dropdown = ({
         onClose();
         setMounted(false);
       }}
-      {...{ plugins, ...otherProps, ...controlledProps }}
+      {...{ disabled, plugins, ...otherProps, ...controlledProps }}
     >
       {customTarget ? (
-        <span {...{ onClick }}>
+        <span
+          className={classnames({ "neeto-ui-cursor-not-allowed": disabled })}
+        >
           {typeof customTarget === "function" ? customTarget() : customTarget}
         </span>
       ) : (

--- a/tests/Dropdown.test.jsx
+++ b/tests/Dropdown.test.jsx
@@ -123,6 +123,18 @@ describe("Dropdown", () => {
     expect(listItems).toHaveLength(2);
   });
 
+  it("should not open dropdown on click of custom target if disabled", async () => {
+    const { getByText } = render(
+      <Dropdown disabled customTarget={<span>Click</span>} label="Dropdown">
+        {options}
+      </Dropdown>
+    );
+
+    await userEvent.click(getByText("Click"));
+    const listItems = screen.queryAllByRole("listitem");
+    expect(listItems).toHaveLength(0);
+  });
+
   it("should open another dropdown on click trigger when it is multilevel ", async () => {
     const { findByText } = render(
       <Dropdown isOpen label="Dropdown">


### PR DESCRIPTION
- Fixes #2288

**Description**

- Fixed: disabled prop of Dropdown not working when a customTarget is used

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@josephmathew900 _a 