### PR TITLE
Sets the initial frozen column based on the set columnData.

### DIFF
--- a/src/components/Table/hooks/useColumns.js
+++ b/src/components/Table/hooks/useColumns.js
@@ -1,6 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
-import { append, equals, props, without } from "ramda";
+import { append, equals, isEmpty, props, union, without } from "ramda";
 
 import useLocalStorage from "hooks/useLocalStorage";
 
@@ -30,6 +30,8 @@ const useColumns = ({
   isDefaultPageChangeHandler,
   localStorageKeyPrefix,
 }) => {
+  const didSetInitialFrozenColumnsRef = useRef(false);
+
   const [frozenColumns, setFrozenColumns] = useLocalStorage(
     getFrozenColumnsLocalStorageKey(localStorageKeyPrefix),
     getFixedColumns(columnData)
@@ -45,6 +47,14 @@ const useColumns = ({
     },
     [frozenColumns, setFrozenColumns]
   );
+
+  useEffect(() => {
+    if (isEmpty(columnData) || didSetInitialFrozenColumnsRef.current) return;
+
+    const fixedCols = getFixedColumns(columnData);
+    setFrozenColumns(union(fixedCols));
+    didSetInitialFrozenColumnsRef.current = true;
+  }, [columnData, setFrozenColumns]);
 
   const { dragProps } = useReorderColumns({
     isEnabled: isReorderEnabled,


### PR DESCRIPTION
- Fixes #2316 

**Description**
The existing implementation was ignoring the already set fixed columns. This will merge the frozen columns with the fixed columns in the columnData in the initial render.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
