### PR TITLE
Convert static `px` values to `rem` for improved accessibility and scalability

### DIFF
--- a/src/styles/components/_accordion.scss
+++ b/src/styles/components/_accordion.scss
@@ -11,18 +11,18 @@
   --neeto-ui-accordion-wrapper-border-radius: 0px;
 
   // Item
-  --neeto-ui-accordion-item-padding-x: 8px;
-  --neeto-ui-accordion-item-padding-y: 16px;
+  --neeto-ui-accordion-item-padding-x: 0.5rem;
+  --neeto-ui-accordion-item-padding-y: 1rem;
   --neeto-ui-accordion-item-font-size: var(--neeto-ui-text-base);
   --neeto-ui-accordion-item-font-weight: var(--neeto-ui-font-medium);
-  --neeto-ui-accordion-item-line-height: 16px;
+  --neeto-ui-accordion-item-line-height: 1rem;
   --neeto-ui-accordion-item-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-accordion-item-bg-color: transparent;
 
   // Drop
-  --neeto-ui-accordion-drop-padding-x: 8px;
-  --neeto-ui-accordion-drop-padding-top: 4px;
-  --neeto-ui-accordion-drop-padding-bottom: 16px;
+  --neeto-ui-accordion-drop-padding-x: 0.5rem;
+  --neeto-ui-accordion-drop-padding-top: 0.25rem;
+  --neeto-ui-accordion-drop-padding-bottom: 1rem;
   --neeto-ui-accordion-drop-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-accordion-drop-margin-bottom: 0px;
 
@@ -45,8 +45,8 @@
   background-color: var(--neeto-ui-accordion-outer-wrapper-bg-color);
 
   &--padded {
-    --neeto-ui-accordion-outer-wrapper-padding-x: 24px;
-    --neeto-ui-accordion-outer-wrapper-padding-y: 24px;
+    --neeto-ui-accordion-outer-wrapper-padding-x: 1.5rem;
+    --neeto-ui-accordion-outer-wrapper-padding-y: 1.5rem;
     --neeto-ui-accordion-outer-wrapper-border-radius: var(--neeto-ui-rounded-lg);
   }
 

--- a/src/styles/components/_avatar.scss
+++ b/src/styles/components/_avatar.scss
@@ -1,8 +1,8 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
   // Container
   --neeto-ui-avatar-container-border-radius: var(--neeto-ui-rounded);
-  --neeto-ui-avatar-container-width: 24px;
-  --neeto-ui-avatar-container-height: 24px;
+  --neeto-ui-avatar-container-width: 1.5rem;
+  --neeto-ui-avatar-container-height: 1.5rem;
 
   // Avatar
   --neeto-ui-avatar-width: 1.5rem;
@@ -10,8 +10,8 @@
   --neeto-ui-avatar-border-radius: var(--neeto-ui-rounded-full);
 
   // Status
-  --neeto-ui-avatar-status-width: 12px;
-  --neeto-ui-avatar-status-height: 12px;
+  --neeto-ui-avatar-status-width: 0.75rem;
+  --neeto-ui-avatar-status-height: 0.75rem;
   --neeto-ui-avatar-status-bg-color: var(--neeto-ui-white);
   --neeto-ui-avatar-status-border-width: 2px;
   --neeto-ui-avatar-status-border-color: rgb(var(--neeto-ui-white));
@@ -34,18 +34,18 @@
   }
 
   &--medium {
-    --neeto-ui-avatar-container-width: 32px;
-    --neeto-ui-avatar-container-height: 32px;
+    --neeto-ui-avatar-container-width: 2rem;
+    --neeto-ui-avatar-container-height: 2rem;
   }
 
   &--large {
-    --neeto-ui-avatar-container-width: 40px;
-    --neeto-ui-avatar-container-height: 40px;
+    --neeto-ui-avatar-container-width: 2.5rem;
+    --neeto-ui-avatar-container-height: 2.5rem;
   }
 
   &--xlarge {
-    --neeto-ui-avatar-container-width: 64px;
-    --neeto-ui-avatar-container-height: 64px;
+    --neeto-ui-avatar-container-width: 4rem;
+    --neeto-ui-avatar-container-height: 4rem;
   }
 
   .neeto-ui-avatar__status {
@@ -61,18 +61,18 @@
     z-index: 4;
 
     &.neeto-ui-avatar__status-medium {
-      --neeto-ui-avatar-status-width: 12px;
-      --neeto-ui-avatar-status-height: 12px;
+      --neeto-ui-avatar-status-width: 0.75rem;
+      --neeto-ui-avatar-status-height: 0.75rem;
     }
 
     &.neeto-ui-avatar__status-large {
-      --neeto-ui-avatar-status-width: 14px;
-      --neeto-ui-avatar-status-height: 14px;
+      --neeto-ui-avatar-status-width: 0.875rem;
+      --neeto-ui-avatar-status-height: 0.875rem;
     }
 
     &.neeto-ui-avatar__status-xlarge {
-      --neeto-ui-avatar-status-width: 16px;
-      --neeto-ui-avatar-status-height: 16px;
+      --neeto-ui-avatar-status-width: 1rem;
+      --neeto-ui-avatar-status-height: 1rem;
     }
 
     &.online {

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -1,16 +1,16 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-btn-padding-x: 8px;
-  --neeto-ui-btn-padding-y: 6px;
+  --neeto-ui-btn-padding-x: 0.5rem;
+  --neeto-ui-btn-padding-y: 0.375rem;
   --neeto-ui-btn-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-btn-font-weight: var(--neeto-ui-font-medium);
-  --neeto-ui-btn-line-height: 16px;
+  --neeto-ui-btn-line-height: 1rem;
   --neeto-ui-btn-color: rgb(var(--neeto-ui-black));
   --neeto-ui-btn-bg-color: transparent;
   --neeto-ui-btn-border-width: 0;
   --neeto-ui-btn-border-color: transparent;
   --neeto-ui-btn-border-radius: var(--neeto-ui-rounded);
-  --neeto-ui-btn-gap: 4px;
-  --neeto-ui-btn-icon-size: 16px;
+  --neeto-ui-btn-gap: 0.25rem;
+  --neeto-ui-btn-icon-size: 1rem;
   --neeto-ui-btn-box-shadow: none;
   --neeto-ui-btn-outline: none;
 
@@ -60,8 +60,8 @@
   cursor: pointer;
 
   &.neeto-ui-btn--icon-only {
-    --neeto-ui-btn-padding-x: 6px;
-    --neeto-ui-btn-padding-y: 6px;
+    --neeto-ui-btn-padding-x: 0.375rem;
+    --neeto-ui-btn-padding-y: 0.375rem;
 
     .neeto-ui-btn__icon,
     .neeto-ui-btn__spinner svg {
@@ -73,23 +73,23 @@
 
   // size - medium - 32px
   &--size-medium {
-    --neeto-ui-btn-padding-x: 16px;
-    --neeto-ui-btn-padding-y: 8px;
-    --neeto-ui-btn-gap: 8px;
-    --neeto-ui-btn-icon-size: 20px;
+    --neeto-ui-btn-padding-x: 1rem;
+    --neeto-ui-btn-padding-y: 0.5rem;
+    --neeto-ui-btn-gap: 0.5rem;
+    --neeto-ui-btn-icon-size: 1.25rem;
   }
 
   // size - large - 40px
   &--size-large {
     --neeto-ui-btn-font-size: var(--neeto-ui-text-base);
-    --neeto-ui-btn-padding-x: 20px;
-    --neeto-ui-btn-padding-y: 12px;
-    --neeto-ui-btn-gap: 10px;
-    --neeto-ui-btn-icon-size: 24px;
+    --neeto-ui-btn-padding-x: 1.25rem;
+    --neeto-ui-btn-padding-y: 0.75rem;
+    --neeto-ui-btn-gap: 0.625rem;
+    --neeto-ui-btn-icon-size: 1.5rem;
 
     &.neeto-ui-btn--icon-only {
-      --neeto-ui-btn-padding-x: 8px;
-      --neeto-ui-btn-padding-y: 8px;
+      --neeto-ui-btn-padding-x: 0.5rem;
+      --neeto-ui-btn-padding-y: 0.5rem;
     }
   }
 

--- a/src/styles/components/_checkbox.scss
+++ b/src/styles/components/_checkbox.scss
@@ -1,5 +1,5 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-checkbox-size: 16px;
+  --neeto-ui-checkbox-size: 1rem;
   --neeto-ui-checkbox-color: rgb(var(--neeto-ui-primary-500));
   --neeto-ui-checkbox-border-width: 2px;
   --neeto-ui-checkbox-border-color: rgb(var(--neeto-ui-gray-400));
@@ -24,7 +24,7 @@
   --neeto-ui-checkbox-checked-border-color: rgb(var(--neeto-ui-primary-500));
 
   // Margin
-  --neeto-ui-checkbox-label-margin: 8px;
+  --neeto-ui-checkbox-label-margin: 0.5rem;
   --neeto-ui-checkbox-label-line-height: 1.2;
 }
 

--- a/src/styles/components/_color-picker.scss
+++ b/src/styles/components/_color-picker.scss
@@ -1,18 +1,18 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
   // Popover
-  --neeto-ui-colorpicker-popover-width: 224px;
-  --neeto-ui-colorpicker-popover-padding: 12px;
+  --neeto-ui-colorpicker-popover-width: 14rem;
+  --neeto-ui-colorpicker-popover-padding: 0.75rem;
 
   // Pointer
-  --neeto-ui-colorpicker-pointer-width: 20px;
-  --neeto-ui-colorpicker-pointer-height: 20px;
+  --neeto-ui-colorpicker-pointer-width: 1.25rem;
+  --neeto-ui-colorpicker-pointer-height: 1.25rem;
 
   // Palette Wrapper
-  --neeto-ui-colorpicker-palette-wrapper-margin-bottom: 12px;
+  --neeto-ui-colorpicker-palette-wrapper-margin-bottom: 0.75rem;
 
   // Palette Item
-  --neeto-ui-colorpicker-palette-item-width: 32px;
-  --neeto-ui-colorpicker-palette-item-height: 32px;
+  --neeto-ui-colorpicker-palette-item-width: 2rem;
+  --neeto-ui-colorpicker-palette-item-height: 2rem;
   --neeto-ui-colorpicker-palette-item-border-width: 1px;
   --neeto-ui-colorpicker-palette-item-border-color: transparent;
   --neeto-ui-colorpicker-palette-item-border-radius: var(--neeto-ui-rounded-md);
@@ -20,16 +20,16 @@
   --neeto-ui-colorpicker-palette-item-margin-left: 1.25px;
 
   // Target Wrapper
-  --neeto-ui-colorpicker-target-wrapper-gap: 8px;
+  --neeto-ui-colorpicker-target-wrapper-gap: 0.5rem;
 
   // Target
   --neeto-ui-colorpicker-target-bg-color: rgb(var(--neeto-ui-white));
   --neeto-ui-colorpicker-target-border-radius: var(--neeto-ui-rounded);
   --neeto-ui-colorpicker-target-border-width: 1px;
   --neeto-ui-colorpicker-target-border-color: rgb(var(--neeto-ui-gray-400));
-  --neeto-ui-colorpicker-target-height: 28px;
-  --neeto-ui-colorpicker-target-padding: 8px;
-  --neeto-ui-colorpicker-target-gap: 12px;
+  --neeto-ui-colorpicker-target-height: 1.75rem;
+  --neeto-ui-colorpicker-target-padding: 0.5rem;
+  --neeto-ui-colorpicker-target-gap: 0.75rem;
 
   // Targer: Hover
   --neeto-ui-colorpicker-target-hover-border-color: rgb(var(--neeto-ui-gray-700));
@@ -41,14 +41,14 @@
 
   // Target - Color
   --neeto-ui-colorpicker-target-color-block-border-radius: var(--neeto-ui-rounded);
-  --neeto-ui-colorpicker-target-color-block-width: 20px;
-  --neeto-ui-colorpicker-target-color-block-height: 20px;
+  --neeto-ui-colorpicker-target-color-block-width: 1.25rem;
+  --neeto-ui-colorpicker-target-color-block-height: 1.25rem;
 
   // Target - Hexcode
   --neeto-ui-colorpicker-target-hexcode-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-colorpicker-target-hexcode-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-colorpicker-target-hexcode-font-weight: var(--neeto-ui-font-medium);
-  --neeto-ui-colorpicker-target-hexcode-min-width: 72px;
+  --neeto-ui-colorpicker-target-hexcode-min-width: 4.5rem;
 }
 
 .neeto-ui-colorpicker__dropdown{
@@ -151,17 +151,17 @@
   }
 
   &-size--medium {
-    --neeto-ui-colorpicker-target-height: 32px;
-    --neeto-ui-colorpicker-target-padding: 8px;
-    --neeto-ui-colorpicker-target-color-block-width: 24px;
-    --neeto-ui-colorpicker-target-color-block-height: 24px;
+    --neeto-ui-colorpicker-target-height: 2rem;
+    --neeto-ui-colorpicker-target-padding: 0.5rem;
+    --neeto-ui-colorpicker-target-color-block-width: 1.5rem;
+    --neeto-ui-colorpicker-target-color-block-height: 1.5rem;
   }
 
   &-size--large {
-    --neeto-ui-colorpicker-target-height: 40px;
-    --neeto-ui-colorpicker-target-padding: 12px;
-    --neeto-ui-colorpicker-target-color-block-width: 24px;
-    --neeto-ui-colorpicker-target-color-block-height: 24px;
+    --neeto-ui-colorpicker-target-height: 2.5rem;
+    --neeto-ui-colorpicker-target-padding: 0.75rem;
+    --neeto-ui-colorpicker-target-color-block-width: 1.5rem;
+    --neeto-ui-colorpicker-target-color-block-height: 1.5rem;
   }
 }
 

--- a/src/styles/components/_date-time-picker.scss
+++ b/src/styles/components/_date-time-picker.scss
@@ -22,12 +22,12 @@
 
   // Prefix & Suffix
   --neeto-ui-date-input-prefix-suffix-color: rgb(var(--neeto-ui-gray-700));
-  --neeto-ui-date-input-prefix-suffix-size: 16px;
+  --neeto-ui-date-input-prefix-suffix-size: 1rem;
   --neeto-ui-date-input-focus-prefix-suffix-color: rgb(var(--neeto-ui-gray-700));
 
   // Cell
   --neeto-ui-date-input-cell-font-size: var(--neeto-ui-text-sm);
-  --neeto-ui-date-input-cell-height: 32px;
+  --neeto-ui-date-input-cell-height: 2rem;
   --neeto-ui-date-input-cell-border-radius: var(--neeto-ui-rounded-sm);
   --neeto-ui-date-input-cell-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-date-input-cell-hover-bg-color: rgb(var(--neeto-ui-gray-200));
@@ -42,12 +42,12 @@
 
   // Footer
   --neeto-ui-date-input-footer-bg-color: rgb(var(--neeto-ui-gray-100));
-  --neeto-ui-date-input-footer-btn-padding-x: 8px;
-  --neeto-ui-date-input-footer-btn-padding-y: 5px;
-  --neeto-ui-date-input-footer-btn-gap: 4px;
+  --neeto-ui-date-input-footer-btn-padding-x: 0.5rem;
+  --neeto-ui-date-input-footer-btn-padding-y: 0.3125rem;
+  --neeto-ui-date-input-footer-btn-gap: 0.25rem;
   --neeto-ui-date-input-footer-btn-font-size: var(--neeto-ui-text-xs);
   --neeto-ui-date-input-footer-btn-font-weight: var(--neeto-ui-font-medium);
-  --neeto-ui-date-input-footer-btn-line-height: 16px;
+  --neeto-ui-date-input-footer-btn-line-height: 1rem;
   --neeto-ui-date-input-footer-btn-border-radius: var(--neeto-ui-rounded);
   --neeto-ui-date-input-footer-today-now-btn-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-date-input-footer-today-now-btn-hover-color: rgb(var(--neeto-ui-gray-800));
@@ -60,14 +60,14 @@
   --neeto-ui-date-input-footer-ok-btn-disabled-opacity: 0.5;
 
   // Date Panel
-  --neeto-ui-date-panel-width: 320px;
-  --neeto-ui-date-panel-content-width: 272px;
+  --neeto-ui-date-panel-width: 20rem;
+  --neeto-ui-date-panel-content-width: 17rem;
   --neeto-ui-date-panel-content-header-color: rgb(var(--neeto-ui-gray-600));
   --neeto-ui-date-panel-content-header-font-size: var(--neeto-ui-text-xs);
 
 
   // Date Panel Dropdown
-  --neeto-ui-date-panel-dropdown-padding-y: 2px;
+  --neeto-ui-date-panel-dropdown-padding-y: 0.125rem;
 
   // Date Panel Container
   --neeto-ui-date-panel-container-border-width: 1px;
@@ -77,31 +77,31 @@
 
   // Date Panel Header
   --neeto-ui-date-panel-header-color: rgb(var(--neeto-ui-gray-800));
-  --neeto-ui-date-panel-header-min-height: 68px;
-  --neeto-ui-date-panel-header-padding-top: 12px;
+  --neeto-ui-date-panel-header-min-height: 4.25rem;
+  --neeto-ui-date-panel-header-padding-top: 0.75rem;
   --neeto-ui-date-panel-header-padding-bottom: 0px;
-  --neeto-ui-date-panel-header-padding-x: 24px;
+  --neeto-ui-date-panel-header-padding-x: 1.5rem;
   --neeto-ui-date-panel-header-border-bottom-width: 0px;
   --neeto-ui-date-panel-header-nav-btn-font-size: var(--neeto-ui-text-base);
   --neeto-ui-date-panel-header-nav-btn-font-weight: var(--neeto-ui-font-semibold);
-  --neeto-ui-date-panel-header-nav-btn-padding-right: 24px;
+  --neeto-ui-date-panel-header-nav-btn-padding-right: 1.5rem;
   --neeto-ui-date-panel-header-btn-color: rgb(var(--neeto-ui-gray-800));
 
   // Time Panel
-  --neeto-ui-time-panel-header-padding-top: 16px;
-  --neeto-ui-time-panel-header-padding-bottom: 8px;
-  --neeto-ui-time-panel-header-padding-x: 16px;
+  --neeto-ui-time-panel-header-padding-top: 1rem;
+  --neeto-ui-time-panel-header-padding-bottom: 0.5rem;
+  --neeto-ui-time-panel-header-padding-x: 1rem;
   --neeto-ui-time-panel-header-column-font-size: var(--neeto-ui-text-xs);
-  --neeto-ui-time-panel-header-column-line-height: 16px;
+  --neeto-ui-time-panel-header-column-line-height: 1rem;
   --neeto-ui-time-panel-header-column-color: rgb(var(--neeto-ui-gray-600));
-  --neeto-ui-time-panel-header-column-gap: 12px;
-  --neeto-ui-time-panel-body-gap: 12px;
-  --neeto-ui-time-panel-body-padding-x: 16px;
-  --neeto-ui-time-panel-column-width: 62px;
+  --neeto-ui-time-panel-header-column-gap: 0.75rem;
+  --neeto-ui-time-panel-body-gap: 0.75rem;
+  --neeto-ui-time-panel-body-padding-x: 1rem;
+  --neeto-ui-time-panel-column-width: 3.875rem;
   --neeto-ui-time-panel-column-border-left-color: rgb(var(--neeto-ui-gray-200));
   --neeto-ui-time-panel-cell-padding-x: 0px;
   --neeto-ui-time-panel-cell-color: rgb(var(--neeto-ui-gray-800));
-  --neeto-ui-time-panel-now-btn-margin-bottom: 22px;
+  --neeto-ui-time-panel-now-btn-margin-bottom: 1.375rem;
 
   // Time Input
   --neeto-ui-time-input-font-size: var(--neeto-ui-text-sm);
@@ -125,7 +125,7 @@
 
   // Prefix & Suffix
   --neeto-ui-time-input-prefix-suffix-color: rgb(var(--neeto-ui-gray-700));
-  --neeto-ui-time-input-prefix-suffix-size: 16px;
+  --neeto-ui-time-input-prefix-suffix-size: 1rem;
   --neeto-ui-time-input-focus-prefix-suffix-color: rgb(var(--neeto-ui-gray-700));
 
   // Date Time Picker
@@ -151,22 +151,23 @@
   box-shadow: var(--neeto-ui-date-input-box-shadow);
 
   &.neeto-ui-date-input--large {
-    --neeto-ui-date-input-padding-x: 12px;
-    --neeto-ui-date-input-padding-y: 8px;
+    --neeto-ui-date-input-padding-x: 0.75rem;
+    --neeto-ui-date-input-padding-y: 0.5rem;
   }
 
   &.neeto-ui-date-input--medium {
-    --neeto-ui-date-input-padding-x: 8px;
-    --neeto-ui-date-input-padding-y: 4px;
+    --neeto-ui-date-input-padding-x: 0.5rem;
+    --neeto-ui-date-input-padding-y: 0.25rem;
   }
 
   &.neeto-ui-date-input--small {
-    --neeto-ui-date-input-padding-x: 8px;
-    --neeto-ui-date-input-padding-y: 2px;
+    --neeto-ui-date-input-padding-x: 0.5rem;
+    --neeto-ui-date-input-padding-y: 0.125rem;
   }
 
   .ant-picker-input > input {
     color: var(--neeto-ui-date-input-color);
+    font-size: var(--neeto-ui-date-input-font-size);
   }
 
   &:hover:not(.neeto-ui-date-input--naked, .neeto-ui-date-input--disabled, .ant-picker-focused) {
@@ -242,18 +243,18 @@
   box-shadow: var(--neeto-ui-time-input-box-shadow);
 
   &.neeto-ui-time-input--large {
-    --neeto-ui-time-input-padding-x: 12px;
-    --neeto-ui-time-input-padding-y: 8px;
+    --neeto-ui-time-input-padding-x: 0.75rem;
+    --neeto-ui-time-input-padding-y: 0.5rem;
   }
 
   &.neeto-ui-time-input--medium {
-    --neeto-ui-time-input-padding-x: 8px;
-    --neeto-ui-time-input-padding-y: 4px;
+    --neeto-ui-time-input-padding-x: 0.5rem;
+    --neeto-ui-time-input-padding-y: 0.25rem;
   }
 
   &.neeto-ui-time-input--small {
-    --neeto-ui-time-input-padding-x: 8px;
-    --neeto-ui-time-input-padding-y: 2px;
+    --neeto-ui-time-input-padding-x: 0.5rem;
+    --neeto-ui-time-input-padding-y: 0.125rem;
   }
 
   &:hover:not(.neeto-ui-time-input--naked, .neeto-ui-time-input--disabled) {
@@ -364,8 +365,8 @@
     .ant-picker-body {
 
       @include viewport(xs-mob) {
-        padding-left: 8px;
-        padding-right: 8px;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
       }
 
       .ant-picker-content {
@@ -490,8 +491,8 @@
     border-bottom: var(--neeto-ui-date-panel-header-border-bottom-width);
 
     @include viewport(xs-mob) {
-      padding-left: 8px;
-      padding-right: 8px;
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
     }
   }
 
@@ -511,7 +512,7 @@
       right: 0;
       top: 0;
       height: 100%;
-      width: 16px;
+      width: 1rem;
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' height='16' width='16'%3E%3Cpath d='M6 9L12 15L18 9' stroke='%232f3941' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3C/svg%3E");
       background-repeat: no-repeat;
       background-position: center;
@@ -527,7 +528,7 @@
     width: var(--neeto-ui-date-panel-width);
 
     @include viewport(xs-mob) {
-      width: 296px;
+      width: 18.5rem;
     }
   }
 
@@ -633,7 +634,7 @@
   }
 }
 .ant-picker-ranges > li {
-  margin-right: 8px;
+  margin-right: 0.5rem;
 }
 
 .ant-picker-ranges .ant-picker-preset > .ant-tag-blue {
@@ -697,6 +698,6 @@
 }
 
 .neetix-datetimepicker {
-  --neeto-ui-date-time-picker-gap: 2px;
-  --neeto-ui-date-time-picker-border-radius: 4px;
+  --neeto-ui-date-time-picker-gap: 0.125rem;
+  --neeto-ui-date-time-picker-border-radius: 0.25rem;
 }

--- a/src/styles/components/_date-time-picker.scss
+++ b/src/styles/components/_date-time-picker.scss
@@ -257,6 +257,11 @@
     --neeto-ui-time-input-padding-y: 0.125rem;
   }
 
+  .ant-picker-input > input {
+    color: var(--neeto-ui-time-input-color);
+    font-size: var(--neeto-ui-time-input-font-size);
+  }
+
   &:hover:not(.neeto-ui-time-input--naked, .neeto-ui-time-input--disabled) {
     border-color: var(--neeto-ui-time-input-hover-border-color);
   }

--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -1,6 +1,6 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
   --neeto-ui-dropdown-margin-x: 0px;
-  --neeto-ui-dropdown-margin-y: 6px;
+  --neeto-ui-dropdown-margin-y: 0.375rem;
   --neeto-ui-dropdown-padding-x: 0px;
   --neeto-ui-dropdown-padding-y: 0px;
   --neeto-ui-dropdown-border-width: 1px;
@@ -10,27 +10,27 @@
 
   // Popup
   --neeto-ui-dropdown-popup-width: auto;
-  --neeto-ui-dropdown-popup-min-width: 168px;
-  --neeto-ui-dropdown-popup-max-height: 480px;
+  --neeto-ui-dropdown-popup-min-width: 10.5rem;
+  --neeto-ui-dropdown-popup-max-height: 30rem;
   --neeto-ui-dropdown-popup-bg-color: rgb(var(--neeto-ui-white));
   --neeto-ui-dropdown-popup-border-radius: var(--neeto-ui-rounded);
   --neeto-ui-dropdown-popup-z-index: 99999;
 
   // Popup Menu
   --neeto-ui-dropdown-popup-menu-padding-x: 0px;
-  --neeto-ui-dropdown-popup-menu-padding-y: 4px;
+  --neeto-ui-dropdown-popup-menu-padding-y: 0.25rem;
 
   // Item
-  --neeto-ui-dropdown-item-padding-y: 6px;
-  --neeto-ui-dropdown-item-padding-x: 12px;
+  --neeto-ui-dropdown-item-padding-y: 0.375rem;
+  --neeto-ui-dropdown-item-padding-x: 0.75rem;
   --neeto-ui-dropdown-item-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-dropdown-item-font-weight: var(--neeto-ui-font-normal);
   --neeto-ui-dropdown-item-line-height: 1.143;
   --neeto-ui-dropdown-item-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-dropdown-item-bg-color: rgb(var(--neeto-ui-white));
   --neeto-ui-dropdown-item-white-space: nowrap;
-  --neeto-ui-dropdown-item-min-height: 32px;
-  --neeto-ui-dropdown-item-gap: 8px;
+  --neeto-ui-dropdown-item-min-height: 2rem;
+  --neeto-ui-dropdown-item-gap: 0.5rem;
   --neeto-ui-dropdown-item-border-radius: 0px;
 
   // Item - Active
@@ -49,7 +49,7 @@
   // Divider
   --neeto-ui-dropdown-divider-height: 1px;
   --neeto-ui-dropdown-divider-bg-color: rgb(var(--neeto-ui-gray-200));
-  --neeto-ui-dropdown-divider-margin: 4px;
+  --neeto-ui-dropdown-divider-margin: 0.25rem;
 }
 
 .neeto-ui-dropdown {
@@ -76,7 +76,7 @@
   z-index: var(--neeto-ui-dropdown-popup-z-index);
 
   @media (max-height: 1000px) {
-    max-height: calc(40vh - 50px);
+    max-height: calc(40vh - 3.125rem);
   }
 
   li,

--- a/src/styles/components/_email-input.scss
+++ b/src/styles/components/_email-input.scss
@@ -1,13 +1,13 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
   // Label Wrapper
-  --neeto-ui-multi-email-input-label-wrapper-gap: 8px;
+  --neeto-ui-multi-email-input-label-wrapper-gap: 0.5rem;
   --neeto-ui-multi-email-input-counter-color: rgb(var(--neeto-ui-gray-700));
   --neeto-ui-multi-email-input-counter-line-height: 1;
-  --neeto-ui-multi-email-input-counter-margin-bottom: 8px;
+  --neeto-ui-multi-email-input-counter-margin-bottom: 0.5rem;
 
   // Prefx & Suffix
-  --neeto-ui-multi-email-input-prefix-suffix-icon-size: 16px;
-  --neeto-ui-multi-email-input-prefix-margin-left: 12px;
+  --neeto-ui-multi-email-input-prefix-suffix-icon-size: 1rem;
+  --neeto-ui-multi-email-input-prefix-margin-left: 0.75rem;
 }
 
 .neeto-ui-email-input__wrapper {
@@ -58,7 +58,7 @@
   .neeto-ui-email-input__suffix,
   .neeto-ui-email-input__prefix{
     line-height: 1.1;
-    min-height: 16px;
+    min-height: 1rem;
   }
 }
 

--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -3,11 +3,11 @@
   --neeto-ui-input-wrapper-flex-grow: 1;
 
   // Label Wrapper
-  --neeto-ui-input-label-wrapper-gap: 8px;
+  --neeto-ui-input-label-wrapper-gap: 0.5rem;
 
   // Label
   --neeto-ui-input-label-overflow-wrap: break-word;
-  --neeto-ui-input-label-margin: 8px;
+  --neeto-ui-input-label-margin: 0.5rem;
 
   // Max Length
   --neeto-ui-input-max-length-font-size: var(--neeto-ui-text-sm);
@@ -30,7 +30,7 @@
   --neeto-ui-textarea-padding-x: 0px;
   --neeto-ui-textarea-padding-y: 0px;
   --neeto-ui-textarea-line-height: 1.5;
-  --neeto-ui-textarea-max-height: 224px;
+  --neeto-ui-textarea-max-height: 14rem;
 
   // Placeholder
   --neeto-ui-input-placeholder-color: rgb(var(--neeto-ui-gray-400));
@@ -50,26 +50,26 @@
   --neeto-ui-input-prefix-suffix-color: rgb(var(--neeto-ui-gray-700));
   --neeto-ui-input-prefix-suffix-bg-color: transparent;
   --neeto-ui-input-prefix-suffix-line-height: 1;
-  --neeto-ui-input-prefix-suffix-icon-size: 16px;
+  --neeto-ui-input-prefix-suffix-icon-size: 1rem;
   --neeto-ui-input-prefix-suffix-margin: 0px;
   --neeto-ui-input-prefix-suffix-padding-x: 0px;
   --neeto-ui-input-prefix-suffix-border-width: 0px;
   --neeto-ui-input-prefix-suffix-border-color: transparent;
 
   // Help Text
-  --neeto-ui-input-help-text-margin: 8px;
+  --neeto-ui-input-help-text-margin: 0.5rem;
   --neeto-ui-input-help-text-font-size: var(--neeto-ui-text-xs);
   --neeto-ui-input-help-text-color: rgb(var(--neeto-ui-gray-700));
   --neeto-ui-input-help-text-line-height: 1.1;
 
   // Warning Text
-  --neeto-ui-input-warning-text-margin: 8px;
+  --neeto-ui-input-warning-text-margin: 0.5rem;
   --neeto-ui-input-warning-text-font-size: var(--neeto-ui-text-xs);
   --neeto-ui-input-warning-text-color: rgb(var(--neeto-ui-warning-800));
   --neeto-ui-input-warning-text-line-height: 1.1;
 
   // Error Text
-  --neeto-ui-input-error-text-margin: 8px;
+  --neeto-ui-input-error-text-margin: 0.5rem;
   --neeto-ui-input-error-text-font-size: var(--neeto-ui-text-xs);
   --neeto-ui-input-error-text-color: rgb(var(--neeto-ui-error-800));
   --neeto-ui-input-error-text-line-height: 1.1;
@@ -213,36 +213,36 @@
     }
 
     &.neeto-ui-input--small {
-      --neeto-ui-input-padding-x: 8px;
-      --neeto-ui-input-padding-y: 4px;
-      --neeto-ui-input-min-height: 26px;
+      --neeto-ui-input-padding-x: 0.5rem;
+      --neeto-ui-input-padding-y: 0.25rem;
+      --neeto-ui-input-min-height: 1.625rem;
 
-      --neeto-ui-input-prefix-suffix-margin: 8px;
+      --neeto-ui-input-prefix-suffix-margin: 0.5rem;
 
-      --neeto-ui-textarea-padding-x: 8px;
-      --neeto-ui-textarea-padding-y: 4px;
+      --neeto-ui-textarea-padding-x: 0.5rem;
+      --neeto-ui-textarea-padding-y: 0.25rem;
     }
 
     &.neeto-ui-input--medium {
-      --neeto-ui-input-padding-x: 8px;
-      --neeto-ui-input-padding-y: 5px;
-      --neeto-ui-input-min-height: 30px;
+      --neeto-ui-input-padding-x: 0.5rem;
+      --neeto-ui-input-padding-y: 0.3125rem;
+      --neeto-ui-input-min-height: 1.875rem;
 
-      --neeto-ui-input-prefix-suffix-margin: 8px;
+      --neeto-ui-input-prefix-suffix-margin: 0.5rem;
 
-      --neeto-ui-textarea-padding-x: 8px;
-      --neeto-ui-textarea-padding-y: 8px;
+      --neeto-ui-textarea-padding-x: 0.5rem;
+      --neeto-ui-textarea-padding-y: 0.5rem;
     }
 
     &.neeto-ui-input--large {
-      --neeto-ui-input-padding-x: 12px;
-      --neeto-ui-input-padding-y: 8px;
-      --neeto-ui-input-min-height: 38px;
+      --neeto-ui-input-padding-x: 0.75rem;
+      --neeto-ui-input-padding-y: 0.5rem;
+      --neeto-ui-input-min-height: 2.375rem;
 
-      --neeto-ui-input-prefix-suffix-margin: 12px;
+      --neeto-ui-input-prefix-suffix-margin: 0.75rem;
 
-      --neeto-ui-textarea-padding-x: 12px;
-      --neeto-ui-textarea-padding-y: 12px;
+      --neeto-ui-textarea-padding-x: 0.75rem;
+      --neeto-ui-textarea-padding-y: 0.75rem;
     }
 
     &.neeto-ui-input--naked {
@@ -258,7 +258,7 @@
 
     &.neeto-ui-input--block-add-on {
       --neeto-ui-input-prefix-suffix-margin: 0px;
-      --neeto-ui-input-prefix-suffix-padding-x: 12px;
+      --neeto-ui-input-prefix-suffix-padding-x: 0.75rem;
       --neeto-ui-input-prefix-suffix-bg-color: rgb(var(--neeto-ui-gray-100));
       --neeto-ui-input-prefix-suffix-border-width: 1px;
       --neeto-ui-input-prefix-suffix-border-color: rgb(var(--neeto-ui-gray-400));

--- a/src/styles/components/_kbd.scss
+++ b/src/styles/components/_kbd.scss
@@ -4,9 +4,9 @@
   --neeto-ui-kbd-color: rgb(var(--neeto-ui-gray-700));
   --neeto-ui-kbd-bg-color: rgb(var(--neeto-ui-gray-200));
   --neeto-ui-kbd-border-radius: var(--neeto-ui-rounded);
-  --neeto-ui-kbd-min-width: 24px;
-  --neeto-ui-kbd-height: 24px;
-  --neeto-ui-kbd-padding: 4px;
+  --neeto-ui-kbd-min-width: 1.5rem;
+  --neeto-ui-kbd-height: 1.5rem;
+  --neeto-ui-kbd-padding: 0.25rem;
 }
 
 .neeto-ui-kbd {
@@ -28,6 +28,6 @@
   --neeto-ui-kbd-color: rgb(var(--neeto-ui-primary-800));
   --neeto-ui-kbd-bg-color: rgb(var(--neeto-ui-primary-100));
   --neeto-ui-kbd-border-radius: var(--neeto-ui-rounded-sm);
-  --neeto-ui-kbd-min-width: 32px;
-  --neeto-ui-kbd-height: 32px;
+  --neeto-ui-kbd-min-width: 2rem;
+  --neeto-ui-kbd-height: 2rem;
 }

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -1,5 +1,5 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-modal-spacing: 24px;
+  --neeto-ui-modal-spacing: 1.5rem;
 
   // Backdrop
   --neeto-ui-modal-backdrop-z-index: var(--neeto-ui-modal-z-index);
@@ -20,12 +20,12 @@
 
   // Header
   --neeto-ui-modal-header-padding-top: var(--neeto-ui-modal-spacing);
-  --neeto-ui-modal-header-padding-right: 64px;
-  --neeto-ui-modal-header-padding-bottom: 16px;
+  --neeto-ui-modal-header-padding-right: 4rem;
+  --neeto-ui-modal-header-padding-bottom: 1rem;
   --neeto-ui-modal-header-padding-left: var(--neeto-ui-modal-spacing);
 
   // Header Description
-  --neeto-ui-modal-header-description-margin-top: 8px;
+  --neeto-ui-modal-header-description-margin-top: 0.5rem;
   --neeto-ui-modal-header-description-color: rgb(var(--neeto-ui-gray-700));
 
   // Body
@@ -36,7 +36,7 @@
   --neeto-ui-modal-body-line-height: 1.5;
 
   // Footer
-  --neeto-ui-modal-footer-padding-y: 16px;
+  --neeto-ui-modal-footer-padding-y: 1rem;
   --neeto-ui-modal-footer-padding-x: var(--neeto-ui-modal-spacing);
   --neeto-ui-modal-footer-bg: rgb(var(--neeto-ui-gray-100));
   --neeto-ui-modal-footer-border-radius: var(--neeto-ui-rounded-xl);
@@ -97,15 +97,15 @@
     }
 
     &.neeto-ui-modal__wrapper--small {
-      --neeto-ui-modal-wrapper-width: 320px;
+      --neeto-ui-modal-wrapper-width: 20rem;
     }
 
     &.neeto-ui-modal__wrapper--medium {
-      --neeto-ui-modal-wrapper-width: 480px;
+      --neeto-ui-modal-wrapper-width: 30rem;
     }
 
     &.neeto-ui-modal__wrapper--large {
-      --neeto-ui-modal-wrapper-width: 720px;
+      --neeto-ui-modal-wrapper-width: 45rem;
     }
 
     &.neeto-ui-modal__wrapper--fullscreen {
@@ -113,7 +113,7 @@
       --neeto-ui-modal-wrapper-max-width: 100vw;
       --neeto-ui-modal-wrapper-height: 100%;
       --neeto-ui-modal-wrapper-border-radius: var(--neeto-ui-rounded-none);
-      --neeto-ui-modal-header-padding-top: 28px;
+      --neeto-ui-modal-header-padding-top: 1.75rem;
 
       max-height: 100vh;
       transform: scale(1);
@@ -181,13 +181,13 @@
 }
 
 .neetix-alert, .neetix-modal {
-  --neeto-ui-modal-close-btn-top: 32px;
-  --neeto-ui-modal-close-btn-right: 32px;
-  --neeto-ui-modal-header-padding-top: 32px;
-  --neeto-ui-modal-header-padding-left: 32px;
-  --neeto-ui-modal-body-padding-bottom: 32px;
-  --neeto-ui-modal-body-padding-x: 32px;
-  --neeto-ui-modal-footer-padding-bottom: 32px;
-  --neeto-ui-modal-footer-padding-x: 32px;
+  --neeto-ui-modal-close-btn-top: 2rem;
+  --neeto-ui-modal-close-btn-right: 2rem;
+  --neeto-ui-modal-header-padding-top: 2rem;
+  --neeto-ui-modal-header-padding-left: 2rem;
+  --neeto-ui-modal-body-padding-bottom: 2rem;
+  --neeto-ui-modal-body-padding-x: 2rem;
+  --neeto-ui-modal-footer-padding-bottom: 2rem;
+  --neeto-ui-modal-footer-padding-x: 2rem;
   --neeto-ui-modal-wrapper-border-radius: var(--neeto-ui-rounded-none);
 }

--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -1,9 +1,9 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-pagination-item-padding-x: 4px;
-  --neeto-ui-pagination-item-padding-y: 4px;
-  --neeto-ui-pagination-item-width: 28px;
-  --neeto-ui-pagination-item-height: 28px;
-  --neeto-ui-pagination-item-margin-x: 4px;
+  --neeto-ui-pagination-item-padding-x: 0.25rem;
+  --neeto-ui-pagination-item-padding-y: 0.25rem;
+  --neeto-ui-pagination-item-width: 1.75rem;
+  --neeto-ui-pagination-item-height: 1.75rem;
+  --neeto-ui-pagination-item-margin-x: 0.25rem;
   --neeto-ui-pagination-item-margin-y: 0px;
   --neeto-ui-pagination-item-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-pagination-item-font-weight: var(--neeto-ui-font-medium);
@@ -104,8 +104,8 @@
 }
 
 .neetix-pagination {
-  --neeto-ui-pagination-item-width: 32px;
-  --neeto-ui-pagination-item-height: 32px;
+  --neeto-ui-pagination-item-width: 2rem;
+  --neeto-ui-pagination-item-height: 2rem;
   --neeto-ui-pagination-item-active-border-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-pagination-item-active-bg-color: rgb(var(--neeto-ui-gray-800));
 }

--- a/src/styles/components/_radio.scss
+++ b/src/styles/components/_radio.scss
@@ -1,5 +1,5 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-radio-size: 16px;
+  --neeto-ui-radio-size: 1rem;
   --neeto-ui-radio-color: rgb(var(--neeto-ui-primary-500));
   --neeto-ui-radio-border-width: 2px;
   --neeto-ui-radio-border-color: rgb(var(--neeto-ui-gray-400));
@@ -28,11 +28,11 @@
   --neeto-ui-radio-error-font-size: var(--neeto-ui-text-xs);
 
   // Margin
-  --neeto-ui-radio-wrapper-label-margin: 12px;
-  --neeto-ui-radio-wrapper-error-margin: 4px;
-  --neeto-ui-radio-label-margin: 8px;
+  --neeto-ui-radio-wrapper-label-margin: 0.75rem;
+  --neeto-ui-radio-wrapper-error-margin: 0.25rem;
+  --neeto-ui-radio-label-margin: 0.5rem;
   --neeto-ui-radio-label-line-height: 1.2;
-  --neeto-ui-radio-margin: 16px;
+  --neeto-ui-radio-margin: 1rem;
 }
 
 .neeto-ui-radio__wrapper {

--- a/src/styles/components/_select.scss
+++ b/src/styles/components/_select.scss
@@ -28,7 +28,7 @@
 
   // Indicators
   --neeto-ui-select-indicators-padding: 0px;
-  --neeto-ui-select-indicators-gap: 8px;
+  --neeto-ui-select-indicators-gap: 0.5rem;
   --neeto-ui-select-indicators-color: rgb(var(--neeto-ui-gray-800));
   --neeto-ui-select-indicators-hover-color: rgb(var(--neeto-ui-gray-700));
 
@@ -36,19 +36,19 @@
   --neeto-ui-select-menu-border-width: 1px;
   --neeto-ui-select-menu-border-color: rgb(var(--neeto-ui-gray-400));
   --neeto-ui-select-menu-border-radius: var(--neeto-ui-rounded);
-  --neeto-ui-select-menu-margin-top: 6px;
-  --neeto-ui-select-menu-margin-bottom: 16px;
+  --neeto-ui-select-menu-margin-top: 0.375rem;
+  --neeto-ui-select-menu-margin-bottom: 1rem;
   --neeto-ui-select-menu-z-index: 20;
   --neeto-ui-select-menu-bg-color: rgb(var(--neeto-ui-white));
   --neeto-ui-select-menu-box-shadow: var(--neeto-ui-shadow-lg);
-  --neeto-ui-select-menu-max-height: 480px;
+  --neeto-ui-select-menu-max-height: 30rem;
 
   // Menu Option
   --neeto-ui-select-menu-option-color: rgb(var(--neeto-ui-gray-800));
-  --neeto-ui-select-menu-option-padding-x: 12px;
-  --neeto-ui-select-menu-option-padding-y: 8px;
+  --neeto-ui-select-menu-option-padding-x: 0.75rem;
+  --neeto-ui-select-menu-option-padding-y: 0.5rem;
   --neeto-ui-select-menu-option-line-height: 1.1;
-  --neeto-ui-select-menu-option-min-height: 32px;
+  --neeto-ui-select-menu-option-min-height: 2rem;
 
   // Menu Option Focus
   --neeto-ui-select-menu-option-focus-bg-color: rgb(var(--neeto-ui-gray-200));
@@ -64,20 +64,20 @@
   --neeto-ui-select-menu-fixed-option-border-top-width: 1px;
   --neeto-ui-select-menu-fixed-option-border-top-color: rgb(var(--neeto-ui-gray-100));
   --neeto-ui-select-menu-fixed-option-padding-x: 0px;
-  --neeto-ui-select-menu-fixed-option-padding-y: 2px;
+  --neeto-ui-select-menu-fixed-option-padding-y: 0.125rem;
   --neeto-ui-select-menu-fixed-option-link-color: rgb(var(--neeto-ui-gray-700));
-  --neeto-ui-select-menu-fixed-option-link-padding-x: 12px;
-  --neeto-ui-select-menu-fixed-option-link-padding-y: 8px;
+  --neeto-ui-select-menu-fixed-option-link-padding-x: 0.75rem;
+  --neeto-ui-select-menu-fixed-option-link-padding-y: 0.5rem;
   --neeto-ui-select-menu-fixed-option-link-hover-color: rgb(var(--neeto-ui-gray-800));
 
   // Multi Value
   --neeto-ui-select-multi-value-bg-color: transparent;
   --neeto-ui-select-multi-value-border-width: 1px;
   --neeto-ui-select-multi-value-border-color: rgb(var(--neeto-ui-gray-400));
-  --neeto-ui-select-multi-value-border-radius: 100px;
-  --neeto-ui-select-multi-value-margin-right: 4px;
-  --neeto-ui-select-multi-value-margin-y: 4px;
-  --neeto-ui-select-multi-value-padding-x: 8px;
+  --neeto-ui-select-multi-value-border-radius: 6.25rem;
+  --neeto-ui-select-multi-value-margin-right: 0.25rem;
+  --neeto-ui-select-multi-value-margin-y: 0.25rem;
+  --neeto-ui-select-multi-value-padding-x: 0.5rem;
   --neeto-ui-select-multi-value-padding-y: 0px;
   --neeto-ui-select-multi-value-color: rgb(var(--neeto-ui-gray-800));
 
@@ -85,14 +85,14 @@
   --neeto-ui-select-multi-value-label-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-select-multi-value-label-line-height: 1;
   --neeto-ui-select-multi-value-label-padding-x: 0px;
-  --neeto-ui-select-multi-value-label-padding-y: 2px;
+  --neeto-ui-select-multi-value-label-padding-y: 0.125rem;
 
   --neeto-ui-select-multi-value-remove-hover-opacity: 0.7;
 
   // Add Button
   --neeto-ui-select-add-btn-font-size: var(--neeto-ui-text-xs);
-  --neeto-ui-select-add-btn-padding-x: 8px;
-  --neeto-ui-select-add-btn-padding-y: 4px;
+  --neeto-ui-select-add-btn-padding-x: 0.5rem;
+  --neeto-ui-select-add-btn-padding-y: 0.25rem;
   --neeto-ui-select-add-btn-margin-left: 0px;
 }
 
@@ -160,21 +160,21 @@
   }
 
   &.neeto-ui-react-select__container--small {
-    --neeto-ui-select-min-height: 26px;
-    --neeto-ui-select-padding-x: 8px;
-    --neeto-ui-select-indicators-padding: 8px;
+    --neeto-ui-select-min-height: 1.625rem;
+    --neeto-ui-select-padding-x: 0.5rem;
+    --neeto-ui-select-indicators-padding: 0.5rem;
   }
 
   &.neeto-ui-react-select__container--medium {
-    --neeto-ui-select-min-height: 30px;
-    --neeto-ui-select-padding-x: 8px;
-    --neeto-ui-select-indicators-padding: 8px;
+    --neeto-ui-select-min-height: 1.875rem;
+    --neeto-ui-select-padding-x: 0.5rem;
+    --neeto-ui-select-indicators-padding: 0.5rem;
   }
 
   &.neeto-ui-react-select__container--large {
-    --neeto-ui-select-min-height: 38px;
-    --neeto-ui-select-padding-x: 12px;
-    --neeto-ui-select-indicators-padding: 12px;
+    --neeto-ui-select-min-height: 2.375rem;
+    --neeto-ui-select-padding-x: 0.75rem;
+    --neeto-ui-select-indicators-padding: 0.75rem;
   }
 
   .neeto-ui-react-select__placeholder {
@@ -231,7 +231,7 @@
       max-height: var(--neeto-ui-select-menu-max-height);
 
       @media (max-height: 1000px) {
-        max-height: calc(40vh - 50px);
+        max-height: calc(40vh - 3.125rem);
       }
     }
 

--- a/src/styles/components/_spinner.scss
+++ b/src/styles/components/_spinner.scss
@@ -1,6 +1,6 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-spinner-size: 20px;
-  --neeto-ui-spinner-border-width: 3px;
+  --neeto-ui-spinner-size: 1.25rem;
+  --neeto-ui-spinner-border-width: 0.1875rem;
   --neeto-ui-spinner-color: rgb(var(--neeto-ui-gray-600));
 }
 
@@ -23,8 +23,8 @@
   }
 
   &--size-small {
-    --neeto-ui-spinner-size: 16px;
-    --neeto-ui-spinner-border-width: 3px;
+    --neeto-ui-spinner-size: 1rem;
+    --neeto-ui-spinner-border-width: 0.1875rem;
   }
 }
 
@@ -115,6 +115,6 @@
 }
 
 .neetix-spinner {
-  --neeto-ui-spinner-size: 32px;
+  --neeto-ui-spinner-size: 2rem;
   --neeto-ui-spinner-color: rgb(var(--neeto-ui-primary-500));
 }

--- a/src/styles/components/_switch.scss
+++ b/src/styles/components/_switch.scss
@@ -3,30 +3,30 @@
   --neeto-ui-switch-wrapper-width: fit-content;
 
   // Switch Item
-  --neeto-ui-switch-item-width: 44px;
-  --neeto-ui-switch-item-height: 24px;
+  --neeto-ui-switch-item-width: 2.75rem;
+  --neeto-ui-switch-item-height: 1.5rem;
   --neeto-ui-switch-item-border-width: 2px;
   --neeto-ui-switch-item-border-color: transparent;
-  --neeto-ui-switch-item-border-radius: 20px;
+  --neeto-ui-switch-item-border-radius: 1.25rem;
   --neeto-ui-switch-item-bg-color: rgb(var(--neeto-ui-gray-300));
   --neeto-ui-switch-item-opacity: 1;
 
   // Switch
-  --neeto-ui-switch-width: 20px;
-  --neeto-ui-switch-height: 20px;
+  --neeto-ui-switch-width: 1.25rem;
+  --neeto-ui-switch-height: 1.25rem;
   --neeto-ui-switch-color: rgb(var(--neeto-ui-gray-400));
   --neeto-ui-switch-bg-color: rgb(var(--neeto-ui-white));
   --neeto-ui-switch-transform: translateX(0);
-  --neeto-ui-switch-border-radius: 16px;
+  --neeto-ui-switch-border-radius: 1rem;
   --neeto-ui-switch-box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.05);
 
   // Checked
   --neeto-ui-switch-item-checked-bg-color: rgb(var(--neeto-ui-primary-500));
   --neeto-ui-switch-checked-color: rgb(var(--neeto-ui-primary-500));
-  --neeto-ui-switch-checked-transform: translateX(20px);
+  --neeto-ui-switch-checked-transform: translateX(1.25rem);
 
   // Margin
-  --neeto-ui-switch-label-margin: 12px;
+  --neeto-ui-switch-label-margin: 0.75rem;
 
   // Focus Within
   --neeto-ui-switch-focus-within-box-shadow: 0 0 0 3px rgb(var(--neeto-ui-gray-200));

--- a/src/styles/components/_tab.scss
+++ b/src/styles/components/_tab.scss
@@ -1,15 +1,15 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
   --neeto-ui-tab-wrapper-border-width: 2px;
   --neeto-ui-tab-wrapper-border-color: rgb(var(--neeto-ui-gray-200));
-  --neeto-ui-tab-padding-x: 8px;
-  --neeto-ui-tab-padding-y: 12px;
+  --neeto-ui-tab-padding-x: 0.5rem;
+  --neeto-ui-tab-padding-y: 0.75rem;
   --neeto-ui-tab-font-size: var(--neeto-ui-text-sm);
   --neeto-ui-tab-font-weight: var(--neeto-ui-font-semibold);
   --neeto-ui-tab-line-height: 1;
   --neeto-ui-tab-color: rgb(var(--neeto-ui-gray-600));
   --neeto-ui-tab-border-color: transparent;
-  --neeto-ui-tab-gap: 12px;
-  --neeto-ui-tab-icon-size: 16px;
+  --neeto-ui-tab-gap: 0.75rem;
+  --neeto-ui-tab-icon-size: 1rem;
   --neeto-ui-tab-text-decoration: none;
   --neeto-ui-tab-outline: none;
 
@@ -43,7 +43,7 @@
   &--size-large {
     .neeto-ui-tab {
       --neeto-ui-tab-font-size: var(--neeto-ui-text-xl);
-      --neeto-ui-tab-padding-x: 12px;
+      --neeto-ui-tab-padding-x: 0.75rem;
     }
   }
 

--- a/src/styles/components/_tag.scss
+++ b/src/styles/components/_tag.scss
@@ -1,19 +1,19 @@
 :root, .neeto-ui-theme--light, .neeto-ui-theme--dark {
-  --neeto-ui-tag-padding-x: 8px;
-  --neeto-ui-tag-padding-y: 3px;
+  --neeto-ui-tag-padding-x: 0.5rem;
+  --neeto-ui-tag-padding-y: 0.1875rem;
   --neeto-ui-tag-font-size: var(--neeto-ui-text-xs);
   --neeto-ui-tag-font-weight: var(--neeto-ui-font-normal);
-  --neeto-ui-tag-line-height: 12px;
+  --neeto-ui-tag-line-height: 0.75rem;
   --neeto-ui-tag-color: rgb(var(--neeto-ui-black));
   --neeto-ui-tag-bg-color: transparent;
   --neeto-ui-tag-border-width: 1px;
   --neeto-ui-tag-border-color: transparent;
   --neeto-ui-tag-border-radius: var(--neeto-ui-rounded-full);
-  --neeto-ui-tag-gap: 4px;
-  --neeto-ui-tag-icon-size: 12px;
+  --neeto-ui-tag-gap: 0.25rem;
+  --neeto-ui-tag-icon-size: 0.75rem;
 
   // Indicator
-  --neeto-ui-tag-indicator-size: 8px;
+  --neeto-ui-tag-indicator-size: 0.5rem;
   --neeto-ui-tag-indicator-border-radius: var(--neeto-ui-rounded-full);
 
   // Hover
@@ -68,12 +68,12 @@
   }
 
   &--size-large {
-    --neeto-ui-tag-padding-x: 12px;
-    --neeto-ui-tag-padding-y: 3px;
-    --neeto-ui-tag-gap: 6px;
+    --neeto-ui-tag-padding-x: 0.75rem;
+    --neeto-ui-tag-padding-y: 0.1875rem;
+    --neeto-ui-tag-gap: 0.375rem;
     --neeto-ui-tag-font-size: var(--neeto-ui-text-sm);
-    --neeto-ui-tag-line-height: 16px;
-    --neeto-ui-tag-icon-size: 16px;
+    --neeto-ui-tag-line-height: 1rem;
+    --neeto-ui-tag-icon-size: 1rem;
   }
 
   &--type-outline {


### PR DESCRIPTION
- Fixes #2378 

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
