### PR TITLE
Preserved default Toastr className when custom className is provided

### DIFF
--- a/src/components/Toastr/index.jsx
+++ b/src/components/Toastr/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import classnames from "classnames";
 import { t } from "i18next";
 import { CheckCircle, Warning, Info, Close } from "neetoicons";
 import { toast, Slide } from "react-toastify";
@@ -95,6 +96,7 @@ const withUniqueCheck =
             ? toast.POSITION.BOTTOM_RIGHT
             : toast.POSITION.BOTTOM_LEFT,
         ...customConfig,
+        className: classnames(TOAST_CONFIG.className, customConfig?.className),
       };
 
       toastId = toastFunc({ message, buttonLabel, onClick, config });

--- a/tests/Toastr.test.jsx
+++ b/tests/Toastr.test.jsx
@@ -410,4 +410,32 @@ describe("Toastr", () => {
       expect(toastrIcon).toBeInTheDocument();
     });
   });
+
+  it("should retain neeto-ui-toastr class on thumbs-up Success Toastr", async () => {
+    const button = renderToastrButton("Success", () =>
+      // eslint-disable-next-line @bigbinary/neeto/use-show-thumbs-up-toastr
+      Toastr.success("", { icon: "👍", className: "w-20" })
+    );
+    await userEvent.click(button);
+
+    const icon = await screen.findByText("👍");
+    const toastrElement = icon.closest(".neeto-ui-toastr");
+    expect(toastrElement).toBeInTheDocument();
+    expect(toastrElement).toHaveClass("neeto-ui-toastr", "w-20");
+  });
+
+  ["Success", "Info", "Warning", "Error"].forEach(type => {
+    it(`should retain neeto-ui-toastr class on message-passing ${type} Toastr`, async () => {
+      const message = i18next.t("message.toastr");
+      const button = renderToastrButton(type, () =>
+        Toastr[type.toLowerCase()](message)
+      );
+      await userEvent.click(button);
+
+      const toastr = await screen.findByText(message);
+      const toastrElement = toastr.closest(".neeto-ui-toastr");
+      expect(toastrElement).toBeInTheDocument();
+      expect(toastrElement).toHaveClass("neeto-ui-toastr");
+    });
+  });
 });


### PR DESCRIPTION
- Fixes #2819

**Description**
- Fixed:  Toastr losing its default `neeto-ui-toastr` class when callers pass a custom className.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
