### PR TITLE
Fixed datepicker timezone issue

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useState, useEffect } from "react";
 
 import { DatePicker as AntDatePicker } from "antd";
 import classnames from "classnames";
-import dayjs from "dayjs";
 import { isNotPresent } from "neetocist";
 import { Left, Right, Calendar, Close } from "neetoicons";
 import PropTypes from "prop-types";
@@ -10,7 +9,13 @@ import PropTypes from "prop-types";
 import { Tag } from "components";
 import Label from "components/Label";
 import { useSyncedRef, useId } from "hooks";
-import { convertToDayjsObjects, noop, hyphenize } from "utils";
+import {
+  convertToDayjsObjects,
+  noop,
+  hyphenize,
+  dayjs,
+  getTimezoneAppliedDateTime,
+} from "utils";
 
 import IconOverride from "./IconOverride";
 import Provider from "./Provider";
@@ -77,7 +82,12 @@ const DatePicker = forwardRef(
       if (type === "range" && isNotPresent(date)) {
         return onChange([], dateString);
       }
-      const allowed = getAllowed(date, minDate, maxDate);
+
+      const allowed = getAllowed(
+        getTimezoneAppliedDateTime(date),
+        minDate,
+        maxDate
+      );
       setValue(allowed);
 
       return onChange(allowed, formattedString(allowed, dateFormat));

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -16,6 +16,7 @@ import {
   hyphenize,
   ANT_DESIGN_GLOBAL_TOKEN_OVERRIDES,
   getLocale,
+  getTimezoneAppliedDateTime,
 } from "utils";
 
 import { TIME_PICKER_TYPES } from "./constants";
@@ -77,7 +78,7 @@ const TimePicker = forwardRef(
     const handleOnChange = (time, timeString) => {
       type === "range" && !time
         ? onChange([], timeString)
-        : onChange(time, timeString);
+        : onChange(getTimezoneAppliedDateTime(time), timeString);
     };
 
     const panelRender = originalPanel => (

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -42,15 +42,17 @@ const hasTimezone = dateString => {
 // eslint-disable-next-line import/exports-last
 export const dayjs = (...args) => {
   if (args.length > 0 && typeof args[0] === "string") {
-    if (hasTimezone(args[0])) {
-      args[0] = pureDayjs(args[0]);
-    } else {
-      const pureDayjsArgs = args.slice(0, Math.min(args.length, 2));
+    const pureDayjsArgs = args.slice(0, Math.min(args.length, 2));
 
+    if (hasTimezone(args[0])) {
+      args[0] = pureDayjs(...pureDayjsArgs);
+    } else {
       args[0] = pureDayjs(...pureDayjsArgs).format("YYYY-MM-DD HH:mm:ss");
       args[1] = "YYYY-MM-DD HH:mm:ss";
     }
   }
+
+  if (args[0]?.toString() === "Invalid Date") return pureDayjs(...args);
 
   const timezone = pureDayjs.tz().$x.$timezone || pureDayjs.tz.guess();
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -41,6 +41,13 @@ const hasTimezone = dateString => {
 
 // eslint-disable-next-line import/exports-last
 export const dayjs = (...args) => {
+  if (
+    pureDayjs.tz().$x.$timezone === pureDayjs.tz.guess() ||
+    pureDayjs.tz().$x.$timezone === undefined
+  ) {
+    return pureDayjs(...args);
+  }
+
   if (args.length > 0 && typeof args[0] === "string") {
     const pureDayjsArgs = args.slice(0, Math.min(args.length, 2));
 

--- a/stories/Components/DatePicker.stories.jsx
+++ b/stories/Components/DatePicker.stories.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 
-import dayjs from "dayjs";
-
 import { Modal, Typography, Pane, DatePicker } from "components";
 import Button from "components/Button";
+import { dayjs } from "utils";
 
 import { disabledDateTime } from "./constants";
 

--- a/stories/Components/TimePicker.stories.jsx
+++ b/stories/Components/TimePicker.stories.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 
-import dayjs from "dayjs";
-
 import { Modal, Typography, Pane } from "components";
 import Button from "components/Button";
 import TimePicker from "components/TimePicker";
+import { dayjs } from "utils";
 
 import { disabledDateTime } from "./constants";
 

--- a/tests/DatePicker.test.jsx
+++ b/tests/DatePicker.test.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import dayjs from "dayjs";
 
 import DatePicker from "components/DatePicker";
+import { dayjs } from "utils";
 
 const today = dayjs();
 const theDate = dayjs(new Date(1999, 7, 16));

--- a/tests/TimePicker.test.jsx
+++ b/tests/TimePicker.test.jsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { screen, render, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import dayjs from "dayjs";
 
 import { TimePicker } from "components";
+import { dayjs } from "utils";
 
 const currentTime = dayjs();
 const { getByRole, getByText, getAllByText, getAllByRole } = screen;


### PR DESCRIPTION
- Fixes #2324 

**Description**
- Fixed dayjs timezone issue with _DatePicker_ and _TimePicker_ components.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
