### PR TITLE
Fixed an issue where getFromLocalStorage() could throw errors in environments where localStorage is inaccessible or null.

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -4,24 +4,11 @@ import { useState } from "react";
 
 import { isNil } from "ramda";
 
-import { removeFromLocalStorage, setToLocalStorage } from "utils";
-
-const getStorageValue = (key, defaultValue) => {
-  try {
-    const storedValue = localStorage.getItem(key);
-
-    return storedValue ? JSON.parse(storedValue) : defaultValue;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
-
-    return defaultValue;
-  }
-};
+import { getFromLocalStorage, removeFromLocalStorage, setToLocalStorage } from "utils";
 
 const useLocalStorage = (key, defaultValue) => {
   const [storedValue, setStoredValue] = useState(() =>
-    getStorageValue(key, defaultValue)
+    getFromLocalStorage(key, defaultValue)
   );
 
   const setValue = value =>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -193,10 +193,7 @@ export const getFromLocalStorage = (key, defaultValue) => {
     const storedValue = localStorage.getItem(key);
 
     return storedValue ? JSON.parse(storedValue) : defaultValue;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
-
+  } catch {
     return defaultValue;
   }
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -188,10 +188,17 @@ export const setToLocalStorage = (key, value) =>
 export const removeFromLocalStorage = key => localStorage.removeItem(key);
 
 export const getFromLocalStorage = (key, defaultValue) => {
-  // eslint-disable-next-line @bigbinary/neeto/no-local-storage
-  const storedValue = localStorage.getItem(key);
+  try {
+    // eslint-disable-next-line @bigbinary/neeto/no-local-storage
+    const storedValue = localStorage.getItem(key);
 
-  return storedValue ? JSON.parse(storedValue) : defaultValue;
+    return storedValue ? JSON.parse(storedValue) : defaultValue;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    return defaultValue;
+  }
 };
 
 export { dayjs };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -180,12 +180,23 @@ export const getLocale = (i18n, t, translationKey) => {
     : getEnTranslationValue(translationKey);
 };
 
-export const setToLocalStorage = (key, value) =>
-  // eslint-disable-next-line @bigbinary/neeto/no-local-storage
-  localStorage.setItem(key, JSON.stringify(value));
+export const setToLocalStorage = (key, value) => {
+  try {
+    // eslint-disable-next-line @bigbinary/neeto/no-local-storage
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // The catch was added due to handle situations where localstorage goes null
+  }
+};
 
-// eslint-disable-next-line @bigbinary/neeto/no-local-storage
-export const removeFromLocalStorage = key => localStorage.removeItem(key);
+export const removeFromLocalStorage = key => {
+  try {
+    // eslint-disable-next-line @bigbinary/neeto/no-local-storage
+    localStorage.removeItem(key);
+  } catch {
+    // The catch was added due to handle situations where localstorage goes null
+  }
+};
 
 export const getFromLocalStorage = (key, defaultValue) => {
   try {


### PR DESCRIPTION
- Fixes #2419 

**Description**

- Wrapped all localStorage operations in try-catch blocks to handle potential failures in private browsing mode or due to storage restrictions.

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@josephmathew900 _a
cc: @AbhayVAshokan 
