### PR TITLE
Add tests for formik Select initial value handling

### DIFF
--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -2,9 +2,11 @@ import React from "react";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useField, Formik } from "formik";
 import { evolve } from "ramda";
 
 import { Select } from "components";
+import SelectField from "formikcomponents/Select";
 
 const options = [
   { label: "Option 1", value: "option-1" },
@@ -250,5 +252,83 @@ describe("Select", () => {
 
     expect(screen.getByText("Group 2 - Option 1")).toBeInTheDocument();
     expect(screen.queryByText("Group 2 - Option 2")).not.toBeInTheDocument();
+  });
+
+  it("should correctly fetch initial value for non-grouped options", () => {
+    const FormikSelectWrapper = () => {
+      const [field] = useField("test-select");
+
+      return (
+        <div>
+          <span data-testid="field-value">{field.value}</span>
+          <SelectField
+            {...{ options }}
+            label="Test Select"
+            name="test-select"
+          />
+        </div>
+      );
+    };
+
+    const TestComponent = () => (
+      <Formik initialValues={{ "test-select": "option-2" }} onSubmit={() => {}}>
+        <FormikSelectWrapper />
+      </Formik>
+    );
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByTestId("field-value")).toHaveTextContent("option-2");
+  });
+
+  it("should correctly fetch initial value for grouped options", () => {
+    const groupedOptions = [
+      {
+        label: "Group 1",
+        options: [
+          { label: "Group 1 - Option 1", value: "group1-option1" },
+          { label: "Group 1 - Option 2", value: "group1-option2" },
+        ],
+      },
+      {
+        label: "Group 2",
+        options: [
+          { label: "Group 2 - Option 1", value: "group2-option1" },
+          { label: "Group 2 - Option 2", value: "group2-option2" },
+        ],
+      },
+    ];
+
+    const FormikSelectWrapper = () => {
+      const [field] = useField("test-grouped-select");
+
+      return (
+        <div>
+          <span data-testid="field-value">{field.value}</span>
+          <SelectField
+            label="Test Grouped Select"
+            name="test-grouped-select"
+            options={groupedOptions}
+          />
+        </div>
+      );
+    };
+
+    const TestComponent = () => (
+      <Formik
+        initialValues={{ "test-grouped-select": "group2-option1" }}
+        onSubmit={() => {}}
+      >
+        <FormikSelectWrapper />
+      </Formik>
+    );
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("Group 2 - Option 1")).toBeInTheDocument();
+    expect(screen.getByTestId("field-value")).toHaveTextContent(
+      "group2-option1"
+    );
   });
 });


### PR DESCRIPTION
- Fixes #2501 

**Description**
Add jest tests to ensure initial values are correctly fetched.

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
~~- [ ] I have verified the functionality in some of the neeto web-apps.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
