### PR TITLE
Ensure newly opened overlay appears on top of existing ones

### DIFF
--- a/src/atoms/Portal.js
+++ b/src/atoms/Portal.js
@@ -1,9 +1,15 @@
+/* eslint-disable @bigbinary/neeto/file-name-and-export-name-standards */
 import { useEffect, useRef } from "react";
 
 import { isEmpty } from "ramda";
 import { createPortal } from "react-dom";
 
-const Portal = ({ children, rootId = "root-portal", el = "div" }) => {
+const Portal = ({
+  children,
+  rootId = "root-portal",
+  el = "div",
+  bringToFront = false,
+}) => {
   const target = useRef(null);
 
   useEffect(() => {
@@ -23,6 +29,12 @@ const Portal = ({ children, rootId = "root-portal", el = "div" }) => {
       }
     };
   }, [rootId]);
+
+  useEffect(() => {
+    if (bringToFront && target.current?.parentElement) {
+      target.current.parentElement.appendChild(target.current);
+    }
+  }, [bringToFront]);
 
   if (!target.current) {
     target.current = document.createElement(el);

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -61,7 +61,7 @@ const Modal = ({
   const isFullScreenModal = size === SIZES.fullScreen;
 
   return (
-    <Portal rootId="neeto-ui-portal">
+    <Portal bringToFront={isOpen} rootId="neeto-ui-portal">
       <CSSTransition
         unmountOnExit
         appear={isOpen}

--- a/src/components/Pane/index.jsx
+++ b/src/components/Pane/index.jsx
@@ -88,7 +88,7 @@ const Pane = ({
   }, [hasTransitionCompleted, isTopOverlay]);
 
   return (
-    <Portal rootId="neeto-ui-portal">
+    <Portal bringToFront={isOpen} rootId="neeto-ui-portal">
       <CSSTransition
         unmountOnExit
         appear={isOpen}


### PR DESCRIPTION
- Fixes #2748

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
