### PR TITLE
Fixed hex color input field auto-population issue in ColorPicker

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -42,7 +42,7 @@ const ColorPicker = ({
   const { t, i18n } = useTranslation();
   const [colorInternal, setColorInternal] = useState(color);
   const [isColorSelected, setIsColorSelected] = useState(false);
-  const isInputChanged = useRef(false);
+  const hexColorInputValue = useRef("");
   const { open, isSupported } = useEyeDropper({ pickRadius: 3 });
   const [recentlyUsedColors, setRecentlyUsedColors] = useRecentlyUsedColors();
 
@@ -75,17 +75,19 @@ const ColorPicker = ({
   };
 
   const onColorInputChange = hex => {
-    isInputChanged.current = true;
+    // HexColorInput onChange will trigger only if the input value is a valid color
+    hexColorInputValue.current = hex;
+    if (hex.length !== (showTransparencyControl ? 9 : 7)) return;
 
+    hexColorInputValue.current = "";
     onColorChange(hex);
   };
 
   const onBlur = () => {
-    // If input is not changed, don't call onChange on blur
-    if (!isInputChanged.current) return;
+    if (!hexColorInputValue.current) return;
 
-    isInputChanged.current = false;
-    onColorChange(colorValue);
+    onColorChange(hexColorInputValue.current);
+    hexColorInputValue.current = "";
   };
 
   const pickColor = async () => {

--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -79,8 +79,8 @@ const ColorPicker = ({
     hexColorInputValue.current = hex;
     if (hex.length !== (showTransparencyControl ? 9 : 7)) return;
 
-    hexColorInputValue.current = "";
     onColorChange(hex);
+    hexColorInputValue.current = "";
   };
 
   const onBlur = () => {


### PR DESCRIPTION
- Fixes #2421 

**Description**
- Fixed: Hex color input field auto-population issue in _ColorPicker_.

**Checklist**
- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
