### PR TITLE
Removed usage of git directly from the code

### DIFF
--- a/.storybook/express/index.js
+++ b/.storybook/express/index.js
@@ -5,7 +5,7 @@ const { execSync } = require("child_process");
 const server = express();
 const port = 3000;
 
-const commitHash = execSync("git rev-parse HEAD").toString().trim();
+const commitHash = process.env.NEETODEPLOY_SLUG_COMMIT;
 
 const generateUrlWithHash = req => {
   const parsedUrl = new URL(


### PR DESCRIPTION
`git` cli is not present in heroku-24 stack. For getting the commit hash we can use the `NEETODEPLOY_SLUG_COMMIT` env.

**Description**
- Removed usage of `git` from the codebase.



**Reviewers**

@AbhayVAshokan _a
