### PR TITLE
Handle invalid date in DatePicker and TimePicker

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -17,11 +17,11 @@ import { Tag } from "components";
 import Label from "components/Label";
 import { useSyncedRef, useId } from "hooks";
 import {
-  convertToDayjsObjects,
   noop,
   hyphenize,
   dayjs,
   getTimezoneAppliedDateTime,
+  getValidDayjsValue,
 } from "utils";
 
 import IconOverride from "./IconOverride";
@@ -157,11 +157,11 @@ const DatePicker = forwardRef(
           {label && <Label {...{ required, ...labelProps }}>{label}</Label>}
           <Component
             data-testid={label ? `${hyphenize(label)}-input` : "picker-input"}
-            defaultValue={convertToDayjsObjects(defaultValue)}
+            defaultValue={getValidDayjsValue(defaultValue)}
             placeholder={placeholder ?? format}
             ref={datePickerRef}
             showTime={showTime && { format: timeFormat, ...timePickerProps }}
-            value={convertToDayjsObjects(value)}
+            value={getValidDayjsValue(value)}
             className={classnames("neeto-ui-date-input", [className], {
               "neeto-ui-date-input--small": size === "small",
               "neeto-ui-date-input--medium": size === "medium",

--- a/src/components/TimePicker/index.jsx
+++ b/src/components/TimePicker/index.jsx
@@ -11,12 +11,12 @@ import { ANTD_LOCALE } from "components/constants";
 import Label from "components/Label";
 import { useSyncedRef, useId } from "hooks";
 import {
-  convertToDayjsObjects,
   noop,
   hyphenize,
   ANT_DESIGN_GLOBAL_TOKEN_OVERRIDES,
   getLocale,
   getTimezoneAppliedDateTime,
+  getValidDayjsValue,
 } from "utils";
 
 import { TIME_PICKER_TYPES } from "./constants";
@@ -153,11 +153,11 @@ const TimePicker = forwardRef(
             ])}
             onChange={handleOnChange}
             {...{ disabled, format, ...otherProps, panelRender }}
-            defaultValue={convertToDayjsObjects(defaultValue)}
+            defaultValue={getValidDayjsValue(defaultValue)}
             mode={undefined}
             picker="time"
             placeholder={placeholder ?? format}
-            value={convertToDayjsObjects(value)}
+            value={getValidDayjsValue(value)}
             suffixIcon={
               timezone ? <Tag label={timezone} /> : <Clock size={16} />
             }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -53,10 +53,23 @@ export const hyphenize = input => {
   return fallbackString;
 };
 
-export const convertToDayjsObjects = value =>
-  value instanceof Array
-    ? value.map(date => (date ? dayjs(date) : date))
-    : value && dayjs(value);
+export const getValidDayjsValue = value => {
+  if (Array.isArray(value)) {
+    return value.map(date => {
+      if (!date) return null;
+
+      const parsed = dayjs(date);
+
+      return parsed.isValid() ? parsed : null;
+    });
+  }
+
+  if (!value) return value;
+
+  const parsed = dayjs(value);
+
+  return parsed.isValid() ? parsed : null;
+};
 
 export class UniqueArray {
   constructor() {

--- a/tests/DatePicker.test.jsx
+++ b/tests/DatePicker.test.jsx
@@ -324,4 +324,24 @@ describe("DatePicker", () => {
     await userEvent.click(screen.getByText("UTC"));
     expect(onTimezoneChange).toHaveBeenCalledWith("utc");
   });
+
+  it("should display valid calendar when invalid date is passed", async () => {
+    const invalidDate = new Date("invalid");
+    render(<DatePicker open value={invalidDate} />);
+
+    await waitFor(() => {
+      const dateCells = screen.getAllByText(
+        /^[1-9]$|^1[0-9]$|^2[0-9]$|^3[01]$/
+      );
+      expect(dateCells.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      const calendarPanel = document.querySelector(".ant-picker-date-panel");
+      expect(calendarPanel).toBeInTheDocument();
+      const panelText = calendarPanel.textContent || "";
+      expect(panelText).not.toContain("Invalid Date");
+      expect(panelText).toMatch(/([1-9]|1[0-9]|2[0-9]|3[01])/);
+    });
+  });
 });


### PR DESCRIPTION
- Fixes #2680 

**Description**
- Handled invalid date in DatePicker and TimePicker

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
