### PR TITLE
Fix `100vh` height issue in Pane component for iOS Safari

### DIFF
--- a/src/styles/components/_pane.scss
+++ b/src/styles/components/_pane.scss
@@ -98,7 +98,7 @@
 
     &.neeto-ui-pane__body--has-footer {
       --neeto-ui-pane-body-height: calc(
-        100vh - var(--neeto-ui-pane-header-height) -
+        100dvh - var(--neeto-ui-pane-header-height) -
           var(--neeto-ui-pane-footer-height));
     }
   }

--- a/src/styles/components/_pane.scss
+++ b/src/styles/components/_pane.scss
@@ -98,8 +98,16 @@
 
     &.neeto-ui-pane__body--has-footer {
       --neeto-ui-pane-body-height: calc(
-        100dvh - var(--neeto-ui-pane-header-height) -
+        100vh - var(--neeto-ui-pane-header-height) -
           var(--neeto-ui-pane-footer-height));
+
+      /* Apply dvh if supported */
+      @supports (height: 100dvh) {
+        --neeto-ui-pane-body-height: calc(
+          100dvh - var(--neeto-ui-pane-header-height) -
+            var(--neeto-ui-pane-footer-height)
+        );
+      }
     }
   }
 


### PR DESCRIPTION
- Fixes #2429 

**Description**

- Fixed: Pane footer cut-off issue in iOS Safari.

iPad Pro (11-inch) - Tested using Xcode

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2025-02-19 at 20 04 00](https://github.com/user-attachments/assets/987f5448-c67f-4b76-b3c9-c58b9364249e)


**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
