### PR TITLE
Fixed table sorting when array is passed to dataIndex

### DIFF
--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 
 import { isPresent } from "neetocist";
 import { Check, MenuHorizontal } from "neetoicons";
+import { equals } from "ramda";
 import { useTranslation } from "react-i18next";
 
 import Dropdown from "components/Dropdown";
@@ -75,7 +76,7 @@ const HeaderCellMenu = ({
               >
                 <span>{getLocale(i18n, t, "neetoui.table.ascending")}</span>
                 {sortedInfo.order === TABLE_SORT_ORDERS.asc &&
-                  sortedInfo.field === column.dataIndex && (
+                  equals(sortedInfo.field, column.dataIndex) && (
                     <Check className="neeto-ui-text-success-500" size={20} />
                   )}
               </MenuItem.Button>
@@ -93,7 +94,7 @@ const HeaderCellMenu = ({
               >
                 <span>{getLocale(i18n, t, "neetoui.table.descending")}</span>
                 {sortedInfo.order === TABLE_SORT_ORDERS.desc &&
-                  sortedInfo.field === column.dataIndex && (
+                  equals(sortedInfo.field, column.dataIndex) && (
                     <Check className="neeto-ui-text-success-500" size={20} />
                   )}
               </MenuItem.Button>

--- a/src/components/Table/hooks/useTableSort.js
+++ b/src/components/Table/hooks/useTableSort.js
@@ -1,27 +1,13 @@
 import { useEffect, useState } from "react";
 
-import { camelToSnakeCase, isPresent, snakeToCamelCase } from "neetocist";
 import { mergeLeft } from "ramda";
 import { useHistory } from "react-router-dom";
 
 import { useQueryParams } from "hooks";
 import { buildUrl } from "utils";
 
-import { URL_SORT_ORDERS, TABLE_SORT_ORDERS } from "../constants";
-
-const getSortInfoFromQueryParams = queryParams => {
-  const sortedInfo = {};
-  if (
-    isPresent(queryParams.sort_by) &&
-    isPresent(queryParams.order_by) &&
-    isPresent(TABLE_SORT_ORDERS[queryParams.order_by])
-  ) {
-    sortedInfo.field = snakeToCamelCase(queryParams.sort_by);
-    sortedInfo.order = TABLE_SORT_ORDERS[queryParams.order_by];
-  }
-
-  return sortedInfo;
-};
+import { URL_SORT_ORDERS } from "../constants";
+import { getSortInfoFromQueryParams, getSortField } from "../utils";
 
 const useTableSort = () => {
   const queryParams = useQueryParams();
@@ -37,7 +23,7 @@ const useTableSort = () => {
 
   const handleTableChange = (pagination, sorter) => {
     const params = {
-      sort_by: sorter.order ? camelToSnakeCase(sorter.field) : undefined,
+      sort_by: sorter.order ? getSortField(sorter.field) : undefined,
       order_by: URL_SORT_ORDERS[sorter.order],
       page: pagination.current,
     };

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -1,5 +1,5 @@
-import { isPresent } from "neetocist";
-import { __, all, filter, includes, pipe, pluck } from "ramda";
+import { isPresent, snakeToCamelCase, camelToSnakeCase } from "neetocist";
+import { __, all, equals, filter, includes, pipe, pluck } from "ramda";
 
 import {
   CellContent,
@@ -11,6 +11,7 @@ import {
   COLUMN_FIXED_VALUES,
   SELECT_ALL_ROWS_CALLOUT_DESKTOP_HEIGHT,
   SELECT_ALL_ROWS_CALLOUT_MOBILE_HEIGHT,
+  TABLE_SORT_ORDERS,
 } from "./constants";
 
 const convertLocationPathnameToId = () => {
@@ -71,7 +72,7 @@ export const getFixedColumns = columnData =>
   )(columnData);
 
 export const getColumnSortOrder = (col, sortedInfo) =>
-  sortedInfo.field === col.dataIndex || sortedInfo.field === col.key
+  equals(sortedInfo.field, col.dataIndex) || equals(sortedInfo.field, col.key)
     ? sortedInfo.order
     : null;
 
@@ -84,4 +85,28 @@ export const getFrozenColumnsLocalStorageKey = localStorageKeyPrefix => {
     : convertLocationPathnameToId();
 
   return `NEETOUI-${prefix}-FIXED_COLUMNS`;
+};
+
+export const getSortInfoFromQueryParams = queryParams => {
+  const sortedInfo = {};
+  if (
+    isPresent(queryParams.sort_by) &&
+    isPresent(queryParams.order_by) &&
+    isPresent(TABLE_SORT_ORDERS[queryParams.order_by])
+  ) {
+    sortedInfo.field = queryParams.sort_by.includes("+")
+      ? queryParams.sort_by.split("+").map(snakeToCamelCase)
+      : snakeToCamelCase(queryParams.sort_by);
+    sortedInfo.order = TABLE_SORT_ORDERS[queryParams.order_by];
+  }
+
+  return sortedInfo;
+};
+
+export const getSortField = field => {
+  if (Array.isArray(field)) {
+    return field.map(camelToSnakeCase).join("+");
+  }
+
+  return camelToSnakeCase(field);
 };


### PR DESCRIPTION
- Fixes #2452 

**Description**
- Fixed table sorting when array is passed to dataIndex.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
