### PR TITLE
Fixed issue with select dropdown not opening in pane when custom styles are passed

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { _existsBy, isPresent } from "neetocist";
 import { Down, Close } from "neetoicons";
 import PropTypes from "prop-types";
-import { prop, assoc, flatten, pluck } from "ramda";
+import { prop, assoc, flatten, pluck, mergeDeepRight } from "ramda";
 import SelectInput, { components } from "react-select";
 import Async from "react-select/async";
 import AsyncCreatable from "react-select/async-creatable";
@@ -219,6 +219,7 @@ const Select = ({
   onMenuClose,
   onMenuOpen,
   onKeyDown,
+  styles = {},
   ...otherProps
 }) => {
   const inputId = useId(id);
@@ -246,7 +247,7 @@ const Select = ({
 
   const portalProps = strategy === STRATEGIES.fixed && {
     menuPortalTarget: document.body,
-    styles: { menuPortal: assoc("zIndex", 999999) },
+    styles: mergeDeepRight({ menuPortal: assoc("zIndex", 999999) }, styles),
     menuPosition: "fixed",
   };
 
@@ -345,7 +346,7 @@ const Select = ({
         onKeyDown={handleKeyDown}
         onMenuClose={handleMenuClose}
         onMenuOpen={handleMenuOpen}
-        {...{ inputId, label, ...portalProps, ...otherProps }}
+        {...{ inputId, label, ...styles, ...portalProps, ...otherProps }}
       />
       {!!error && (
         <p
@@ -481,6 +482,10 @@ Select.propTypes = {
    * Callback function which will be invoked when a key is pressed.
    */
   onKeyDown: PropTypes.func,
+  /**
+   * To specify the styles for the Select component.
+   */
+  styles: PropTypes.object,
 };
 
 export default Select;

--- a/types/Select.d.ts
+++ b/types/Select.d.ts
@@ -25,6 +25,7 @@ export type SelectProps = {
   onMenuOpen?: () => void;
   onMenuClose?: () => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  styles?: object;
 };
 
 const Select: React.ForwardRefExoticComponent<SelectProps>;


### PR DESCRIPTION
- Fixes #2456 

**Description**
- Fixed issue with Select dropdown not opening in pane when custom styles are passed.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
