### PR TITLE
Fixed issue with table height computation when reorder column is enabled

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -116,12 +116,16 @@ const Table = ({
       const observer = resizeObserver.current;
 
       if (table !== null) {
-        observer.observe(table?.parentNode);
+        const targetNode = enableColumnReorder
+          ? table?.parentNode?.parentNode
+          : table?.parentNode;
+
+        observer.observe(targetNode);
       } else if (observer) {
         observer.disconnect();
       }
     },
-    [resizeObserver.current, fixedHeight]
+    [resizeObserver.current, fixedHeight, enableColumnReorder]
   );
 
   const { handleScroll } = useRestoreScrollPosition({


### PR DESCRIPTION
- Fixes #2396 

**Description**
- Fixed issue with table height computation when reorder column is enabled.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
