### PR TITLE
Adds ability to set custom portal classes for enabling theming.

### DIFF
--- a/src/components/ActionDropdown.jsx
+++ b/src/components/ActionDropdown.jsx
@@ -23,10 +23,10 @@ const ActionDropdown = ({
   disabled = false,
   onClick = noop,
   buttonProps: { style, size, ...buttonProps } = {},
-  dropdownProps = {},
   className = "",
+  dropdownProps,
   children,
-  portalProps = {},
+  portalProps,
 }) => (
   <div className={classnames(["neeto-ui-action-dropdown", className])}>
     <Button
@@ -42,7 +42,7 @@ const ActionDropdown = ({
       buttonProps={{ size: size ?? buttonSize }}
       buttonStyle={style ?? buttonStyle}
       {...dropdownProps}
-      dropdownProps={{ ...dropdownProps.dropdownProps, ...portalProps }}
+      dropdownProps={{ ...dropdownProps?.dropdownProps, ...portalProps }}
     >
       {children}
     </Dropdown>

--- a/src/components/ActionDropdown.jsx
+++ b/src/components/ActionDropdown.jsx
@@ -26,6 +26,7 @@ const ActionDropdown = ({
   dropdownProps = {},
   className = "",
   children,
+  portalProps = {},
 }) => (
   <div className={classnames(["neeto-ui-action-dropdown", className])}>
     <Button
@@ -41,6 +42,7 @@ const ActionDropdown = ({
       buttonProps={{ size: size ?? buttonSize }}
       buttonStyle={style ?? buttonStyle}
       {...dropdownProps}
+      dropdownProps={{ ...dropdownProps.dropdownProps, ...portalProps }}
     >
       {children}
     </Dropdown>
@@ -80,6 +82,10 @@ ActionDropdown.propTypes = {
    * To specify the props to be passed to the Dropdown target.
    */
   dropdownProps: PropTypes.object,
+  /**
+   * To specify the props to be passed to the Dropdown portal.
+   */
+  portalProps: PropTypes.object,
   /**
    * To provide external classnames to ActionDropdown target wrapper.
    */

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -33,6 +33,7 @@ const ColorPicker = ({
   showHexValue = false,
   showTransparencyControl = false,
   showPicker = true,
+  portalProps,
 }) => {
   const [colorInternal, setColorInternal] = useState(color);
   const isInputChanged = useRef(false);
@@ -119,6 +120,7 @@ const ColorPicker = ({
       label={colorValue}
       position="bottom-start"
       {...dropdownProps}
+      dropdownProps={{ ...dropdownProps?.dropdownProps, ...portalProps }}
     >
       <div className="neeto-ui-colorpicker__popover">
         {colorPaletteProps && (
@@ -221,6 +223,10 @@ ColorPicker.propTypes = {
    * To show the color picker. Used to hide the picker in cases where only palette is required. By default it will be true.
    */
   showPicker: PropTypes.bool,
+  /**
+   * To specify the props to be passed to the dropdown portal.
+   */
+  portalProps: PropTypes.object,
 };
 
 export default ColorPicker;

--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -179,6 +179,10 @@ DatePicker.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * To provide external classnames to DatePicker popup.
+   */
+  popupClassName: PropTypes.string,
+  /**
    * To set the text to be displayed above the DatePicker.
    */
   label: PropTypes.string,

--- a/src/components/Dropdown/index.jsx
+++ b/src/components/Dropdown/index.jsx
@@ -109,8 +109,11 @@ const Dropdown = ({
     ? { visible: isOpen }
     : { onClickOutside: () => closeOnOutsideClick };
 
-  const { classNames: dropdownClassname, ...otherDropdownProps } =
-    dropdownProps;
+  const {
+    classNames: dropdownClassnames,
+    className: dropdownClassName,
+    ...otherDropdownProps
+  } = dropdownProps;
 
   const close = () => instance.hide();
 
@@ -139,7 +142,8 @@ const Dropdown = ({
           <div
             data-cy={`${hyphenize(label)}-dropdown-container`}
             className={classnames("neeto-ui-dropdown__popup", {
-              [dropdownClassname]: dropdownClassname,
+              [dropdownClassName]: dropdownClassName,
+              [dropdownClassnames]: dropdownClassnames,
             })}
             onClick={closeOnSelect ? close : noop}
             {...otherDropdownProps}

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -149,8 +149,13 @@ const ValueContainer = props => {
 };
 
 const MenuList = props => {
-  const { fetchMore, totalOptionsCount, isAsyncLoadOptionEnabled, options } =
-    props.selectProps;
+  const {
+    fetchMore,
+    totalOptionsCount,
+    isAsyncLoadOptionEnabled,
+    options,
+    menuListProps = {},
+  } = props.selectProps;
 
   const hasMore =
     isAsyncLoadOptionEnabled && totalOptionsCount > options.length;
@@ -177,6 +182,7 @@ const MenuList = props => {
   return (
     <components.MenuList
       {...props}
+      {...menuListProps}
       innerProps={{ ...props.innerProps, ["data-testid"]: "menu-list" }}
     >
       {props.children}
@@ -432,6 +438,10 @@ Select.propTypes = {
    * To specify the label for the button shown in multi select
    */
   addButtonLabel: PropTypes.string,
+  /**
+   * To specify the extra props to be passed to the menu list.
+   */
+  menuListProps: PropTypes.object,
 };
 
 export default Select;

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -154,7 +154,7 @@ const MenuList = props => {
     totalOptionsCount,
     isAsyncLoadOptionEnabled,
     options,
-    menuListProps = {},
+    portalProps = {},
   } = props.selectProps;
 
   const hasMore =
@@ -182,7 +182,7 @@ const MenuList = props => {
   return (
     <components.MenuList
       {...props}
-      {...menuListProps}
+      {...portalProps}
       innerProps={{ ...props.innerProps, ["data-testid"]: "menu-list" }}
     >
       {props.children}
@@ -441,7 +441,7 @@ Select.propTypes = {
   /**
    * To specify the extra props to be passed to the menu list.
    */
-  menuListProps: PropTypes.object,
+  portalProps: PropTypes.object,
 };
 
 export default Select;

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -184,6 +184,10 @@ TimePicker.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * To provide external classnames to TimePicker popup component.
+   */
+  popupClassName: PropTypes.string,
+  /**
    * To set the text to be displayed above the TimePicker.
    */
   label: PropTypes.string,

--- a/src/components/TreeSelect.jsx
+++ b/src/components/TreeSelect.jsx
@@ -30,6 +30,7 @@ const TreeSelect = forwardRef(
       treeData,
       treeDataSimpleMode = true,
       value,
+      popupClassName,
       ...otherProps
     },
     ref
@@ -76,7 +77,6 @@ const TreeSelect = forwardRef(
             }}
             data-cy="neeto-ui-tree-select-wrapper"
             dropdownStyle={{ zIndex: 100000 }}
-            popupClassName="neeto-ui-tree-select-dropdown"
             suffixIcon={<SuffixIcon />}
             treeNodeFilterProp={fieldNames?.label ?? "label"}
             value={value || undefined}
@@ -89,6 +89,10 @@ const TreeSelect = forwardRef(
                 {getLocale(i18n, t, "neetoui.treeSelect.noOptions")}
               </div>
             }
+            popupClassName={classnames(
+              "neeto-ui-tree-select-dropdown",
+              popupClassName
+            )}
             switcherIcon={props => (
               <div {...props}>
                 <SwitcherIcon />
@@ -118,6 +122,10 @@ TreeSelect.propTypes = {
    * To specify additional classes.
    */
   className: PropTypes.string,
+  /**
+   * To specify additional classes to the popup.
+   */
+  popupClassName: PropTypes.string,
   /**
    * To disable the TreeSelect component.
    */

--- a/stories/Components/ActionDropdown.stories.jsx
+++ b/stories/Components/ActionDropdown.stories.jsx
@@ -221,6 +221,43 @@ CSSCustomization.parameters = {
   docs: { description: { story: ActionDropdownCSSCustomization } },
 };
 
-export { Default, Styles, Sizes, CustomIcon, CSSCustomization };
+const PortalCustomClassName = args => {
+  const { Menu, MenuItem, Divider } = ActionDropdown;
+
+  return (
+    <div className="h-40">
+      <ActionDropdown {...args}>
+        <Menu>
+          {listItems.map((item, idx) => (
+            <MenuItem.Button key={idx} prefix={<Settings size={20} />}>
+              {item}
+            </MenuItem.Button>
+          ))}
+          <Divider />
+          <MenuItem.Button prefix={<Delete size={20} />} style="danger">
+            Delete
+          </MenuItem.Button>
+        </Menu>
+      </ActionDropdown>
+    </div>
+  );
+};
+
+PortalCustomClassName.storyName =
+  "ActionDropdown with custom classname for the dropdown menu";
+
+PortalCustomClassName.args = {
+  label: "Custom ActionDropdown",
+  portalProps: { classNames: "neeto-ui__action-menu" },
+};
+
+export {
+  Default,
+  Styles,
+  Sizes,
+  CustomIcon,
+  CSSCustomization,
+  PortalCustomClassName,
+};
 
 export default metadata;

--- a/stories/Components/ColorPicker.stories.jsx
+++ b/stories/Components/ColorPicker.stories.jsx
@@ -288,6 +288,33 @@ CSSCustomization.parameters = {
   docs: { description: { story: ColorPickerCSSCustomization } },
 };
 
+const PortalCustomClassName = ({ color, ...args }) => {
+  const [currentColor, setCurrentColor] = useState("#4558F9");
+
+  const onChange = value => {
+    action("onChange")(value);
+    setCurrentColor(value.hex);
+  };
+
+  useEffect(() => {
+    setCurrentColor(color || "#4558F9");
+  }, [color]);
+
+  return (
+    <div className="h-60 w-40">
+      <ColorPicker {...{ onChange }} color={currentColor} {...args} />
+    </div>
+  );
+};
+
+PortalCustomClassName.storyName =
+  "ColorPicker with custom classname for the dropdown menu";
+
+PortalCustomClassName.args = {
+  color: "#4558F9",
+  portalProps: { classNames: "neeto-ui__color-pallette-wrapper" },
+};
+
 export {
   Default,
   Sizes,
@@ -297,6 +324,7 @@ export {
   ShowTransparencyControl,
   OnlyPalettePicker,
   CSSCustomization,
+  PortalCustomClassName,
 };
 
 export default metadata;

--- a/stories/Components/DatePicker.stories.jsx
+++ b/stories/Components/DatePicker.stories.jsx
@@ -232,6 +232,18 @@ CSSCustomization.parameters = {
   docs: { description: { story: DateInputCSSCustomization } },
 };
 
+const PortalCustomClassName = args => <DatePicker {...args} />;
+
+PortalCustomClassName.storyName =
+  "DatePicker with custom class name for the popup menu";
+
+PortalCustomClassName.args = {
+  label: "DatePicker with custom class for the popup",
+  type: "date",
+  picker: "date",
+  popupClassName: "neeto-ui__date-picker-popup-wrapper",
+};
+
 export {
   Default,
   RequiredDatePicker,
@@ -244,6 +256,7 @@ export {
   ShowTime,
   MinAndMaxDate,
   CSSCustomization,
+  PortalCustomClassName,
 };
 
 export default metadata;

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -48,6 +48,7 @@ Default.args = {
   optionRemapping: {},
   options: OPTIONS,
   strategy: "fixed",
+  menuListProps: { className: "select-menu-list" },
 };
 
 const Sizes = args => (

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -48,7 +48,7 @@ Default.args = {
   optionRemapping: {},
   options: OPTIONS,
   strategy: "fixed",
-  menuListProps: { className: "select-menu-list" },
+  portalProps: { className: "select-menu-list" },
 };
 
 const Sizes = args => (

--- a/types/ActionDropdown.d.ts
+++ b/types/ActionDropdown.d.ts
@@ -11,6 +11,7 @@ export interface ActionDropdownProps {
   className?: string;
   buttonProps?: ButtonProps;
   dropdownProps?: DropdownProps;
+  portalProps?: object;
   /** @deprecated Prop deprecated. Use `buttonStyle` prop instead*/
   style?: "primary" | "secondary";
   /** @deprecated Prop deprecated. Use `buttonStyle` prop instead*/

--- a/types/ColorPicker.d.ts
+++ b/types/ColorPicker.d.ts
@@ -18,6 +18,7 @@ export interface ColorPickerProps {
   showTransparencyControl?: boolean;
   showPicker?: boolean;
   dropdownProps?: DropdownProps;
+  portalProps?: object;
 }
 
 const ColorPicker: React.FC<ColorPickerProps>;

--- a/types/DatePicker.d.ts
+++ b/types/DatePicker.d.ts
@@ -5,6 +5,7 @@ export type DatePickerProps = {
   value: any;
   defaultValue?: any;
   className?: string;
+  popupClassName?: string;
   label?: string;
   size?: "small" | "medium" | "large";
   dropdownClassName?: string;

--- a/types/Select.d.ts
+++ b/types/Select.d.ts
@@ -21,7 +21,7 @@ export type SelectProps = {
   isAsyncLoadOptionEnabled?: boolean;
   isMulti?: boolean;
   addButtonLabel?: string;
-  menuListProps?: object;
+  portalProps?: object;
 };
 
 const Select: React.ForwardRefExoticComponent<SelectProps>;

--- a/types/Select.d.ts
+++ b/types/Select.d.ts
@@ -21,6 +21,7 @@ export type SelectProps = {
   isAsyncLoadOptionEnabled?: boolean;
   isMulti?: boolean;
   addButtonLabel?: string;
+  menuListProps?: object;
 };
 
 const Select: React.ForwardRefExoticComponent<SelectProps>;

--- a/types/TimePicker.d.ts
+++ b/types/TimePicker.d.ts
@@ -3,6 +3,7 @@ import { LabelProps } from "./Label";
 
 export type TimePickerProps = {
   className?: string;
+  popupClassName?: string;
   label?: string;
   format?: string;
   placeholder?: string;

--- a/types/TreeSelect.d.ts
+++ b/types/TreeSelect.d.ts
@@ -18,6 +18,7 @@ type TreeItem = {
 export type TreeSelectProps = {
   allowClear?: Boolean;
   className?: string;
+  popupClassName?: string;
   disabled?: Boolean;
   error?: string;
   fieldNames?: { label?: string; value?: string };


### PR DESCRIPTION
Fixes https://github.com/bigbinary/neeto-form-nano/issues/628

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] ~I have verified the functionality in some of the neeto web-apps.~
- [x] ~I have added tests that prove my fix is effective or that my feature works.~
- [x] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
