### PR TITLE
Improve MultiEmailInput error message and style

### DIFF
--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -234,10 +234,10 @@ const MultiEmailInput = forwardRef(
         )}
         {!!duplicateEmails.length && (
           <p
-            className="neeto-ui-input__warning"
+            className="neeto-ui-input__error"
             data-cy={`${hyphenize(label)}-duplicate-emails-warning`}
           >
-            Duplicate emails that were removed case insensitively:{" "}
+            Duplicate emails detected and removed (matched case-insensitively):{" "}
             {duplicateEmails.join(", ")}
           </p>
         )}

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -274,7 +274,7 @@ describe("MultiEmailInput", () => {
 
     expect(
       screen.getByText(
-        "Duplicate emails that were removed case insensitively: test@Example.com"
+        "Duplicate emails detected and removed (matched case-insensitively): test@Example.com"
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
- Fixes #2482 

### After
<img width="593" alt="Screenshot 2025-05-20 at 9 41 28 PM" src="https://github.com/user-attachments/assets/845d80e5-76c5-4140-bf52-63794525d58d" />

### Before
<img width="509" alt="Screenshot 2025-05-20 at 9 02 06 PM" src="https://github.com/user-attachments/assets/a18fef50-df8b-48f7-9439-5d77b9dc5560" />

**Description**

- Updated: the duplicate email error message and style.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
