### PR TITLE
Re-calculates the table height when select all rows callout is displayed.

### DIFF
--- a/src/components/Callout.jsx
+++ b/src/components/Callout.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import classnames from "classnames";
 import PropTypes from "prop-types";
@@ -10,35 +10,43 @@ const STYLES = {
   success: "success",
 };
 
-const Callout = ({
-  icon = null,
-  style = STYLES.info,
-  className = "",
-  children,
-  ...otherProps
-}) => {
-  const Icon = icon;
+const Callout = forwardRef(
+  (
+    {
+      icon = null,
+      style = STYLES.info,
+      className = "",
+      children,
+      ...otherProps
+    },
+    ref
+  ) => {
+    const Icon = icon;
 
-  return (
-    <div
-      className={classnames("neeto-ui-callout", {
-        "neeto-ui-callout--info": style === STYLES.info,
-        "neeto-ui-callout--warning": style === STYLES.warning,
-        "neeto-ui-callout--danger": style === STYLES.danger,
-        "neeto-ui-callout--success": style === STYLES.success,
-        [className]: className,
-      })}
-      {...otherProps}
-    >
-      {icon && (
-        <div className="neeto-ui-callout__icon" data-testid="callout-icon">
-          <Icon />
-        </div>
-      )}
-      {children}
-    </div>
-  );
-};
+    return (
+      <div
+        {...{ ref }}
+        className={classnames("neeto-ui-callout", {
+          "neeto-ui-callout--info": style === STYLES.info,
+          "neeto-ui-callout--warning": style === STYLES.warning,
+          "neeto-ui-callout--danger": style === STYLES.danger,
+          "neeto-ui-callout--success": style === STYLES.success,
+          [className]: className,
+        })}
+        {...otherProps}
+      >
+        {icon && (
+          <div className="neeto-ui-callout__icon" data-testid="callout-icon">
+            <Icon />
+          </div>
+        )}
+        {children}
+      </div>
+    );
+  }
+);
+
+Callout.displayName = "Callout";
 
 Callout.propTypes = {
   /**

--- a/src/components/Table/components/SelectAllRowsCallout.jsx
+++ b/src/components/Table/components/SelectAllRowsCallout.jsx
@@ -1,30 +1,37 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import Button from "../../Button";
 import Callout from "../../Callout";
 import Typography from "../../Typography";
 
-const SelectAllRowsCallout = ({
-  calloutProps,
-  onBulkSelectAllRows,
-  selectAllRowButtonLabel,
-  selectAllRowMessage,
-}) => (
-  <Callout
-    className="my-2"
-    {...calloutProps}
-    data-testid="select-all-rows-callout"
-  >
-    <div className="flex space-x-3">
-      <Typography style="body2">{selectAllRowMessage}</Typography>
-      <Button
-        data-testid="select-all-rows-button"
-        label={selectAllRowButtonLabel}
-        style="link"
-        onClick={onBulkSelectAllRows}
-      />
-    </div>
-  </Callout>
+const SelectAllRowsCallout = forwardRef(
+  (
+    {
+      calloutProps,
+      onBulkSelectAllRows,
+      selectAllRowButtonLabel,
+      selectAllRowMessage,
+    },
+    ref
+  ) => (
+    <Callout
+      className="my-2"
+      {...{ ...calloutProps, ref }}
+      data-testid="select-all-rows-callout"
+    >
+      <div className="flex space-x-3">
+        <Typography style="body2">{selectAllRowMessage}</Typography>
+        <Button
+          data-testid="select-all-rows-button"
+          label={selectAllRowButtonLabel}
+          style="link"
+          onClick={onBulkSelectAllRows}
+        />
+      </div>
+    </Callout>
+  )
 );
+
+SelectAllRowsCallout.displayName = "SelectAllRowsCallout";
 
 export default SelectAllRowsCallout;

--- a/src/components/Table/components/SelectAllRowsCallout.jsx
+++ b/src/components/Table/components/SelectAllRowsCallout.jsx
@@ -1,35 +1,30 @@
-import React, { forwardRef } from "react";
+import React from "react";
 
 import Button from "../../Button";
 import Callout from "../../Callout";
 import Typography from "../../Typography";
 
-const SelectAllRowsCallout = forwardRef(
-  (
-    {
-      calloutProps,
-      onBulkSelectAllRows,
-      selectAllRowButtonLabel,
-      selectAllRowMessage,
-    },
-    ref
-  ) => (
-    <Callout
-      className="my-2"
-      {...{ ...calloutProps, ref }}
-      data-testid="select-all-rows-callout"
-    >
-      <div className="flex space-x-3">
-        <Typography style="body2">{selectAllRowMessage}</Typography>
-        <Button
-          data-testid="select-all-rows-button"
-          label={selectAllRowButtonLabel}
-          style="link"
-          onClick={onBulkSelectAllRows}
-        />
-      </div>
-    </Callout>
-  )
+const SelectAllRowsCallout = ({
+  calloutProps,
+  onBulkSelectAllRows,
+  selectAllRowButtonLabel,
+  selectAllRowMessage,
+}) => (
+  <Callout
+    className="my-2"
+    {...{ ...calloutProps }}
+    data-testid="select-all-rows-callout"
+  >
+    <div className="flex space-x-3">
+      <Typography style="body2">{selectAllRowMessage}</Typography>
+      <Button
+        data-testid="select-all-rows-button"
+        label={selectAllRowButtonLabel}
+        style="link"
+        onClick={onBulkSelectAllRows}
+      />
+    </div>
+  </Callout>
 );
 
 SelectAllRowsCallout.displayName = "SelectAllRowsCallout";

--- a/src/components/Table/components/SelectAllRowsCallout.jsx
+++ b/src/components/Table/components/SelectAllRowsCallout.jsx
@@ -12,7 +12,7 @@ const SelectAllRowsCallout = ({
 }) => (
   <Callout
     className="my-2"
-    {...{ ...calloutProps }}
+    {...calloutProps}
     data-testid="select-all-rows-callout"
   >
     <div className="flex space-x-3">
@@ -26,7 +26,5 @@ const SelectAllRowsCallout = ({
     </div>
   </Callout>
 );
-
-SelectAllRowsCallout.displayName = "SelectAllRowsCallout";
 
 export default SelectAllRowsCallout;

--- a/src/components/Table/constants.js
+++ b/src/components/Table/constants.js
@@ -4,4 +4,5 @@ export const TABLE_SORT_ORDERS = { asc: "ascend", desc: "descend" };
 
 export const COLUMN_ADD_DIRECTION = { left: 0, right: 1 };
 
-export const SELECT_ALL_ROWS_CALLOUT_MARGIN = 16;
+export const SELECT_ALL_ROWS_CALLOUT_DESKTOP_HEIGHT = 57;
+export const SELECT_ALL_ROWS_CALLOUT_MOBILE_HEIGHT = 78;

--- a/src/components/Table/constants.js
+++ b/src/components/Table/constants.js
@@ -3,3 +3,5 @@ export const URL_SORT_ORDERS = { ascend: "asc", descend: "desc" };
 export const TABLE_SORT_ORDERS = { asc: "ascend", desc: "descend" };
 
 export const COLUMN_ADD_DIRECTION = { left: 0, right: 1 };
+
+export const SELECT_ALL_ROWS_CALLOUT_MARGIN = 16;

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -198,9 +198,9 @@ const Table = ({
     if (selectedRowKeys.length !== defaultPageSize) {
       setBulkSelectedAllRows(false);
       handleSetBulkSelectedAllRows?.(false);
-      tableWrapper.classList.remove("neeto-ui-overflow-hidden");
+      tableWrapper?.classList.remove("neeto-ui-overflow-hidden");
     } else {
-      tableWrapper.classList.add("neeto-ui-overflow-hidden");
+      tableWrapper?.classList.add("neeto-ui-overflow-hidden");
     }
     onRowSelect?.(selectedRowKeys, selectedRows);
   };

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -26,11 +26,15 @@ import { useQueryParams, useTimeout } from "hooks";
 import { ANT_DESIGN_GLOBAL_TOKEN_OVERRIDES, buildUrl, noop } from "utils";
 
 import SelectAllRowsCallout from "./components/SelectAllRowsCallout";
-import { SELECT_ALL_ROWS_CALLOUT_MARGIN, TABLE_SORT_ORDERS } from "./constants";
+import { TABLE_SORT_ORDERS } from "./constants";
 import useColumns from "./hooks/useColumns";
 import { useRestoreScrollPosition } from "./hooks/useRestoreScrollPosition";
 import useTableSort from "./hooks/useTableSort";
-import { getHeaderCell, isIncludedIn } from "./utils";
+import {
+  getHeaderCell,
+  getSelectAllRowsCalloutHeight,
+  isIncludedIn,
+} from "./utils";
 
 import Button from "../Button";
 import Typography from "../Typography";
@@ -249,10 +253,8 @@ const Table = ({
       otherProps.pagination !== false && rowData.length > pageSize;
 
     let selectAllRowsCalloutHeight = 0;
-    if (shouldShowSelectAllRowsCallout && selectAllRowsCalloutRef.current) {
-      selectAllRowsCalloutHeight =
-        selectAllRowsCalloutRef.current?.offsetHeight +
-        SELECT_ALL_ROWS_CALLOUT_MARGIN;
+    if (shouldShowSelectAllRowsCallout) {
+      selectAllRowsCalloutHeight = getSelectAllRowsCalloutHeight();
     }
 
     return (

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -96,7 +96,6 @@ const Table = ({
 
   const headerRef = useRef();
   const tableOnChangeProps = useRef({});
-  const selectAllRowsCalloutRef = useRef({});
 
   const resizeObserver = useRef(
     new ResizeObserver(([entry]) =>

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -369,7 +369,6 @@ const Table = ({
       {shouldShowSelectAllRowsCallout && (
         <SelectAllRowsCallout
           {...bulkSelectAllRowsProps}
-          ref={selectAllRowsCalloutRef}
           onBulkSelectAllRows={() => {
             setBulkSelectedAllRows(true);
             handleSetBulkSelectedAllRows?.(true);

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -26,7 +26,7 @@ import { useQueryParams, useTimeout } from "hooks";
 import { ANT_DESIGN_GLOBAL_TOKEN_OVERRIDES, buildUrl, noop } from "utils";
 
 import SelectAllRowsCallout from "./components/SelectAllRowsCallout";
-import { TABLE_SORT_ORDERS } from "./constants";
+import { SELECT_ALL_ROWS_CALLOUT_MARGIN, TABLE_SORT_ORDERS } from "./constants";
 import useColumns from "./hooks/useColumns";
 import { useRestoreScrollPosition } from "./hooks/useRestoreScrollPosition";
 import useTableSort from "./hooks/useTableSort";
@@ -92,6 +92,7 @@ const Table = ({
 
   const headerRef = useRef();
   const tableOnChangeProps = useRef({});
+  const selectAllRowsCalloutRef = useRef({});
 
   const resizeObserver = useRef(
     new ResizeObserver(([entry]) =>
@@ -186,6 +187,9 @@ const Table = ({
     [selectedRowKeys, rowKey, rowData, totalCount, bulkSelectedAllRows]
   );
 
+  const shouldShowSelectAllRowsCallout =
+    bulkSelectAllRowsProps && showBulkSelectionCallout;
+
   const handleRowChange = (selectedRowKeys, selectedRows) => {
     if (selectedRowKeys.length !== defaultPageSize) {
       setBulkSelectedAllRows(false);
@@ -237,10 +241,18 @@ const Table = ({
     const isPaginationVisible =
       otherProps.pagination !== false && rowData.length > pageSize;
 
+    let selectAllRowsCalloutHeight = 0;
+    if (shouldShowSelectAllRowsCallout && selectAllRowsCalloutRef.current) {
+      selectAllRowsCalloutHeight =
+        selectAllRowsCalloutRef.current?.offsetHeight +
+        SELECT_ALL_ROWS_CALLOUT_MARGIN;
+    }
+
     return (
       containerHeight -
       headerHeight -
-      (isPaginationVisible ? TABLE_PAGINATION_HEIGHT : 0)
+      (isPaginationVisible ? TABLE_PAGINATION_HEIGHT : 0) -
+      selectAllRowsCalloutHeight
     );
   };
 
@@ -345,9 +357,10 @@ const Table = ({
         },
       }}
     >
-      {bulkSelectAllRowsProps && showBulkSelectionCallout && (
+      {shouldShowSelectAllRowsCallout && (
         <SelectAllRowsCallout
           {...bulkSelectAllRowsProps}
+          ref={selectAllRowsCalloutRef}
           onBulkSelectAllRows={() => {
             setBulkSelectedAllRows(true);
             handleSetBulkSelectedAllRows?.(true);

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -191,9 +191,16 @@ const Table = ({
     bulkSelectAllRowsProps && showBulkSelectionCallout;
 
   const handleRowChange = (selectedRowKeys, selectedRows) => {
+    const tableWrapper = document.querySelector(
+      '[data-testid="table-wrapper"]'
+    );
+
     if (selectedRowKeys.length !== defaultPageSize) {
       setBulkSelectedAllRows(false);
       handleSetBulkSelectedAllRows?.(false);
+      tableWrapper.classList.remove("neeto-ui-overflow-hidden");
+    } else {
+      tableWrapper.classList.add("neeto-ui-overflow-hidden");
     }
     onRowSelect?.(selectedRowKeys, selectedRows);
   };

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -6,6 +6,10 @@ import {
   ReorderableHeaderCell,
   ResizableHeaderCell,
 } from "./components/HeaderCell";
+import {
+  SELECT_ALL_ROWS_CALLOUT_DESKTOP_HEIGHT,
+  SELECT_ALL_ROWS_CALLOUT_MOBILE_HEIGHT,
+} from "./constants";
 
 export const getHeaderCell = ({ enableColumnResize, enableColumnReorder }) => {
   if (enableColumnReorder && enableColumnResize) return { cell: HeaderCell };
@@ -19,3 +23,8 @@ export const getHeaderCell = ({ enableColumnResize, enableColumnReorder }) => {
 
 export const isIncludedIn = (array1, array2) =>
   all(includes(__, array1), array2);
+
+export const getSelectAllRowsCalloutHeight = () =>
+  window.innerWidth < 768
+    ? SELECT_ALL_ROWS_CALLOUT_MOBILE_HEIGHT
+    : SELECT_ALL_ROWS_CALLOUT_DESKTOP_HEIGHT;


### PR DESCRIPTION
Fixes #2286 

**Description**
https://deepak-jose.neetorecord.com/watch/ab0a7044-22de-4564-a015-0002ed390736

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
