### PR TITLE
Update neeto-icons styles to fix visibility issues in NeetoUI dark mode

### DIFF
--- a/src/styles/layout/_common.scss
+++ b/src/styles/layout/_common.scss
@@ -8,10 +8,10 @@
   }
 }
 
-.neeto-ui-theme--dark [data-dark-mode-color="true"][fill] {
+.neeto-ui-theme--dark [data-dark-mode-color="true"][fill]:not([fill="none"]) {
   fill: currentColor;
 }
 
-.neeto-ui-theme--dark [data-dark-mode-color="true"][stroke] {
+.neeto-ui-theme--dark [data-dark-mode-color="true"][stroke]:not([stroke="none"]) {
   stroke: currentColor;
 }


### PR DESCRIPTION
- Fixes #2717

**Description**

- Updated: neeto-icons styles to fix visibility issues in NeetoUI dark mode.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

@praveen-murali-ind _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
