### PR TITLE
Improves the MultiEmailIput component interactions.

### DIFF
--- a/src/components/MultiEmailInput/constants.jsx
+++ b/src/components/MultiEmailInput/constants.jsx
@@ -131,17 +131,25 @@ const SelectContainer = props => (
   />
 );
 
-const Input = props => (
-  <components.Input
-    {...props}
-    data-cy="email-select-input-field"
-    onPaste={e => {
-      const clipboardData = e.clipboardData.getData("Text");
+const Input = props => {
+  const handlePaste = event => {
+    const { handleEmailChange } = props.selectProps;
 
-      setTimeout(() => props.selectProps.handleEmailChange(clipboardData));
-    }}
-  />
-);
+    const text = event.clipboardData.getData("Text");
+    if (!EMAIL_REGEX.test(text)) return;
+
+    event?.preventDefault();
+    setTimeout(() => handleEmailChange(text));
+  };
+
+  return (
+    <components.Input
+      {...props}
+      data-cy="email-select-input-field"
+      onPaste={handlePaste}
+    />
+  );
+};
 
 export const EMAIL_REGEX = new RegExp(
   "^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$",

--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -48,6 +48,7 @@ const MultiEmailInput = forwardRef(
     const [inputValue, setInputValue] = useState("");
     const [isFocused, setIsFocused] = useState(false);
     const [duplicateEmails, setDuplicateEmails] = useState([]);
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
 
     const isCounterVisible =
       !!counter &&
@@ -169,6 +170,7 @@ const MultiEmailInput = forwardRef(
           classNamePrefix="neeto-ui-react-select"
           components={CUSTOM_COMPONENTS}
           isDisabled={disabled}
+          menuIsOpen={isMenuOpen}
           className={classnames(
             "neeto-ui-react-select__container neeto-ui-react-select__container--medium neeto-ui-email-input__select",
             { "neeto-ui-react-select__container--error": !!error }
@@ -182,8 +184,11 @@ const MultiEmailInput = forwardRef(
           }}
           onBlur={handleBlur}
           onFocus={() => setIsFocused(true)}
-          onInputChange={inputValue => setInputValue(inputValue)}
           onKeyDown={handleKeyDown}
+          onInputChange={inputValue => {
+            setIsMenuOpen(Boolean(inputValue));
+            setInputValue(inputValue);
+          }}
           {...{
             handleEmailChange,
             inputValue,

--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -74,6 +74,7 @@ const MultiEmailInput = forwardRef(
       onChange(uniqueEmails);
       setDuplicateEmails(duplicates);
       setInputValue("");
+      setIsMenuOpen(false);
     };
 
     const handleKeyDown = event => {

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -290,4 +290,26 @@ describe("MultiEmailInput", () => {
       { label: "email@domain.com", valid: true, value: "email@domain.com" },
     ]);
   });
+
+  it("should not render the menu when clicked on the input field", async () => {
+    const onChange = jest.fn();
+    const selectedEmails = SAMPLE_EMAILS.slice(0, 2);
+    const { container } = render(
+      <MultiEmailInput
+        {...{ onChange }}
+        options={SAMPLE_EMAILS}
+        value={selectedEmails}
+      />
+    );
+    const emailInput = screen.getByRole("combobox");
+    await userEvent.click(emailInput);
+    expect(
+      container.querySelector(".neeto-ui-react-select__menu")
+    ).not.toBeInTheDocument();
+
+    await userEvent.type(emailInput, "test");
+    await expect(
+      container.querySelector(".neeto-ui-react-select__menu")
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes #2358 

**Description**
- Sets the dropdown menu open only when there's some text in the input field.
- When pasting some text, an email will be added only if it's a valid email or sets the pasted content as the input value so that user can finish or edit the pasted content.

![multiemailinput-improvements](https://github.com/user-attachments/assets/85e58265-d5eb-40f3-94d0-fcfdafaad46c)

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
