### PR TITLE
Fixes pruning saved emails when there's a duplicate entry.

### DIFF
--- a/src/components/MultiEmailInput/utils.js
+++ b/src/components/MultiEmailInput/utils.js
@@ -1,12 +1,22 @@
+import { isPresent } from "neetocist";
 import { pluck } from "ramda";
 
 import { EMAIL_REGEX } from "./constants";
 
-const getEmailsMap = (options = [], inputEmails = []) =>
-  new Map([...inputEmails, ...options].map(option => [option.value, option]));
+const getEmailsMap = (inputEmails = [], options = []) => {
+  const emails = [...inputEmails, ...options];
+  const emailsMap = new Map();
 
-const processEmailOptions = (options = [], inputEmails = []) => {
-  const emailsMap = getEmailsMap(options, inputEmails);
+  emails.forEach(option => {
+    const hasPersistedEntry = isPresent(emailsMap.get(option.value)?.id);
+    if (!hasPersistedEntry) emailsMap.set(option.value, option);
+  });
+
+  return emailsMap;
+};
+
+const processEmailOptions = (inputEmails = [], options = []) => {
+  const emailsMap = getEmailsMap(inputEmails, options);
 
   return email => {
     const emailDetails = emailsMap.get(email) || { value: email };
@@ -23,7 +33,7 @@ export const formatEmailInputOption = ({ label, value, ...otherDetails }) => ({
 });
 
 export const pruneDuplicates = (inputValues, options) => {
-  const emailProcessor = processEmailOptions(options, inputValues);
+  const emailProcessor = processEmailOptions(inputValues, options);
   const emails = pluck("value", inputValues);
   const uniqueValuesSet = new Set();
   const duplicates = [];


### PR DESCRIPTION
- Fixes #issue_number

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
