### PR TITLE
Fixed the data-cy label for select option of Menu dropdown in Select component

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -87,7 +87,7 @@ const CustomOption = props => {
       innerRef={ref}
       innerProps={{
         ...props.innerProps,
-        "data-cy": dataCy || `${props.hyphenatedDataCyLabel}-select-option`,
+        "data-cy": dataCy || `${hyphenize(props.label)}-select-option`,
       }}
     />
   );
@@ -101,7 +101,7 @@ const Placeholder = props => {
       {...props}
       innerProps={{
         ...props.innerProps,
-        "data-cy": selectProps
+        "data-cy": selectProps?.hyphenatedDataCyLabel
           ? `${selectProps.hyphenatedDataCyLabel}-select-placeholder`
           : "select-placeholder",
       }}


### PR DESCRIPTION
- Fixes #2473 

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->

patch _t
@deepanshu-rajput-git _a