### PR TITLE
Added data-cy prop to Check and Close icon in Switch component

### DIFF
--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -50,9 +50,19 @@ const Switch = forwardRef(
               })}
             >
               {checked ? (
-                <Check data-testid="check-icon" size="12" strokeWidth={4} />
+                <Check
+                  data-cy="check-icon"
+                  data-testid="check-icon"
+                  size="12"
+                  strokeWidth={4}
+                />
               ) : (
-                <Close data-testid="close-icon" size="12" strokeWidth={3} />
+                <Close
+                  data-cy="close-icon"
+                  data-testid="close-icon"
+                  size="12"
+                  strokeWidth={3}
+                />
               )}
             </span>
           </label>


### PR DESCRIPTION
- Fixes #2328

**Description**
Added: `data-cy` prop to _Check_ and _Close_ icons in _Switch_ component.
**Checklist**

- [x] ~~I have made corresponding changes to the documentation.~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->

@VarunSriram99 _a
@shreyakurian02 _a
Please review this PR.