### PR TITLE
Prevent overlay from closing when Select, DatePicker or nested overlays are open

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -72,7 +72,7 @@ const DatePicker = forwardRef(
     const [pickerValue, setPickerValue] = useState();
     const id = useId(otherProps.id);
     const datePickerRef = useSyncedRef(ref);
-    const isOpen = useRef(otherProps.open ?? false);
+    const isDatePickerOpen = useRef(otherProps.open ?? false);
 
     const Component = datePickerTypes[type?.toLowerCase()];
     const format = showTime ? `${dateFormat} ${timeFormat}` : dateFormat;
@@ -104,12 +104,12 @@ const DatePicker = forwardRef(
     };
 
     const handleOnOpenChange = open => {
-      isOpen.current = open;
+      isDatePickerOpen.current = open;
       onOpenChange?.(open);
     };
 
     const handleOnKeyDown = e => {
-      if (!isOpen.current) return;
+      if (!isDatePickerOpen.current) return;
 
       e.stopPropagation();
       onKeyDown?.(e);
@@ -306,6 +306,14 @@ DatePicker.propTypes = {
    * To specify the maximum date of the DatePicker.
    */
   maxDate: PropTypes.object,
+  /**
+   * Callback function which will be invoked when the DatePicker is opened or closed.
+   */
+  onOpenChange: PropTypes.func,
+  /**
+   * Callback function which will be invoked when a key is pressed.
+   */
+  onKeyDown: PropTypes.func,
 };
 
 export default DatePicker;

--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useState, useEffect, useCallback } from "react";
+import React, {
+  forwardRef,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from "react";
 
 import { DatePicker as AntDatePicker } from "antd";
 import classnames from "classnames";
@@ -55,6 +61,8 @@ const DatePicker = forwardRef(
       minDate,
       timePickerProps,
       timezone,
+      onOpenChange,
+      onKeyDown,
       ...otherProps
     },
     ref
@@ -64,6 +72,7 @@ const DatePicker = forwardRef(
     const [pickerValue, setPickerValue] = useState();
     const id = useId(otherProps.id);
     const datePickerRef = useSyncedRef(ref);
+    const isOpen = useRef(otherProps.open ?? false);
 
     const Component = datePickerTypes[type?.toLowerCase()];
     const format = showTime ? `${dateFormat} ${timeFormat}` : dateFormat;
@@ -92,6 +101,18 @@ const DatePicker = forwardRef(
       setValue(allowed);
 
       return onChange(allowed, formattedString(allowed, dateFormat));
+    };
+
+    const handleOnOpenChange = open => {
+      isOpen.current = open;
+      onOpenChange?.(open);
+    };
+
+    const handleOnKeyDown = e => {
+      if (!isOpen.current) return;
+
+      e.stopPropagation();
+      onKeyDown?.(e);
     };
 
     const renderExtraFooter = () => {
@@ -133,6 +154,8 @@ const DatePicker = forwardRef(
               popupClassName,
             ])}
             onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+            onOpenChange={handleOnOpenChange}
             {...{
               format,
               maxDate,

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -469,6 +469,18 @@ Select.propTypes = {
    * To specify the extra props to be passed to the menu list.
    */
   portalProps: PropTypes.object,
+  /**
+   * Callback function which will be invoked when the menu is opened.
+   */
+  onMenuOpen: PropTypes.func,
+  /**
+   * Callback function which will be invoked when the menu is closed.
+   */
+  onMenuClose: PropTypes.func,
+  /**
+   * Callback function which will be invoked when a key is pressed.
+   */
+  onKeyDown: PropTypes.func,
 };
 
 export default Select;

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -216,9 +216,15 @@ const Select = ({
   defaultValue,
   components: componentOverrides,
   optionRemapping = {},
+  onMenuClose,
+  onMenuOpen,
+  onKeyDown,
   ...otherProps
 }) => {
   const inputId = useId(id);
+  const isMenuOpen = useRef(
+    otherProps.isMenuOpen ?? otherProps.defaultMenuIsOpen ?? false
+  );
 
   let Parent = SelectInput;
 
@@ -274,6 +280,23 @@ const Select = ({
     );
   };
 
+  const handleMenuOpen = () => {
+    isMenuOpen.current = true;
+    onMenuOpen?.();
+  };
+
+  const handleMenuClose = () => {
+    isMenuOpen.current = false;
+    onMenuClose?.();
+  };
+
+  const handleKeyDown = e => {
+    if (!isMenuOpen.current) return;
+
+    e.stopPropagation();
+    onKeyDown?.(e);
+  };
+
   return (
     <div
       className={classnames(["neeto-ui-input__wrapper", className])}
@@ -319,6 +342,9 @@ const Select = ({
           Control,
           ...componentOverrides,
         }}
+        onKeyDown={handleKeyDown}
+        onMenuClose={handleMenuClose}
+        onMenuOpen={handleMenuOpen}
         {...{ inputId, label, ...portalProps, ...otherProps }}
       />
       {!!error && (

--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -70,7 +70,7 @@ const useOverlay = ({
   );
 
   useHotKeys("escape", handleOverlayClose, {
-    enabled: closeOnEsc && isOpen,
+    enabled: closeOnEsc && isOpen && isTopOverlay,
     mode: "global",
   });
 

--- a/types/DatePicker.d.ts
+++ b/types/DatePicker.d.ts
@@ -27,6 +27,8 @@ export type DatePickerProps = {
   allowClear?: boolean;
   minDate?: Dayjs;
   maxDate?: Dayjs;
+  onOpenChange?: (open: boolean) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   [key: string]: any;
 };
 

--- a/types/Select.d.ts
+++ b/types/Select.d.ts
@@ -22,6 +22,9 @@ export type SelectProps = {
   isMulti?: boolean;
   addButtonLabel?: string;
   portalProps?: object;
+  onMenuOpen?: () => void;
+  onMenuClose?: () => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 };
 
 const Select: React.ForwardRefExoticComponent<SelectProps>;


### PR DESCRIPTION
- Fixes #2431

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
