### PR TITLE
Added data-testid attributes to the header cell menu items

### DIFF
--- a/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
+++ b/src/components/Table/components/HeaderCell/HeaderCellMenu.jsx
@@ -149,6 +149,7 @@ const HeaderCellMenu = ({
           )}
           {isHidable && (
             <ActionItem
+              data-testid="hide-column-menu-button"
               icon={Hide}
               label={getLocale(i18n, t, "neetoui.table.hideColumn")}
               onClick={() => onColumnHide(column)}
@@ -175,6 +176,7 @@ const HeaderCellMenu = ({
           )}
           {isPresent(onColumnUpdate) && (
             <ActionItem
+              data-testid="edit-column-info-menu-button"
               icon={InfoRound}
               label={getLocale(i18n, t, "neetoui.table.editColumnInfo")}
               onClick={() => {
@@ -184,6 +186,7 @@ const HeaderCellMenu = ({
           )}
           {isPresent(onColumnUpdate) && isMoveToLeftEnabled && (
             <ActionItem
+              data-testid="move-column-left-menu-button"
               icon={ColumnToLeft}
               label={getLocale(i18n, t, "neetoui.table.moveColumnLeft")}
               onClick={() => onMoveColumn(-1)}
@@ -191,6 +194,7 @@ const HeaderCellMenu = ({
           )}
           {isPresent(onColumnUpdate) && isMoveToRightEnabled && (
             <ActionItem
+              data-testid="move-column-right-menu-button"
               icon={ColumnToRight}
               label={getLocale(i18n, t, "neetoui.table.moveColumnRight")}
               onClick={() => onMoveColumn(1)}

--- a/src/components/Table/components/TitleWithInfoIcon.jsx
+++ b/src/components/Table/components/TitleWithInfoIcon.jsx
@@ -15,6 +15,7 @@ const TitleWithInfoIcon = ({ title, description, ...rest }) => {
         <>
           <span
             className="neeto-ui-table__column-title-info-icon"
+            data-testid="column-info-icon"
             ref={popoverRef}
           >
             <InfoRound color="currentColor" size={14} />


### PR DESCRIPTION
- Fixes #2724 

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
