### PR TITLE
Add tooltip support to custom select options in Select component

### DIFF
--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -78,7 +78,7 @@ const CustomOption = props => {
   const ref = useRef();
   const {
     innerProps,
-    data: { dataCy, tooltipContent = "" },
+    data: { dataCy, tooltipProps = {} },
   } = props;
 
   useEffect(() => {
@@ -96,9 +96,15 @@ const CustomOption = props => {
     />
   );
 
-  if (tooltipContent) {
+  if (isPresent(tooltipProps)) {
+    const mergedTooltipProps = {
+      zIndex: 1_000_001,
+      position: "bottom-start",
+      ...tooltipProps,
+    };
+
     return (
-      <Tooltip content={tooltipContent} zIndex={1_000_001}>
+      <Tooltip {...mergedTooltipProps}>
         <div>{optionComponent}</div>
       </Tooltip>
     );

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -96,21 +96,13 @@ const CustomOption = props => {
     />
   );
 
-  if (isPresent(tooltipProps)) {
-    const mergedTooltipProps = {
-      zIndex: 1_000_001,
-      position: "bottom-start",
-      ...tooltipProps,
-    };
-
-    return (
-      <Tooltip {...mergedTooltipProps}>
-        <div>{optionComponent}</div>
-      </Tooltip>
-    );
-  }
-
-  return optionComponent;
+  return isPresent(tooltipProps) ? (
+    <Tooltip position="bottom-start" zIndex={1_000_001} {...tooltipProps}>
+      <div>{optionComponent}</div>
+    </Tooltip>
+  ) : (
+    optionComponent
+  );
 };
 
 const Placeholder = props => {

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -87,7 +87,7 @@ const CustomOption = props => {
 
   if (tooltipContent) {
     return (
-      <Tooltip content={tooltipContent}>
+      <Tooltip content={tooltipContent} zIndex={1_000_001}>
         <div
           {...{ ref, ...innerProps }}
           data-cy={dataCy || `${hyphenize(props.label)}-select-option`}

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -85,20 +85,7 @@ const CustomOption = props => {
     props.isSelected && ref.current.scrollIntoView();
   }, [props.isSelected]);
 
-  if (tooltipContent) {
-    return (
-      <Tooltip content={tooltipContent} zIndex={1_000_001}>
-        <div
-          {...{ ref, ...innerProps }}
-          data-cy={dataCy || `${hyphenize(props.label)}-select-option`}
-        >
-          <components.Option {...props} />
-        </div>
-      </Tooltip>
-    );
-  }
-
-  return (
+  const optionComponent = (
     <components.Option
       {...props}
       innerRef={ref}
@@ -108,6 +95,16 @@ const CustomOption = props => {
       }}
     />
   );
+
+  if (tooltipContent) {
+    return (
+      <Tooltip content={tooltipContent} zIndex={1_000_001}>
+        <div>{optionComponent}</div>
+      </Tooltip>
+    );
+  }
+
+  return optionComponent;
 };
 
 const Placeholder = props => {

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -15,6 +15,7 @@ import { hyphenize } from "utils";
 
 import Label from "./Label";
 import Spinner from "./Spinner";
+import Tooltip from "./Tooltip";
 
 const SIZES = { small: "small", medium: "medium", large: "large" };
 
@@ -75,18 +76,34 @@ const CustomInput = props => {
 
 const CustomOption = props => {
   const ref = useRef();
-  const { dataCy } = props.data;
+  const {
+    innerProps,
+    data: { dataCy, tooltipContent = "" },
+  } = props;
 
   useEffect(() => {
     props.isSelected && ref.current.scrollIntoView();
   }, [props.isSelected]);
+
+  if (tooltipContent) {
+    return (
+      <Tooltip content={tooltipContent}>
+        <div
+          {...{ ref, ...innerProps }}
+          data-cy={dataCy || `${hyphenize(props.label)}-select-option`}
+        >
+          <components.Option {...props} />
+        </div>
+      </Tooltip>
+    );
+  }
 
   return (
     <components.Option
       {...props}
       innerRef={ref}
       innerProps={{
-        ...props.innerProps,
+        ...innerProps,
         "data-cy": dataCy || `${hyphenize(props.label)}-select-option`,
       }}
     />

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -162,6 +162,27 @@ Grouped.args = {
   ],
 };
 
+const OptionTooltips = Template.bind({});
+OptionTooltips.storyName = "With Option Tooltips";
+OptionTooltips.args = {
+  label: "Select with Tooltips",
+  placeholder: "Hover any option",
+  strategy: "fixed",
+  options: OPTIONS.map(option => ({
+    value: option.value,
+    label: option.label,
+    tooltipContent: `Tooltip content for ${option.label}`,
+  })),
+};
+
+OptionTooltips.parameters = {
+  docs: {
+    description: {
+      story: `Use the \`tooltipContent\` field on each option to show a tooltip when hovering.`,
+    },
+  },
+};
+
 const Creatable = args => {
   const [options, setOptions] = useState([
     { value: "value1", label: "Value one" },
@@ -560,6 +581,7 @@ export {
   Sizes,
   MultiSelect,
   Grouped,
+  OptionTooltips,
   Creatable,
   AsyncCreatable,
   Searchable,

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -163,7 +163,7 @@ Grouped.args = {
 };
 
 const OptionTooltips = Template.bind({});
-OptionTooltips.storyName = "With Option Tooltips";
+OptionTooltips.storyName = "Option Tooltip";
 OptionTooltips.args = {
   label: "Select with Tooltips",
   placeholder: "Hover any option",

--- a/stories/Components/Select.stories.jsx
+++ b/stories/Components/Select.stories.jsx
@@ -162,23 +162,26 @@ Grouped.args = {
   ],
 };
 
-const OptionTooltips = Template.bind({});
-OptionTooltips.storyName = "Option Tooltip";
-OptionTooltips.args = {
+const OptionWithTooltip = Template.bind({});
+OptionWithTooltip.storyName = "Option with Tooltip";
+OptionWithTooltip.args = {
   label: "Select with Tooltips",
   placeholder: "Hover any option",
   strategy: "fixed",
   options: OPTIONS.map(option => ({
     value: option.value,
     label: option.label,
-    tooltipContent: `Tooltip content for ${option.label}`,
+    tooltipProps: {
+      position: "top-start",
+      content: `Tooltip content for ${option.label}`,
+    },
   })),
 };
 
-OptionTooltips.parameters = {
+OptionWithTooltip.parameters = {
   docs: {
     description: {
-      story: `Use the \`tooltipContent\` field on each option to show a tooltip when hovering.`,
+      story: `Use the \`tooltipProps\` field on each option to show a tooltip when hovering.`,
     },
   },
 };
@@ -581,7 +584,7 @@ export {
   Sizes,
   MultiSelect,
   Grouped,
-  OptionTooltips,
+  OptionWithTooltip,
   Creatable,
   AsyncCreatable,
   Searchable,

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -331,4 +331,20 @@ describe("Select", () => {
       "group2-option1"
     );
   });
+
+  it("should show tooltip when hovering over an option with tooltipContent", async () => {
+    const tooltipText = "Tooltip content";
+    const optionsWithTooltip = [
+      { label: "Option 1", value: "option-1", tooltipContent: tooltipText },
+    ];
+
+    render(<Select label="Select" options={optionsWithTooltip} />);
+
+    const select = screen.getByRole("combobox");
+    await userEvent.click(select);
+    const option = screen.getByText("Option 1");
+    await userEvent.hover(option);
+
+    expect(await screen.findByText(tooltipText)).toBeInTheDocument();
+  });
 });

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -332,10 +332,14 @@ describe("Select", () => {
     );
   });
 
-  it("should show tooltip when hovering over an option with tooltipContent", async () => {
+  it("should show tooltip when hovering over an option with tooltipProps", async () => {
     const tooltipText = "Tooltip content";
     const optionsWithTooltip = [
-      { label: "Option 1", value: "option-1", tooltipContent: tooltipText },
+      {
+        label: "Option 1",
+        value: "option-1",
+        tooltipProps: { content: tooltipText },
+      },
     ];
 
     render(<Select label="Select" options={optionsWithTooltip} />);


### PR DESCRIPTION
- Fixes #2504 

**Description**
Adds support to display a tooltip over the options in Select dropdown.

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
