### PR TITLE
Make the color picker dropdown size-aware to reduce vertical scrolling

### DIFF
--- a/src/components/ColorPicker/index.jsx
+++ b/src/components/ColorPicker/index.jsx
@@ -118,13 +118,20 @@ const ColorPicker = ({
 
   return (
     <Dropdown
-      className="neeto-ui-colorpicker__dropdown"
       closeOnSelect={false}
       label={colorValue}
       position="bottom-start"
       {...{ ...dropdownProps, onClose }}
       customTarget={<Target {...{ color, colorValue, showHexValue, size }} />}
       dropdownProps={{ ...dropdownProps?.dropdownProps, ...portalProps }}
+      className={classnames("neeto-ui-colorpicker__dropdown", {
+        "neeto-ui-colorpicker__dropdown-size--small":
+          size === TARGET_SIZES.small,
+        "neeto-ui-colorpicker__dropdown-size--medium":
+          size === TARGET_SIZES.medium,
+        "neeto-ui-colorpicker__dropdown-size--large":
+          size === TARGET_SIZES.large,
+      })}
     >
       <div className="neeto-ui-colorpicker__popover">
         {showPicker && (

--- a/src/styles/components/_color-picker.scss
+++ b/src/styles/components/_color-picker.scss
@@ -57,6 +57,24 @@
   }
 }
 
+.neeto-ui-colorpicker__dropdown-size--small {
+  .react-colorful {
+    height: 100px;
+  }
+}
+
+.neeto-ui-colorpicker__dropdown-size--medium {
+  .react-colorful {
+    height: 120px;
+  }
+}
+
+.neeto-ui-colorpicker__dropdown-size--large {
+  .react-colorful {
+    height: 140px;
+  }
+}
+
 .neeto-ui-colorpicker__popover {
   width: var(--neeto-ui-colorpicker-popover-width);
   padding: var(--neeto-ui-colorpicker-popover-padding);


### PR DESCRIPTION
- Fixes #2642 

**Description**

- Added size-specific classes to the color Dropdown component based on the size prop.
- Made the color picker height dynamic
  - Small: 100px
  - Medium: 120px
  - Large: 140px

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
