### PR TITLE
Fix TypeError cannot read properties of undefined Click

### DIFF
--- a/src/components/Dropdown/Menu.jsx
+++ b/src/components/Dropdown/Menu.jsx
@@ -19,7 +19,6 @@ const Menu = ({ children, className, ...otherProps }) => {
     const itemsCount = items.length;
     if (itemsCount === 0) return;
 
-
     if (key === "arrowdown") {
       activeIndex = activeIndex >= itemsCount - 1 ? 0 : activeIndex + 1;
       items[activeIndex].focus();


### PR DESCRIPTION
- Fixes 
1. #https://github.com/neetozone/neeto-desk-web/issues/23272
2. #https://github.com/neetozone/neeto-planner-web/issues/8497

**Description**
I was not able to reproduce the issue either in production or local. Chatted with Sarthak and he was not able to reproduce it either, based on the detailed traces, 
<img width="1044" height="369" alt="image" src="https://github.com/user-attachments/assets/9c302f40-bb41-43aa-835d-74b94f7d51e3" />
Issue was coming from Dropdown component, so gone through the code and added null check at every step in click operation.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
