### PR TITLE
Fixed TypeError - Cannot read properties of null (reading 'style') in Pane component

### DIFF
--- a/src/components/Pane/utils.js
+++ b/src/components/Pane/utils.js
@@ -4,15 +4,15 @@ export const getHeader = paneWrapperRef =>
   paneWrapperRef.current.querySelector(".neeto-ui-pane__header");
 
 export const updateHeaderHeight = (header, paneWrapperRef) => {
-  const headerHeight = header.offsetHeight;
+  const headerHeight = header?.offsetHeight;
 
   if (headerHeight > DEFAULT_PANE_HEADER_HEIGHT) {
-    paneWrapperRef.current.style.setProperty(
+    paneWrapperRef.current?.style.setProperty(
       "--neeto-ui-pane-header-height",
       `${headerHeight}px`
     );
   } else {
-    paneWrapperRef.current.style.removeProperty(
+    paneWrapperRef.current?.style.removeProperty(
       "--neeto-ui-pane-header-height"
     );
   }


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-code-web/issues/1123

**Description**
- Fixed TypeError in Pane component.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
