### PR TITLE
Fixed TypeError in useOverlay hook

### DIFF
--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -27,7 +27,7 @@ const useOverlay = ({
 }) => {
   const elementToFocusRef = useRef(null);
 
-  const bodyHeight = document.body.offsetHeight;
+  const bodyHeight = document.body?.offsetHeight;
   const windowHeight = window.innerHeight;
   const hasScroll = bodyHeight > windowHeight;
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -118,12 +118,16 @@ export const focusFirstFocusableElement = ref => {
 };
 
 export const hideScrollAndAddMargin = () => {
+  if (!document.body) return;
+
   const scrollbarWidth = getScrollbarWidth();
   document.body.style.overflow = "hidden";
   document.body.style.marginRight = `${scrollbarWidth}px`;
 };
 
 export const showScrollAndRemoveMargin = () => {
+  if (!document.body) return;
+
   document.body.style.overflow = "auto";
   document.body.style.marginRight = "0px";
 };


### PR DESCRIPTION
- Fixes #2423 

**Description**
- Fixed TypeError in `useOverlay` hook.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
