### PR TITLE
Fixed height computation issue in nested panes

### DIFF
--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -44,7 +44,7 @@ const Pane = ({
 
   useOverlayManager(paneWrapperRef, isOpen);
 
-  const { handleOverlayClose, setFocusField } = useOverlay({
+  const { handleOverlayClose, setFocusField, isTopOverlay } = useOverlay({
     overlayWrapper: paneWrapperRef,
     backdropRef,
     closeOnOutsideClick,
@@ -85,7 +85,7 @@ const Pane = ({
       mutationObserver.disconnect();
       observer.disconnect();
     };
-  }, [hasTransitionCompleted]);
+  }, [hasTransitionCompleted, isTopOverlay]);
 
   return (
     <Portal rootId="neeto-ui-portal">

--- a/src/hooks/useOverlay.js
+++ b/src/hooks/useOverlay.js
@@ -98,7 +98,7 @@ const useOverlay = ({
     if (hasTransitionCompleted) focusRequiredElementInOverlay();
   };
 
-  return { handleOverlayClose, setFocusField };
+  return { handleOverlayClose, setFocusField, isTopOverlay };
 };
 
 export default useOverlay;


### PR DESCRIPTION
- Fixes #2460 

**Description**
- Fixed height computation issue in nested panes.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
