### PR TITLE
Removed the value sanitization logic while rendering and the touched state.

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useState,
-  useEffect,
-  useMemo,
-  useCallback,
-} from "react";
+import React, { forwardRef, useState, useEffect, useCallback } from "react";
 
 import { DatePicker as AntDatePicker } from "antd";
 import classnames from "classnames";
@@ -68,7 +62,6 @@ const DatePicker = forwardRef(
     const [value, setValue] = useState(inputValue);
     const [mode, setMode] = useState(picker);
     const [pickerValue, setPickerValue] = useState();
-    const [touched, setTouched] = useState(false);
     const id = useId(otherProps.id);
     const datePickerRef = useSyncedRef(ref);
 
@@ -97,7 +90,6 @@ const DatePicker = forwardRef(
 
       const allowed = getAllowedValue(getTimezoneAppliedDateTime(date));
       setValue(allowed);
-      setTouched(true);
 
       return onChange(allowed, formattedString(allowed, dateFormat));
     };
@@ -117,29 +109,17 @@ const DatePicker = forwardRef(
       );
     };
 
-    const { sanitizedValue, sanitizedDefaultValue } = useMemo(() => {
-      let sanitizedDefaultValue = convertToDayjsObjects(defaultValue);
-      let sanitizedValue = convertToDayjsObjects(value);
-
-      if (touched) {
-        sanitizedValue = getAllowedValue(sanitizedValue);
-        sanitizedDefaultValue = getAllowedValue(sanitizedDefaultValue);
-      }
-
-      return { sanitizedDefaultValue, sanitizedValue };
-    }, [defaultValue, value, touched, getAllowedValue]);
-
     return (
       <Provider>
         <div className="neeto-ui-input__wrapper">
           {label && <Label {...{ required, ...labelProps }}>{label}</Label>}
           <Component
             data-cy={label ? `${hyphenize(label)}-input` : "picker-input"}
-            defaultValue={sanitizedDefaultValue}
+            defaultValue={convertToDayjsObjects(defaultValue)}
             placeholder={placeholder ?? format}
             ref={datePickerRef}
             showTime={showTime && { format: timeFormat, ...timePickerProps }}
-            value={sanitizedValue}
+            value={convertToDayjsObjects(value)}
             className={classnames("neeto-ui-date-input", [className], {
               "neeto-ui-date-input--small": size === "small",
               "neeto-ui-date-input--medium": size === "medium",


### PR DESCRIPTION
- Fixes #2387 

**Description**
- Removed the logic to sanitize the value of the datepicker.
- The values are already sanitized in the onChange handler.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [ ] ~I have verified the functionality in some of the neeto web-apps.~
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
