### PR TITLE
Changed the useHotkyes mode to global in the useOverlay to fix event getting trapped when the form input fields were in focus.

### DIFF
--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -69,7 +69,10 @@ const useOverlay = ({
     manager.isTopOverlay(overlayWrapper)
   );
 
-  useHotKeys("escape", handleOverlayClose, { enabled: closeOnEsc });
+  useHotKeys("escape", handleOverlayClose, {
+    enabled: closeOnEsc,
+    mode: "global",
+  });
 
   useEffect(() => {
     let cleanUp = noop;

--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -70,7 +70,7 @@ const useOverlay = ({
   );
 
   useHotKeys("escape", handleOverlayClose, {
-    enabled: closeOnEsc,
+    enabled: closeOnEsc && isOpen,
     mode: "global",
   });
 


### PR DESCRIPTION
Fixes #2375 

**Description**
- The MouseTrap lib by default will not fire callbacks for events inside fields like input, textarea etc.. We have to use `bindGlobal` if we want the key bindings for work for form fields as well.

> By default all keyboard events will not fire if you are inside of a textarea, input, or select to prevent undesirable things from happening.

> This means that a keyboard event bound using Mousetrap.bind will only work outside of form input fields, but using Mousetrap.bindGlobal will work in both places.

Documentation - https://craig.is/killing/mice

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
