### PR TITLE
Fix: Copy translation files to dist directory during build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,6 +49,14 @@ const config = args => {
       extensions: [".css", ".scss", ".min.css"],
       mode: ["extract", "index.css"],
     }),
+    copy({
+      targets: [
+        {
+          src: "src/translations",
+          dest: path.resolve(destination, "dist/src"),
+        },
+      ],
+    }),
     // Plugins for local development.
     ...watchPlugins,
   ];


### PR DESCRIPTION
- Fixes https://github.com/neetozone/neeto-ui/issues/2600

**Description**
Translations were not getting resolved for the Playwright tests. [Ref](https://automationbinary.neetoplaydash.net/admin/projects/jq42vyp/runs/mb4x25z?tab=tests&search_term=should%20verify%20members%20operations&page=1&attempt_id=9ydmyce&test_id=q7wxy5y&highlighted_run=p4sr7n4).

**Checklist**

- [x] ~~I have made corresponding changes to the documentation.~~
- [x] ~~I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] ~~I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->

@deepanshu-rajput-git _a
patch _t