### PR TITLE
Handled TypeError in Toastr component

### DIFF
--- a/src/components/Toastr/index.jsx
+++ b/src/components/Toastr/index.jsx
@@ -145,6 +145,7 @@ const showWarningToastr = withUniqueCheck(
 const isError = e => e && e.stack && e.message;
 const isAxiosError = e => e && typeof e === "object" && e.isAxiosError === true;
 const isString = s => typeof s === "string" || s instanceof String;
+const isArray = a => Array.isArray(a);
 const isErrorCodeObject = e =>
   typeof e === "object" && "key" in e && "context" in e;
 
@@ -160,7 +161,12 @@ const errorCodeTranslation = errorCode => {
 
 const getErrorMessage = response => {
   const { error = "", errors = [], errorCode = "", errorCodes = [] } = response;
-  const errorMessages = error || errors?.join("\n");
+
+  let errorMessages = "";
+
+  if (error) errorMessages = error;
+  else if (isArray(errors)) errorMessages = errors.join("\n");
+
   const errorCodeTranslations =
     (errorCode && t(errorCode, response)) ||
     errorCodes?.map(errorCodeTranslation).join("\n");


### PR DESCRIPTION
- Fixes #2497 

**Description**
- Fixed: TypeError in _Toastr_ component

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
