### PR TITLE
Set the getNow prop to the date picker so that the now will make use of dayjs that has timezone set.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@bigbinary/eslint-plugin-neeto": "^1.1.30",
     "@bigbinary/neeto-cist": "1.0.3",
     "@bigbinary/neeto-commons-frontend": "^3.0.10",
+    "@bigbinary/neeto-datepicker": "^1.0.4",
     "@bigbinary/neeto-hotkeys": "1.0.4",
     "@bigbinary/neeto-icons": "^1.9.22",
     "@reach/auto-id": "0.15.0",
@@ -228,7 +229,8 @@
     "@storybook/react/**/glob-parent": "5.1.2",
     "**/trim": "0.0.3",
     "tailwindcss/**/postcss": "7.0.36",
-    "cssnano/**/nth-check": "2.0.1"
+    "cssnano/**/nth-check": "2.0.1",
+    "rc-picker": "@bigbinary/neeto-datepicker"
   },
   "directories": {
     "src": "src"

--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -153,6 +153,7 @@ const DatePicker = forwardRef(
                 },
               }),
             }}
+            getNow={dayjs}
             nextIcon={<IconOverride icon={Right} />}
             prevIcon={<IconOverride icon={Left} />}
             superNextIcon={<IconOverride icon={Right} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,6 +2895,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.24.7":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -3046,6 +3053,18 @@
     util "^0.12.5"
     uuid "^9.0.0"
     zustand "4.3.2"
+
+"@bigbinary/neeto-datepicker@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@bigbinary/neeto-datepicker/-/neeto-datepicker-1.0.4.tgz#7759463468b63f8db18ac11b51af4dfc79f3813c"
+  integrity sha512-JlG0b+G3F3G0IadvcL/6f9jp4Kh56UMS9ctsYnHs8+oFhyqLm2BwfBDYd7/WEGFmTI97hch9/j6mCH2A6YCzMA==
+  dependencies:
+    "@babel/runtime" "^7.24.7"
+    "@rc-component/trigger" "^2.0.0"
+    classnames "^2.2.1"
+    rc-overflow "^1.3.2"
+    rc-resize-observer "^1.4.0"
+    rc-util "^5.43.0"
 
 "@bigbinary/neeto-hotkeys@1.0.4":
   version "1.0.4"
@@ -13990,6 +14009,14 @@ rc-util@^5.38.0, rc-util@^5.38.1, rc-util@^5.39.1:
   version "5.39.1"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.39.1.tgz#7bca4fb55e20add0eef5c23166cd9f9e5f51a8a1"
   integrity sha512-OW/ERynNDgNr4y0oiFmtes3rbEamXw7GHGbkbNd9iRr7kgT03T6fT0b9WpJ3mbxKhyOcAHnGcIoh5u/cjrC2OQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    react-is "^18.2.0"
+
+rc-util@^5.43.0:
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.43.0.tgz#bba91fbef2c3e30ea2c236893746f3e9b05ecc4c"
+  integrity sha512-AzC7KKOXFqAdIBqdGWepL9Xn7cm3vnAmjlHqUnoQaTMZYhM4VlXGLkkHHxj/BZ7Td0+SOPKB4RGPboBVKT9htw==
   dependencies:
     "@babel/runtime" "^7.18.3"
     react-is "^18.2.0"


### PR DESCRIPTION
- Fixes #2344 

**Description**
- Updated NeetoDatePicker to accept `getNow` as an optional prop and replaces the `generateConfig.getNow` with the external `getNow` when availabel.
- set the `getNow` prop with value `dayjs` which will return the current time in the set timezone.

Demo: https://deepak-jose.neetorecord.com/watch/ace8d14e-ca06-42ac-aaa9-affe51287990

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
