### PR TITLE
Fixed CJS interop for ESM default exports

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,10 @@ const config = args => {
     }),
     copy({
       targets: [
-        { src: "src/translations", dest: path.resolve(destination, "dist/src") },
+        {
+          src: "src/translations",
+          dest: path.resolve(destination, "dist/src"),
+        },
       ],
     }),
     // Plugins for local development.
@@ -65,6 +68,7 @@ const config = args => {
       format,
       sourcemap: true,
       exports: "auto",
+      interop: "auto",
       assetFileNames: "[name][extname]",
     })),
     plugins,


### PR DESCRIPTION
- Fixes #2811 

**Description**
Added `interop: "auto"` to the Rollup output config to generate `_interopDefault` helpers that correctly unwrap `exports.default` from ESM-compiled-to-CJS dependencies like `@tippyjs/react` and `@bigbinary/neeto-icons`.

Without this, the CJS build passed the raw namespace object `({ __esModule: true, default: Component })` instead of the component itself, causing "Element type is invalid" errors in consuming projects.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
