### PR TITLE
Added `data-cy` labels to _HeaderCellMenu_ and _CellContent_

### DIFF
--- a/src/components/Table/components/HeaderCell/CellContent.jsx
+++ b/src/components/Table/components/HeaderCell/CellContent.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import { isPresent, noop } from "neetocist";
 import { isEmpty } from "ramda";
 
+import { hyphenize } from "utils";
+
 import HeaderCellMenu from "./HeaderCellMenu";
 
 const CellContent = ({
@@ -41,7 +43,10 @@ const CellContent = ({
       title=""
       onClick={isSortable ? noop : headerProps.onClick}
     >
-      <div className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-between">
+      <div
+        className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-between"
+        data-cy={`${hyphenize(headerProps.title)}-header-title`}
+      >
         <div className="neeto-ui-min-w-0 neeto-ui-flex-grow neeto-ui-truncate">
           {children}
         </div>

--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -12,6 +12,7 @@ import {
 } from "components/Table/constants";
 import Typography from "components/Typography";
 import { getLocale } from "utils";
+import { hyphenize } from "utils";
 
 const { Menu, MenuItem } = Dropdown;
 
@@ -51,6 +52,7 @@ const HeaderCellMenu = ({
           style: "text",
           size: "medium",
           "data-testid": "column-menu-button",
+          "data-cy": "column-menu-button",
           "data-dropdown-button-style": "more-dropdown",
         }}
       >
@@ -62,6 +64,7 @@ const HeaderCellMenu = ({
             <>
               <MenuItem.Button
                 className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-between"
+                data-cy="ascending-column-menu-button"
                 onClick={() =>
                   onSort({
                     column,
@@ -79,6 +82,7 @@ const HeaderCellMenu = ({
               </MenuItem.Button>
               <MenuItem.Button
                 className="neeto-ui-flex neeto-ui-items-center neeto-ui-justify-between"
+                data-cy="descending-column-menu-button"
                 onClick={() =>
                   onSort({
                     column,
@@ -99,11 +103,13 @@ const HeaderCellMenu = ({
           {isAddEnabled && (
             <>
               <MenuItem.Button
+                data-cy="insert-right-column-menu-button"
                 onClick={() => onAddColumn(COLUMN_ADD_DIRECTION.right)}
               >
                 {getLocale(i18n, t, "neetoui.table.insertColRight")}
               </MenuItem.Button>
               <MenuItem.Button
+                data-cy="insert-left-column-menu-button"
                 onClick={() => onAddColumn(COLUMN_ADD_DIRECTION.left)}
               >
                 {getLocale(i18n, t, "neetoui.table.insertColLeft")}
@@ -112,7 +118,10 @@ const HeaderCellMenu = ({
           )}
           {isPresent(column?.description) && (
             <>
-              <MenuItem.Button ref={columnInfoButtonReference}>
+              <MenuItem.Button
+                data-cy="info-column-menu-button"
+                ref={columnInfoButtonReference}
+              >
                 {getLocale(i18n, t, "neetoui.table.columnInfo")}
               </MenuItem.Button>
               <Popover
@@ -137,17 +146,24 @@ const HeaderCellMenu = ({
             </>
           )}
           {isHidable && (
-            <MenuItem.Button onClick={() => onColumnHide(column)}>
+            <MenuItem.Button
+              data-cy="hide-column-menu-button"
+              onClick={() => onColumnHide(column)}
+            >
               {getLocale(i18n, t, "neetoui.table.hideColumn")}
             </MenuItem.Button>
           )}
           {isColumnDeletable && (
-            <MenuItem.Button onClick={() => onColumnDelete(column.id)}>
+            <MenuItem.Button
+              data-cy="delete-column-menu-button"
+              onClick={() => onColumnDelete(column.id)}
+            >
               {getLocale(i18n, t, "neetoui.table.deleteColumn")}
             </MenuItem.Button>
           )}
           {isColumnFreezeEnabled && (
             <MenuItem.Button
+              data-cy="freeze-unfreeze-column-menu-button"
               onClick={() => onColumnFreeze(isFixedColumn, column)}
             >
               {isFixedColumn
@@ -158,6 +174,7 @@ const HeaderCellMenu = ({
           {hasMoreActions &&
             moreActions.map((item, index) => (
               <MenuItem.Button
+                data-cy={`${hyphenize(item.label)}-column-menu-button`}
                 key={index}
                 onClick={() => onMoreActionClick(item.type, column)}
               >

--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -11,8 +11,7 @@ import {
   TABLE_SORT_ORDERS,
 } from "components/Table/constants";
 import Typography from "components/Typography";
-import { getLocale } from "utils";
-import { hyphenize } from "utils";
+import { getLocale, hyphenize } from "utils";
 
 const { Menu, MenuItem } = Dropdown;
 


### PR DESCRIPTION
- Fixes #2440 

**Description**
Added: `data-cy` labels for _HeaderCellMenu_ and _CellContent_.
**Checklist**

- [x] ~~I have made corresponding changes to the documentation.~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**
@VarunSriram99 _a, Please review this PR.
<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->

patch _t