### PR TITLE
Fixes the formik submit handler returning a promise for synchronous submit handlers which in turn immediately sets the isSubmitting to false.

### DIFF
--- a/src/formik/Form/index.jsx
+++ b/src/formik/Form/index.jsx
@@ -13,7 +13,7 @@ const Form = forwardRef(
   ) => {
     const formikRef = useRef();
 
-    const handleSubmit = async (values, actions) => {
+    const handleSubmit = (values, actions) => {
       const fieldsWithServerError = getFieldsWithServerError(
         formikRef.current?.status
       );
@@ -21,10 +21,10 @@ const Form = forwardRef(
       if (fieldsWithServerError.length > 0) {
         actions.setSubmitting(false);
 
-        return;
+        return undefined;
       }
 
-      await formikProps.onSubmit(values, actions);
+      return formikProps.onSubmit(values, actions);
     };
 
     return (


### PR DESCRIPTION
- Fixes #2334 

**Description**
- The `async` `handleSubmit` will always return a `Promise`, even if the submit handler inside doesn’t return one. This leads to unexpected bugs, as the `Promise` resolves immediately when using the `mutate` function of `useMutation` while the API call might still be in progress.
- In Formik, if a Promise is returned, it waits for it to resolve before setting isSubmitting to false. In our case, this happens immediately after the button click.
- Since we weren’t returning the result of the submit handler, it consistently returned a Promise once the handler executed, which caused this behavior.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
