### PR TITLE
Updated neeto-cist path in ModuleNameMapper in jest config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 /dist
 /storybook-static
 
+# Ignore yalc generated files
+yalc.lock
+/.yalc
 
 /formik*.js
 /formik.js.LICENSE.txt

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,9 +18,13 @@ module.exports = () => ({
       __dirname,
       "node_modules/@bigbinary/neeto-icons/dist/neeto-icons.js"
     ),
-    neetocist: path.resolve(
+    "^(@bigbinary/neeto-cist|neetocist)$": path.resolve(
       __dirname,
-      "node_modules/@bigbinary/neeto-cist/index.cjs.js"
+      "node_modules/@bigbinary/neeto-cist/index.mjs"
+    ),
+    "^(@bigbinary/neeto-cist|neetocist)/(.*)$": path.resolve(
+      __dirname,
+      "node_modules/@bigbinary/neeto-cist/$2.js"
     ),
     "^atoms/(.*)$": path.resolve(__dirname, "src/atoms", "$1"),
     "^components/(.*)$": path.resolve(__dirname, "src/components", "$1"),
@@ -33,8 +37,9 @@ module.exports = () => ({
     "^src/(.*)$": path.resolve(__dirname, "src", "$1"),
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(@babel|@bigbinary/neeto-icons|rc-picker|rc-util))",
+    "/node_modules/(?!(@babel|@bigbinary/neeto-icons|rc-picker|rc-util|@bigbinary/neeto-cist))",
   ],
+  transform: { "^.+\\.m?jsx?$": "babel-jest" },
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["./jest-setup.js"],
   collectCoverageFrom: ["src/**/*.js"],


### PR DESCRIPTION
[Fixes](https://github.com/bigbinary/neeto-commons-frontend/issues/1301) 

**Description**
This PR updates the proper path of `neeto-cist` in `ModuleNameMapper` and adds `neeto-cist` in `transformIgnorePatterns` in jest config file

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
