### PR TITLE
Fixed `data-cy` label for `Input`

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -17,7 +17,7 @@ const Input = forwardRef(
       size = SIZES.medium,
       type = "text",
       label = "",
-      name = "",
+      dataCy = "",
       error = "",
       suffix = null,
       prefix = null,
@@ -82,7 +82,7 @@ const Input = forwardRef(
     };
 
     const dataCyLabel =
-      typeof label === "string" ? hyphenize(label) : hyphenize(name);
+      typeof label === "string" ? hyphenize(label) : hyphenize(dataCy);
 
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -17,6 +17,7 @@ const Input = forwardRef(
       size = SIZES.medium,
       type = "text",
       label = "",
+      name = "",
       error = "",
       suffix = null,
       prefix = null,
@@ -80,13 +81,16 @@ const Input = forwardRef(
       onBlur?.(e);
     };
 
+    const dataCyLabel =
+      typeof label === "string" ? hyphenize(label) : hyphenize(name);
+
     return (
       <div className={classnames(["neeto-ui-input__wrapper", className])}>
         <div className="neeto-ui-input__label-wrapper">
           {label && (
             <Label
               {...{ required }}
-              data-cy={`${hyphenize(label)}-input-label`}
+              data-cy={`${dataCyLabel}-input-label`}
               htmlFor={id}
               {...labelProps}
             >
@@ -104,7 +108,7 @@ const Input = forwardRef(
           )}
         </div>
         <div
-          data-cy={`${hyphenize(label)}-input`}
+          data-cy={`${dataCyLabel}-input`}
           className={classnames("neeto-ui-input", {
             "neeto-ui-input--naked": !!nakedInput,
             "neeto-ui-input--error": !!error,
@@ -117,7 +121,7 @@ const Input = forwardRef(
           {prefix && <div className="neeto-ui-input__prefix">{prefix}</div>}
           <input
             aria-invalid={!!error}
-            data-cy={`${hyphenize(label)}-input-field`}
+            data-cy={`${dataCyLabel}-input-field`}
             size={contentSize}
             aria-describedby={classnames({
               [errorId]: !!error,
@@ -141,7 +145,7 @@ const Input = forwardRef(
         {!!error && (
           <p
             className="neeto-ui-input__error"
-            data-cy={`${hyphenize(label)}-input-error`}
+            data-cy={`${dataCyLabel}-input-error`}
             id={errorId}
           >
             {error}
@@ -150,7 +154,7 @@ const Input = forwardRef(
         {helpText && (
           <p
             className="neeto-ui-input__help-text"
-            data-cy={`${hyphenize(label)}-input-help`}
+            data-cy={`${dataCyLabel}-input-help`}
             id={helpTextId}
           >
             {helpText}


### PR DESCRIPTION
- Fixes #2426 

**Description**
Fixed data-cy label for _Input_.

**Checklist**

- [x] ~~I have made corresponding changes to the documentation.~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**
@VarunSriram99 _a, Please review this PR.
<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->

patch _t
