### PR TITLE
Improve Help icon visibility

### DIFF
--- a/src/components/Label/HelpIcon.jsx
+++ b/src/components/Label/HelpIcon.jsx
@@ -14,7 +14,7 @@ const HelpIcon = forwardRef(
           [className]: className,
         })}
       >
-        <HelpIcon size={16} {...otherProps} />
+        <HelpIcon size={20} {...otherProps} />
       </span>
     );
   }


### PR DESCRIPTION
- Fixes #2708

**Description**

- Improved: help icon size in Label.

### Before and After
<img width="258" height="139" alt="Frame 2" src="https://github.com/user-attachments/assets/c1705f4a-e3c3-4d2a-baca-f80b909bd2e9" />

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
