### PR TITLE
Fix .neetoci paths filter (supersedes #2848)

### DIFF
--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,33 +2,6 @@ version: v1.0
 
 plan: standard-2
 
-paths:
-  - app/**
-  - bin/**
-  - config/**
-  - db/**
-  - lib/**
-  - test/**
-  - .neetoci/default.yml
-  - .neetoci/scripts/run_eslint_on_modified_files.sh
-  - .neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh
-  - .neetoci/scripts/check_schema_drift.sh
-  - Gemfile*
-  - package.json
-  - yarn.lock
-  - Rakefile
-  - .env.test
-  - config.ru
-  - .*.yml
-  - .ruby-version
-  - .node-version
-  - .nvmrc
-  - .active_record_doctor.rb
-  - .prettierrc.js
-  - "*.config.*"
-  - .eslintignore
-  - .eslintrc.js
-
 global_job_config:
   setup:
     - checkout

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -8,7 +8,7 @@ paths:
   - stories/**
   - jest-config/**
   - jest-setup.js
-  - .scripts/*
+  - .scripts/**
   - .neetoci/default.yml
   - package.json
   - yarn.lock

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,6 +2,25 @@ version: v1.0
 
 plan: standard-2
 
+paths:
+  - src/**
+  - tests/**
+  - stories/**
+  - jest-config/**
+  - jest-setup.js
+  - .scripts/*
+  - .neetoci/default.yml
+  - package.json
+  - yarn.lock
+  - .yarnrc.yml
+  - .node-version
+  - .nvmrc
+  - .browserslistrc
+  - .prettierrc.js
+  - .eslintignore
+  - .eslintrc.js
+  - "*.config.*"
+
 global_job_config:
   setup:
     - checkout


### PR DESCRIPTION
## What was wrong

#2848 added a generic, copy-pasted `paths:` filter to `.neetoci/default.yml` that was written for a Rails+JS stack and applied blindly across the org (see neetozone/neeto-engineering#1970). For this repo specifically:

- It hardcoded `.neetoci/scripts/run_eslint_on_modified_files.sh`, `.neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh`, and `.neetoci/scripts/check_schema_drift.sh` -- but this repo's CI actually invokes `.scripts/run_eslint_on_modified_files.sh` (a different directory entirely, and no rubocop/schema-drift scripts exist since this isn't a Rails app). Bugwatch flagged this as a critical finding on the original PR.
- It listed `app/**`, `bin/**`, `config/**`, `db/**`, `lib/**`, `test/**`, `Gemfile*`, `Rakefile`, etc. -- none of which exist in this repo. neeto-ui is a JS/TS component library; its real source lives in `src/**`, `tests/**`, and `stories/**`. Since none of the generic paths matched anything real, the filter would have caused CI to silently skip on almost all genuine source changes.

## What changed

This PR reverts #2848 and re-adds a `paths:` list tailored to neeto-ui's actual layout:
- `src/**`, `tests/**`, `stories/**` -- the real source/test/story directories
- `jest-config/**`, `jest-setup.js` -- used by the `yarn test` job
- `.scripts/*` -- the real script directory (glob, not hardcoded filenames)
- `.neetoci/default.yml`, `package.json`, `yarn.lock`, `.yarnrc.yml`, `.node-version`, `.nvmrc`, `.browserslistrc`, `.prettierrc.js`, `.eslintignore`, `.eslintrc.js`, `*.config.*` -- tooling config that actually exists in this repo's root

Dropped Rails-specific entries (`app/**`, `bin/**`, `config/**`, `db/**`, `lib/**`, `test/**`, `Gemfile*`, `Rakefile`, `.env.test`, `config.ru`, `.active_record_doctor.rb`) since this repo has no Rails app.

Refs neetozone/neeto-engineering#1970