### PR TITLE
Revert "Disabled mask format in DatePicker and TimePicker (#2246)"

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -23,6 +23,11 @@ import Today from "./Today";
 import { getAllowed, formattedString } from "./utils";
 
 const INPUT_SIZES = { small: "small", medium: "medium", large: "large" };
+const DEFAULT_TIME_PICKER_PROPS = {
+  hourStep: 1,
+  minuteStep: 15,
+  secondStep: 10,
+};
 
 const { RangePicker } = AntDatePicker;
 
@@ -114,9 +119,9 @@ const DatePicker = forwardRef(
           {label && <Label {...{ required, ...labelProps }}>{label}</Label>}
           <Component
             data-cy={label ? `${hyphenize(label)}-input` : "picker-input"}
+            format={{ format, type: "mask" }}
             placeholder={placeholder ?? format}
             ref={datePickerRef}
-            showTime={showTime && { format: timeFormat, ...timePickerProps }}
             value={getAllowed(convertToDayjsObjects(value), minDate, maxDate)}
             className={classnames("neeto-ui-date-input", [className], {
               "neeto-ui-date-input--small": size === "small",
@@ -135,9 +140,15 @@ const DatePicker = forwardRef(
               dropdownClassName, // Will be removed in the next major version
               popupClassName,
             ])}
+            showTime={
+              showTime && {
+                format: timeFormat,
+                ...DEFAULT_TIME_PICKER_PROPS,
+                ...timePickerProps,
+              }
+            }
             onChange={handleOnChange}
             {...{
-              format,
               maxDate,
               minDate,
               onOk,

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -25,8 +25,8 @@ const INPUT_SIZES = { small: "small", medium: "medium", large: "large" };
 
 const TIME_PICKER_INTERVAL = {
   hourStep: 1,
-  minuteStep: 1,
-  secondStep: 1,
+  minuteStep: 15,
+  secondStep: 10,
 };
 
 const TimePicker = forwardRef(
@@ -135,6 +135,7 @@ const TimePicker = forwardRef(
         <div className="neeto-ui-input__wrapper">
           {label && <Label {...{ required, ...labelProps }}>{label}</Label>}
           <Component
+            format={{ format, type: "mask" }}
             hourStep={interval.hourStep}
             minuteStep={interval.minuteStep}
             ref={timePickerRef}
@@ -152,7 +153,7 @@ const TimePicker = forwardRef(
               popupClassName,
             ])}
             onChange={handleOnChange}
-            {...{ disabled, format, ...otherProps, panelRender }}
+            {...{ disabled, ...otherProps, panelRender }}
             defaultValue={convertToDayjsObjects(defaultValue)}
             mode={undefined}
             picker="time"

--- a/tests/DatePicker.test.jsx
+++ b/tests/DatePicker.test.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import dayjs from "dayjs";
 
 import DatePicker from "components/DatePicker";
 import { dayjs } from "utils";
@@ -142,19 +144,18 @@ describe("DatePicker", () => {
   });
 
   it("if selected date is before minDate then it should round to minDate", async () => {
-    const value = dayjs("2024-03-15");
     const minDate = dayjs("2024-03-14");
     const onChangeMock = jest.fn();
     render(
       <DatePicker
-        {...{ minDate, value }}
+        {...{ minDate }}
         placeholder="Select date"
         onChange={onChangeMock}
       />
     );
 
     const input = screen.getByPlaceholderText("Select date");
-    fireEvent.change(input, { target: { value: "10/10/2000" } });
+    await userEvent.type(input, "10102000");
     fireEvent.blur(input);
 
     await waitFor(() => {
@@ -167,19 +168,18 @@ describe("DatePicker", () => {
   });
 
   it("if selected date is after maxDate then it should round to maxDate", async () => {
-    const value = dayjs("2024-03-11");
     const maxDate = dayjs("2024-03-14");
     const onChangeMock = jest.fn();
     render(
       <DatePicker
-        {...{ maxDate, value }}
+        {...{ maxDate }}
         placeholder="Select date"
         onChange={onChangeMock}
       />
     );
 
     const input = screen.getByPlaceholderText("Select date");
-    fireEvent.change(input, { target: { value: "10/10/2025" } });
+    await userEvent.type(input, "10102025");
     fireEvent.blur(input);
 
     await waitFor(() => {

--- a/tests/TimePicker.test.jsx
+++ b/tests/TimePicker.test.jsx
@@ -67,7 +67,14 @@ describe("TimePicker", () => {
 
   it("should be able to select time in a range", async () => {
     const onChange = jest.fn();
-    render(<TimePicker {...{ onChange }} format="HH:mm:ss" type="range" />);
+    render(
+      <TimePicker
+        {...{ onChange }}
+        format="HH:mm:ss"
+        interval={{ hourStep: 1, minuteStep: 1, secondStep: 1 }}
+        type="range"
+      />
+    );
     const startTimeInput = getAllByRole("textbox")[0];
     const endTimeInput = getAllByRole("textbox")[1];
     await userEvent.click(startTimeInput);


### PR DESCRIPTION
This reverts commit 719150382f3b357c4f234f6416d72f91f54acec7.

**Description**

- Added: mask format to date and time pickers.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

patch _t

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
