### PR TITLE
Refactor `Select` to handle grouped options in buildValueObj

### DIFF
--- a/src/formik/Select.jsx
+++ b/src/formik/Select.jsx
@@ -1,8 +1,9 @@
 import React, { forwardRef, useRef, startTransition } from "react";
 
 import { getIn, useFormikContext, useField } from "formik";
+import { existsBy } from "neetocist";
 import PropTypes from "prop-types";
-import { prop, either, isNil, isEmpty, dissoc } from "ramda";
+import { prop, either, isNil, isEmpty, dissoc, flatten, pluck } from "ramda";
 
 import Select from "components/Select";
 
@@ -31,7 +32,17 @@ const SelectField = forwardRef((props, ref) => {
   const buildValueObj = (value, options) => {
     if (typeof value === "object") return value;
 
-    return options.filter(option => getRealOptionValue(option) === value)[0];
+    const isGrouped = existsBy({ options: Array.isArray }, options);
+
+    let searchOptions = options;
+
+    if (isGrouped) {
+      searchOptions = flatten(pluck("options", options));
+    }
+
+    return searchOptions.filter(
+      option => getRealOptionValue(option) === value
+    )[0];
   };
 
   return (


### PR DESCRIPTION
- Fixes #2499 

**Description**

This PR makes changes to handle the case when the options passed to the Select component are grouped.
The `buildValueObj` method has been modified to get the deeply nested options after checking for grouping.
This change fixes issues with initial values not being displayed in the dropdown when using formik.

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
