### PR TITLE
Replaced AntdTable loader  with NeetoUI Spinner

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -37,6 +37,7 @@ import {
 } from "./utils";
 
 import Button from "../Button";
+import Spinner from "../Spinner";
 import Typography from "../Typography";
 
 const TABLE_PAGINATION_HEIGHT = 64;
@@ -375,10 +376,11 @@ const Table = ({
         />
       )}
       <AntTable
-        {...{ bordered, loading, locale, rowKey }}
+        {...{ bordered, locale, rowKey }}
         columns={sortedColumnsWithAlignment}
         components={componentOverrides}
         dataSource={rowData}
+        loading={{ spinning: loading, indicator: <Spinner /> }}
         ref={tableRef}
         rowSelection={rowSelectionProps}
         showSorterTooltip={false}


### PR DESCRIPTION
- Fixes #2308 

**Description**
- Replaced AntdTable loader with NeetoUI Spinner.

### Before
<img width="1103" alt="Screenshot 2024-09-13 at 12 03 35 PM" src="https://github.com/user-attachments/assets/24602fa3-9cb9-487e-bcaa-e88ea73276c3">


### After
<img width="1438" alt="Screenshot 2024-09-13 at 12 58 28 PM" src="https://github.com/user-attachments/assets/ab934456-c014-4bdb-b03b-709333e98d6a">

<img width="1159" alt="Screenshot 2024-09-13 at 12 26 11 PM" src="https://github.com/user-attachments/assets/73317b59-15f5-429b-8458-359934b216de">

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
