### PR TITLE
Removed redundant data-testid from Backdrop component

### DIFF
--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -72,7 +72,6 @@ const Modal = ({
         onExited={() => setHasTransitionCompleted(false)}
       >
         <Backdrop
-          data-testid="backdrop"
           key="modal-backdrop"
           ref={backdropRef}
           className={classnames(

--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -99,7 +99,6 @@ const Pane = ({
         onExited={() => setHasTransitionCompleted(false)}
       >
         <Backdrop
-          data-testid="backdrop"
           key="pane-backdrop"
           ref={backdropRef}
           className={classnames(

--- a/tests/Alert.test.jsx
+++ b/tests/Alert.test.jsx
@@ -118,7 +118,7 @@ describe("Alert", () => {
         title="Alert title"
       />
     );
-    await userEvent.click(getByTestId("backdrop"));
+    await userEvent.click(getByTestId("neeto-backdrop"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -133,7 +133,7 @@ describe("Alert", () => {
         title="Alert title"
       />
     );
-    await userEvent.click(getByTestId("backdrop"));
+    await userEvent.click(getByTestId("neeto-backdrop"));
     expect(onClose).not.toHaveBeenCalled();
   });
 

--- a/tests/Modal.test.jsx
+++ b/tests/Modal.test.jsx
@@ -113,7 +113,7 @@ describe("Modal", () => {
         <Modal.Body>Sample text</Modal.Body>
       </Modal>
     );
-    await userEvent.click(getByTestId("backdrop"));
+    await userEvent.click(getByTestId("neeto-backdrop"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -127,7 +127,7 @@ describe("Modal", () => {
         </Modal.Body>
       </Modal>
     );
-    await userEvent.click(getByTestId("backdrop"));
+    await userEvent.click(getByTestId("neeto-backdrop"));
     expect(onClose).not.toHaveBeenCalled();
   });
 

--- a/tests/Pane.test.jsx
+++ b/tests/Pane.test.jsx
@@ -113,7 +113,7 @@ describe("Pane", () => {
         <Pane.Body>Pane body</Pane.Body>
       </Pane>
     );
-    await userEvent.click(getByTestId("backdrop"));
+    await userEvent.click(getByTestId("neeto-backdrop"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -149,7 +149,7 @@ describe("Pane", () => {
         <Pane.Body>Pane body</Pane.Body>
       </Pane>
     );
-    await userEvent.click(getByTestId("backdrop"));
+    await userEvent.click(getByTestId("neeto-backdrop"));
     expect(onClose).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Fixes #2693 

**Description**

**Checklist**

- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
