### PR TITLE
Improve Pane width on iPad viewport

### DIFF
--- a/src/styles/components/_pane.scss
+++ b/src/styles/components/_pane.scss
@@ -69,18 +69,17 @@
 
     &--large {
       --neeto-ui-pane-wrapper-width: 50vw;
+      min-width: 600px;
     }
 
     &--extralarge {
       --neeto-ui-pane-wrapper-width: 90vw;
-    }
-
-    @include mixins.viewport(tab-min) {
-      width: 50%;
+      min-width: 700px;
     }
 
     @include mixins.viewport(mob) {
       width: 100%;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
- Fixes #2488 

**Description**

- Fixed: pane width on iPad viewport

Ensures the pane maintains a minimum width for better usability on iPad devices.

small
![localhost_6006_iframe html_args= id=overlays-pane--sizes viewMode=story(iPad) (1)](https://github.com/user-attachments/assets/e0958443-c39a-47eb-a978-f465815ad931)

large
![localhost_6006_iframe html_args= id=overlays-pane--sizes viewMode=story(iPad) (2)](https://github.com/user-attachments/assets/e5b5118f-bb3c-48a9-97eb-79f6efc6b894)

extraLarge
![localhost_6006_iframe html_args= id=overlays-pane--sizes viewMode=story(iPad) (3)](https://github.com/user-attachments/assets/e0229228-5f3b-4857-8ed0-a22a851e9eae)


**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _A

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
