### PR TITLE
Convert `100vh` to `100dvh` for proper layout on iPad and mobile browsers

### DIFF
--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -51,6 +51,7 @@
   top: 0;
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   overflow-y: auto;
   overflow-x: hidden;
   display: grid;
@@ -118,6 +119,7 @@
       --neeto-ui-modal-header-padding-top: 1.75rem;
 
       max-height: 100vh;
+      max-height: 100dvh;
       transform: scale(1);
       animation: nuifadeIn 0s forwards;
 

--- a/src/styles/components/_pane.scss
+++ b/src/styles/components/_pane.scss
@@ -27,7 +27,7 @@
   // Body
   --neeto-ui-pane-body-padding-x: var(--neeto-ui-pane-spacing);
   --neeto-ui-pane-body-padding-y: 0px;
-  --neeto-ui-pane-body-height: calc(100vh - var(--neeto-ui-pane-header-height));
+  --neeto-ui-pane-body-height: calc(100dvh - var(--neeto-ui-pane-header-height));
   --neeto-ui-pane-body-font-size: var(--neeto-ui-text-sm);
 
   // Footer
@@ -45,6 +45,7 @@
     top: 0;
     width: 100vw;
     height: 100vh;
+    height: 100dvh;
     overflow-x: hidden;
     overflow-y: auto;
 
@@ -95,7 +96,7 @@
   }
 
   &__body {
-    --neeto-ui-pane-body-height: calc(100vh - var(--neeto-ui-pane-header-height));
+    --neeto-ui-pane-body-height: calc(100dvh - var(--neeto-ui-pane-header-height));
     width: 100%;
     height: var(--neeto-ui-pane-body-height);
     padding: var(--neeto-ui-pane-body-padding-y) var(--neeto-ui-pane-body-padding-x);
@@ -104,7 +105,7 @@
 
     &.neeto-ui-pane__body--has-footer {
       --neeto-ui-pane-body-height: calc(
-        100vh - var(--neeto-ui-pane-header-height) -
+        100dvh - var(--neeto-ui-pane-header-height) -
           var(--neeto-ui-pane-footer-height));
 
       /* Apply dvh if supported */

--- a/src/styles/layout/_common.scss
+++ b/src/styles/layout/_common.scss
@@ -12,6 +12,7 @@
   align-items: flex-start;
   flex-grow: 1;
   height: 100vh;
+  height: 100dvh;
   overflow-y: auto;
   padding: 0 24px;
 }

--- a/src/styles/utilities/_utilities.scss
+++ b/src/styles/utilities/_utilities.scss
@@ -306,6 +306,10 @@
   height: 100vh;
 }
 
+.neeto-ui-h-dvh {
+  height: 100dvh;
+}
+
 .neeto-ui-no-underline {
   text-decoration: none;
 }


### PR DESCRIPTION
Fixes #2489 

**Description**

- Replaced `100vh` with `100dvh` to fix layout issues on mobile browsers and iPads caused by dynamic browser UI elements.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
