### PR TITLE
Added `data-cy` labels for textarea component

### DIFF
--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -100,7 +100,7 @@ const Textarea = forwardRef(
           )}
         </div>
         <div
-          data-cy={`${hyphenize(label)}-text-input`}
+          data-cy={`${hyphenize(label)}-text-input-label`}
           className={classnames("neeto-ui-input", "neeto-ui-input--textarea", {
             "neeto-ui-input--error": !!error,
             "neeto-ui-input--disabled": !!disabled,
@@ -114,6 +114,7 @@ const Textarea = forwardRef(
         >
           {prefix && <div className="neeto-ui-input__prefix">{prefix}</div>}
           <textarea
+            data-cy={`${hyphenize(label)}-text-input`}
             ref={textareaRef}
             rows={ROWS[size]}
             {...{


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-chat-playwright/issues/38

**Description**

**Checklist**

- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
